### PR TITLE
feat: implement StreamRelay (T11)

### DIFF
--- a/src/__tests__/stream-relay.test.ts
+++ b/src/__tests__/stream-relay.test.ts
@@ -339,4 +339,33 @@ describe("StreamRelay", () => {
     const segments = splitMessage("abc", 1);
     expect(segments).toEqual(["a", "b", "c"]);
   });
+
+  // ── P0 fix: source iterable exception cleans up timer + stream ───────
+
+  it("cleans up flushTimer and stream when source iterable throws", async () => {
+    // Create an iterable that yields one chunk then throws.
+    async function* throwingChunks(): AsyncIterable<string> {
+      yield "partial";
+      throw new Error("source exploded");
+    }
+
+    const chunks = throwingChunks();
+    const promise = relay.deliver(CH_ID, CH_TYPE, chunks, API_URL, BOT_TOKEN);
+    const guarded = promise.catch(() => {});
+    await vi.runAllTimersAsync();
+    await guarded;
+
+    // Verify it rejected with the source error.
+    await expect(promise).rejects.toThrow("source exploded");
+
+    // streamEnd should have been called to close the started stream.
+    const endCalls = mockState.calls.filter((c) => c.fn === "streamEnd");
+    expect(endCalls.length).toBeGreaterThanOrEqual(1);
+
+    // Typing timer should be cleaned up (no more typing calls after error).
+    const countAfter = mockState.calls.filter((c) => c.fn === "sendTyping").length;
+    await vi.advanceTimersByTimeAsync(30_000);
+    const countLater = mockState.calls.filter((c) => c.fn === "sendTyping").length;
+    expect(countLater).toBe(countAfter);
+  });
 });

--- a/src/__tests__/stream-relay.test.ts
+++ b/src/__tests__/stream-relay.test.ts
@@ -78,16 +78,20 @@ interface ApiCall {
 const mockState = vi.hoisted(() => {
   const calls: ApiCall[] = [];
   let streamStartFail = false;
+  let streamSendFailAfter = -1; // Fail streamSend after N successful calls.
   let sendMessageFail = false;
   return {
     calls,
     get streamStartFail() { return streamStartFail; },
     set streamStartFail(v: boolean) { streamStartFail = v; },
+    get streamSendFailAfter() { return streamSendFailAfter; },
+    set streamSendFailAfter(v: number) { streamSendFailAfter = v; },
     get sendMessageFail() { return sendMessageFail; },
     set sendMessageFail(v: boolean) { sendMessageFail = v; },
     reset() {
       calls.length = 0;
       streamStartFail = false;
+      streamSendFailAfter = -1;
       sendMessageFail = false;
     },
   };
@@ -109,6 +113,12 @@ vi.mock("../octo/api.js", () => ({
   }),
   streamSend: vi.fn(async (params: Record<string, unknown>) => {
     mockState.calls.push({ fn: "streamSend", args: params });
+    if (mockState.streamSendFailAfter >= 0) {
+      const sendCount = mockState.calls.filter((c) => c.fn === "streamSend").length;
+      if (sendCount > mockState.streamSendFailAfter) {
+        throw new Error("streamSend failed");
+      }
+    }
   }),
   streamEnd: vi.fn(async (params: Record<string, unknown>) => {
     mockState.calls.push({ fn: "streamEnd", args: params });
@@ -295,5 +305,38 @@ describe("StreamRelay", () => {
     const payload = (startCalls[0].args as { payload: string }).payload;
     const decoded = JSON.parse(Buffer.from(payload, "base64").toString("utf-8")) as { content: string };
     expect(decoded.content).toBe("test data");
+  });
+
+  // ── Review fix: mid-stream failure calls streamEnd ─────────────────────
+
+  it("calls streamEnd on mid-stream failure before fallback", async () => {
+    // First streamSend succeeds (via streamStart), then streamSend fails on the next flush.
+    mockState.streamSendFailAfter = 0; // Fail from the 1st streamSend
+
+    // Yield two chunks: first triggers streamStart, second triggers a streamSend that fails.
+    const chunks = asyncChunks(["first", " second"]);
+    const promise = relay.deliver(CH_ID, CH_TYPE, chunks, API_URL, BOT_TOKEN);
+    await vi.runAllTimersAsync();
+    await promise;
+
+    // streamEnd should be called to close the dangling stream.
+    const endCalls = mockState.calls.filter((c) => c.fn === "streamEnd");
+    expect(endCalls.length).toBeGreaterThanOrEqual(1);
+
+    // Fallback sendMessage should deliver the content.
+    const sendCalls = mockState.calls.filter((c) => c.fn === "sendMessage");
+    expect(sendCalls.length).toBeGreaterThanOrEqual(1);
+  });
+
+  // ── Review fix: splitMessage maxChars guard ────────────────────────────
+
+  it("splitMessage throws on maxChars <= 0", async () => {
+    expect(() => splitMessage("hello", 0)).toThrow("maxChars must be >= 1");
+    expect(() => splitMessage("hello", -5)).toThrow("maxChars must be >= 1");
+  });
+
+  it("splitMessage works with maxChars = 1", () => {
+    const segments = splitMessage("abc", 1);
+    expect(segments).toEqual(["a", "b", "c"]);
   });
 });

--- a/src/__tests__/stream-relay.test.ts
+++ b/src/__tests__/stream-relay.test.ts
@@ -1,0 +1,299 @@
+/**
+ * Tests for StreamRelay — throttled flush, stream lifecycle, fallback, splitting.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { splitMessage } from "../stream-relay.js";
+
+// ─── splitMessage ───────────────────────────────────────────────────────────
+
+describe("splitMessage", () => {
+  it("returns single segment when text fits", () => {
+    const text = "hello world";
+    expect(splitMessage(text, 100)).toEqual(["hello world"]);
+  });
+
+  it("returns single segment when text equals maxChars exactly", () => {
+    const text = "a".repeat(3500);
+    expect(splitMessage(text)).toEqual([text]);
+  });
+
+  it("splits at paragraph boundary (\\n\\n)", () => {
+    const para1 = "a".repeat(1000);
+    const para2 = "b".repeat(1000);
+    const para3 = "c".repeat(1000);
+    const text = `${para1}\n\n${para2}\n\n${para3}`;
+    const segments = splitMessage(text, 2500);
+    expect(segments.length).toBeGreaterThanOrEqual(2);
+    expect(segments[0]).toContain(para1);
+    expect(segments.join("")).toBe(text);
+  });
+
+  it("splits at newline when no paragraph break", () => {
+    const line1 = "a".repeat(2000);
+    const line2 = "b".repeat(2000);
+    const text = `${line1}\n${line2}`;
+    const segments = splitMessage(text, 2500);
+    expect(segments.length).toBe(2);
+    expect(segments[0]).toBe(`${line1}\n`);
+    expect(segments[1]).toBe(line2);
+  });
+
+  it("splits at space when no newline", () => {
+    const word1 = "a".repeat(2000);
+    const word2 = "b".repeat(2000);
+    const text = `${word1} ${word2}`;
+    const segments = splitMessage(text, 2500);
+    expect(segments.length).toBe(2);
+    expect(segments[0]).toBe(`${word1} `);
+    expect(segments[1]).toBe(word2);
+  });
+
+  it("hard cuts when no natural boundary", () => {
+    const text = "a".repeat(7000);
+    const segments = splitMessage(text, 3500);
+    expect(segments.length).toBe(2);
+    expect(segments[0]).toBe("a".repeat(3500));
+    expect(segments[1]).toBe("a".repeat(3500));
+  });
+
+  it("handles empty string", () => {
+    expect(splitMessage("")).toEqual([""]);
+  });
+
+  it("reassembles to original for multi-segment split", () => {
+    const text = Array.from({ length: 20 }, (_, i) => `Paragraph ${i} content.`).join("\n\n");
+    const segments = splitMessage(text, 100);
+    expect(segments.join("")).toBe(text);
+  });
+});
+
+// ─── Shared mock state via vi.hoisted ───────────────────────────────────────
+
+interface ApiCall {
+  fn: string;
+  args: Record<string, unknown>;
+}
+
+const mockState = vi.hoisted(() => {
+  const calls: ApiCall[] = [];
+  let streamStartFail = false;
+  let sendMessageFail = false;
+  return {
+    calls,
+    get streamStartFail() { return streamStartFail; },
+    set streamStartFail(v: boolean) { streamStartFail = v; },
+    get sendMessageFail() { return sendMessageFail; },
+    set sendMessageFail(v: boolean) { sendMessageFail = v; },
+    reset() {
+      calls.length = 0;
+      streamStartFail = false;
+      sendMessageFail = false;
+    },
+  };
+});
+
+vi.mock("../octo/api.js", () => ({
+  sendTyping: vi.fn(async (params: Record<string, unknown>) => {
+    mockState.calls.push({ fn: "sendTyping", args: params });
+  }),
+  sendMessage: vi.fn(async (params: Record<string, unknown>) => {
+    mockState.calls.push({ fn: "sendMessage", args: params });
+    if (mockState.sendMessageFail) throw new Error("sendMessage failed");
+    return { message_id: "msg_1", client_msg_no: "c1", message_seq: 1 };
+  }),
+  streamStart: vi.fn(async (params: Record<string, unknown>) => {
+    mockState.calls.push({ fn: "streamStart", args: params });
+    if (mockState.streamStartFail) throw new Error("stream API unavailable");
+    return "stream_001";
+  }),
+  streamSend: vi.fn(async (params: Record<string, unknown>) => {
+    mockState.calls.push({ fn: "streamSend", args: params });
+  }),
+  streamEnd: vi.fn(async (params: Record<string, unknown>) => {
+    mockState.calls.push({ fn: "streamEnd", args: params });
+  }),
+}));
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+async function* asyncChunks(items: string[]): AsyncIterable<string> {
+  for (const item of items) {
+    yield item;
+  }
+}
+
+// ─── StreamRelay ────────────────────────────────────────────────────────────
+
+// Import after mock setup so vi.mock hoisting takes effect.
+const { StreamRelay } = await import("../stream-relay.js");
+
+describe("StreamRelay", () => {
+  let relay: StreamRelay;
+
+  const CH_ID = "test_channel";
+  const CH_TYPE = 2; // Group
+  const API_URL = "https://api.test";
+  const BOT_TOKEN = "bf_test";
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockState.reset();
+    relay = new StreamRelay();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("delivers short text via stream start + end", async () => {
+    const chunks = asyncChunks(["Hello, world!"]);
+    const promise = relay.deliver(CH_ID, CH_TYPE, chunks, API_URL, BOT_TOKEN);
+    await vi.runAllTimersAsync();
+    await promise;
+
+    const streamCalls = mockState.calls.filter((c) => c.fn.startsWith("stream"));
+    expect(streamCalls.some((c) => c.fn === "streamStart")).toBe(true);
+    expect(streamCalls.some((c) => c.fn === "streamEnd")).toBe(true);
+  });
+
+  it("sends typing indicator at the start", async () => {
+    const chunks = asyncChunks(["Hi"]);
+    const promise = relay.deliver(CH_ID, CH_TYPE, chunks, API_URL, BOT_TOKEN);
+    await vi.runAllTimersAsync();
+    await promise;
+
+    const typingCalls = mockState.calls.filter((c) => c.fn === "sendTyping");
+    expect(typingCalls.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("falls back to sendMessage when stream API fails", async () => {
+    mockState.streamStartFail = true;
+
+    const chunks = asyncChunks(["Fallback text"]);
+    const promise = relay.deliver(CH_ID, CH_TYPE, chunks, API_URL, BOT_TOKEN);
+    await vi.runAllTimersAsync();
+    await promise;
+
+    const sendCalls = mockState.calls.filter((c) => c.fn === "sendMessage");
+    expect(sendCalls.length).toBe(1);
+    expect((sendCalls[0].args as { content: string }).content).toBe("Fallback text");
+  });
+
+  it("splits long fallback text into segments", async () => {
+    mockState.streamStartFail = true;
+
+    const longText = "word ".repeat(1500); // ~7500 chars
+    const chunks = asyncChunks([longText]);
+    const promise = relay.deliver(CH_ID, CH_TYPE, chunks, API_URL, BOT_TOKEN);
+    await vi.runAllTimersAsync();
+    await promise;
+
+    const sendCalls = mockState.calls.filter((c) => c.fn === "sendMessage");
+    expect(sendCalls.length).toBeGreaterThanOrEqual(2);
+    const reassembled = sendCalls.map((c) => (c.args as { content: string }).content).join("");
+    expect(reassembled).toBe(longText);
+  });
+
+  it("handles empty stream (no output)", async () => {
+    const chunks = asyncChunks([]);
+    const promise = relay.deliver(CH_ID, CH_TYPE, chunks, API_URL, BOT_TOKEN);
+    await vi.runAllTimersAsync();
+    await promise;
+
+    const nonTyping = mockState.calls.filter((c) => c.fn !== "sendTyping");
+    expect(nonTyping.length).toBe(0);
+  });
+
+  it("cleans up typing timer on completion", async () => {
+    const chunks = asyncChunks(["done"]);
+    const promise = relay.deliver(CH_ID, CH_TYPE, chunks, API_URL, BOT_TOKEN);
+    await vi.runAllTimersAsync();
+    await promise;
+
+    const countAfter = mockState.calls.filter((c) => c.fn === "sendTyping").length;
+    await vi.advanceTimersByTimeAsync(30_000);
+    const countLater = mockState.calls.filter((c) => c.fn === "sendTyping").length;
+    expect(countLater).toBe(countAfter);
+  });
+
+  it("cleans up typing timer on error", async () => {
+    mockState.streamStartFail = true;
+    mockState.sendMessageFail = true;
+
+    const chunks = asyncChunks(["fail"]);
+    const promise = relay.deliver(CH_ID, CH_TYPE, chunks, API_URL, BOT_TOKEN);
+    // Attach a no-op catch to prevent Node's PromiseRejectionHandledWarning
+    // (the rejection is still observable via the original `promise` reference).
+    const guarded = promise.catch(() => {});
+    await vi.runAllTimersAsync();
+    await guarded;
+
+    // Verify the promise did reject.
+    await expect(promise).rejects.toThrow("sendMessage failed");
+
+    const countAfter = mockState.calls.filter((c) => c.fn === "sendTyping").length;
+    await vi.advanceTimersByTimeAsync(30_000);
+    const countLater = mockState.calls.filter((c) => c.fn === "sendTyping").length;
+    expect(countLater).toBe(countAfter);
+  });
+
+  it("accumulates chunks between flushes", async () => {
+    // Multiple chunks yielded synchronously: first chunk flushes immediately
+    // (lastFlushTime=0), remaining chunks accumulate until final flush.
+    const chunks = asyncChunks(["Hello", ", ", "world", "!"]);
+    const promise = relay.deliver(CH_ID, CH_TYPE, chunks, API_URL, BOT_TOKEN);
+    await vi.runAllTimersAsync();
+    await promise;
+
+    // Find the last stream payload (streamStart or streamSend) — it has the full text.
+    const payloadCalls = mockState.calls.filter(
+      (c) => c.fn === "streamStart" || c.fn === "streamSend",
+    );
+    expect(payloadCalls.length).toBeGreaterThanOrEqual(1);
+    const lastPayload = (payloadCalls[payloadCalls.length - 1].args as { payload: string }).payload;
+    const decoded = JSON.parse(Buffer.from(lastPayload, "base64").toString("utf-8")) as { content: string };
+    // The last flush should contain all accumulated text.
+    expect(decoded.content).toBe("Hello, world!");
+  });
+
+  it("passes correct channelId and channelType to stream calls", async () => {
+    const chunks = asyncChunks(["test"]);
+    const promise = relay.deliver(CH_ID, CH_TYPE, chunks, API_URL, BOT_TOKEN);
+    await vi.runAllTimersAsync();
+    await promise;
+
+    for (const call of mockState.calls) {
+      if (["sendTyping", "streamStart", "streamEnd", "streamSend"].includes(call.fn)) {
+        expect(call.args.channelId).toBe(CH_ID);
+        expect(call.args.channelType).toBe(CH_TYPE);
+      }
+    }
+  });
+
+  it("stream lifecycle: start → send(s) → end in order", async () => {
+    const chunks = asyncChunks(["test output"]);
+    const promise = relay.deliver(CH_ID, CH_TYPE, chunks, API_URL, BOT_TOKEN);
+    await vi.runAllTimersAsync();
+    await promise;
+
+    const streamCalls = mockState.calls
+      .filter((c) => c.fn.startsWith("stream"))
+      .map((c) => c.fn);
+    expect(streamCalls[0]).toBe("streamStart");
+    expect(streamCalls[streamCalls.length - 1]).toBe("streamEnd");
+  });
+
+  it("sends accumulated text (not incremental) in each stream flush", async () => {
+    const chunks = asyncChunks(["test data"]);
+    const promise = relay.deliver(CH_ID, CH_TYPE, chunks, API_URL, BOT_TOKEN);
+    await vi.runAllTimersAsync();
+    await promise;
+
+    // The streamStart payload should contain the full accumulated text
+    const startCalls = mockState.calls.filter((c) => c.fn === "streamStart");
+    const payload = (startCalls[0].args as { payload: string }).payload;
+    const decoded = JSON.parse(Buffer.from(payload, "base64").toString("utf-8")) as { content: string };
+    expect(decoded.content).toBe("test data");
+  });
+});

--- a/src/stream-relay.ts
+++ b/src/stream-relay.ts
@@ -40,6 +40,9 @@ const MAX_SEGMENT_CHARS = 3_500;
  * Each segment is at most `maxChars` characters.
  */
 export function splitMessage(text: string, maxChars: number = MAX_SEGMENT_CHARS): string[] {
+  if (maxChars < 1) {
+    throw new Error(`splitMessage: maxChars must be >= 1, got ${maxChars}`);
+  }
   if (text.length <= maxChars) return [text];
 
   const segments: string[] = [];
@@ -141,15 +144,19 @@ export class StreamRelay {
     let accumulated = "";
     let streamNo: string | null = null;
     let lastFlushTime = 0;
+    let lastSentLength = 0; // Track how much text was last sent to skip duplicate final sends.
     let flushTimer: ReturnType<typeof setTimeout> | null = null;
     let streamFailed = false;
+    let isFlushing = false; // Mutex guard — prevents timer flush and loop flush from racing.
 
     // Pending flush promise so we can await the final timer-triggered flush.
     let pendingFlush: Promise<void> | null = null;
 
     const flush = async (): Promise<void> => {
-      if (accumulated.length === 0) return;
+      if (accumulated.length === 0 || isFlushing) return;
+      if (accumulated.length === lastSentLength) return; // Nothing new since last send.
 
+      isFlushing = true;
       const payload = encodeStreamPayload(accumulated);
 
       try {
@@ -172,10 +179,13 @@ export class StreamRelay {
             payload,
           });
         }
+        lastSentLength = accumulated.length;
         lastFlushTime = Date.now();
       } catch {
         // Stream API unavailable — mark failed so we fall back after iteration.
         streamFailed = true;
+      } finally {
+        isFlushing = false;
       }
     };
 
@@ -220,13 +230,17 @@ export class StreamRelay {
     }
 
     if (streamFailed) {
+      // Close the dangling stream before falling back.
+      if (streamNo !== null) {
+        await streamEnd({ apiUrl, botToken, streamNo, channelId, channelType }).catch(() => {});
+      }
       // Fallback: deliver entire accumulated text via plain messages.
       await this._deliverFallback(channelId, channelType, accumulated, apiUrl, botToken);
       return;
     }
 
-    // Flush any remaining buffered text.
-    if (accumulated.length > 0 && streamNo !== null) {
+    // Flush any remaining buffered text (only if new content since last send).
+    if (accumulated.length > lastSentLength && streamNo !== null) {
       const payload = encodeStreamPayload(accumulated);
       try {
         await streamSend({

--- a/src/stream-relay.ts
+++ b/src/stream-relay.ts
@@ -157,6 +157,9 @@ export class StreamRelay {
       if (accumulated.length === lastSentLength) return; // Nothing new since last send.
 
       isFlushing = true;
+      // Snapshot the length before awaiting — new chunks may extend `accumulated`
+      // during the async send, and we must record only what was actually sent.
+      const snapshotLen = accumulated.length;
       const payload = encodeStreamPayload(accumulated);
 
       try {
@@ -179,7 +182,7 @@ export class StreamRelay {
             payload,
           });
         }
-        lastSentLength = accumulated.length;
+        lastSentLength = snapshotLen;
         lastFlushTime = Date.now();
       } catch {
         // Stream API unavailable — mark failed so we fall back after iteration.
@@ -199,74 +202,92 @@ export class StreamRelay {
       }, delay);
     };
 
-    // --- Consume chunks ---
-    for await (const chunk of chunks) {
-      if (streamFailed) {
-        // Keep accumulating for fallback delivery.
+    // --- Entire body wrapped in try/finally for cleanup on any error path ---
+    try {
+      // --- Consume chunks ---
+      for await (const chunk of chunks) {
+        if (streamFailed) {
+          // Keep accumulating for fallback delivery.
+          accumulated += chunk;
+          continue;
+        }
+
         accumulated += chunk;
-        continue;
+
+        const elapsed = Date.now() - lastFlushTime;
+        if (elapsed >= FLUSH_INTERVAL_MS) {
+          // Enough time has passed — flush immediately.
+          await flush();
+        } else {
+          scheduleFlush();
+        }
       }
 
-      accumulated += chunk;
-
-      const elapsed = Date.now() - lastFlushTime;
-      if (elapsed >= FLUSH_INTERVAL_MS) {
-        // Enough time has passed — flush immediately.
-        await flush();
-      } else {
-        scheduleFlush();
+      // --- Post-loop: cancel pending timer flush ---
+      if (flushTimer !== null) {
+        clearTimeout(flushTimer);
+        flushTimer = null;
       }
-    }
-
-    // --- Final flush ---
-    if (flushTimer !== null) {
-      clearTimeout(flushTimer);
-      flushTimer = null;
-    }
-    // Await any in-flight timer-triggered flush before the final one.
-    if (pendingFlush) {
-      await pendingFlush;
-      pendingFlush = null;
-    }
-
-    if (streamFailed) {
-      // Close the dangling stream before falling back.
-      if (streamNo !== null) {
-        await streamEnd({ apiUrl, botToken, streamNo, channelId, channelType }).catch(() => {});
+      if (pendingFlush) {
+        await pendingFlush;
+        pendingFlush = null;
       }
-      // Fallback: deliver entire accumulated text via plain messages.
-      await this._deliverFallback(channelId, channelType, accumulated, apiUrl, botToken);
-      return;
-    }
 
-    // Flush any remaining buffered text (only if new content since last send).
-    if (accumulated.length > lastSentLength && streamNo !== null) {
-      const payload = encodeStreamPayload(accumulated);
-      try {
-        await streamSend({
-          apiUrl,
-          botToken,
-          streamNo,
-          channelId,
-          channelType,
-          payload,
-        });
-      } catch {
-        // If the final send fails, fall back to plain messages.
-        await streamEnd({ apiUrl, botToken, streamNo, channelId, channelType }).catch(() => {});
+      if (streamFailed) {
+        // Close the dangling stream before falling back.
+        if (streamNo !== null) {
+          await streamEnd({ apiUrl, botToken, streamNo, channelId, channelType }).catch(() => {});
+          streamNo = null; // Mark closed so finally won't double-close.
+        }
+        // Fallback: deliver entire accumulated text via plain messages.
         await this._deliverFallback(channelId, channelType, accumulated, apiUrl, botToken);
         return;
       }
-    }
 
-    // End the stream.
-    if (streamNo !== null) {
-      await streamEnd({ apiUrl, botToken, streamNo, channelId, channelType }).catch(() => {});
-    } else if (accumulated.length > 0) {
-      // Never started a stream (no flush happened) — send as plain message.
-      await this._deliverFallback(channelId, channelType, accumulated, apiUrl, botToken);
+      // Flush any remaining buffered text (only if new content since last send).
+      if (accumulated.length > lastSentLength && streamNo !== null) {
+        const payload = encodeStreamPayload(accumulated);
+        try {
+          await streamSend({
+            apiUrl,
+            botToken,
+            streamNo,
+            channelId,
+            channelType,
+            payload,
+          });
+        } catch {
+          // If the final send fails, fall back to plain messages.
+          await streamEnd({ apiUrl, botToken, streamNo, channelId, channelType }).catch(() => {});
+          streamNo = null;
+          await this._deliverFallback(channelId, channelType, accumulated, apiUrl, botToken);
+          return;
+        }
+      }
+
+      // End the stream normally.
+      if (streamNo !== null) {
+        await streamEnd({ apiUrl, botToken, streamNo, channelId, channelType }).catch(() => {});
+        streamNo = null;
+      } else if (accumulated.length > 0) {
+        // Never started a stream (no flush happened) — send as plain message.
+        await this._deliverFallback(channelId, channelType, accumulated, apiUrl, botToken);
+      }
+      // If accumulated is empty and no stream started, the agent produced no output — nothing to send.
+    } finally {
+      // Always clean up timer + pending flush + dangling stream, even if source throws.
+      if (flushTimer !== null) {
+        clearTimeout(flushTimer);
+        flushTimer = null;
+      }
+      if (pendingFlush) {
+        await pendingFlush;
+        pendingFlush = null;
+      }
+      if (streamNo !== null) {
+        await streamEnd({ apiUrl, botToken, streamNo, channelId, channelType }).catch(() => {});
+      }
     }
-    // If accumulated is empty and no stream started, the agent produced no output — nothing to send.
   }
 
   // ── Fallback: plain sendMessage with splitting ──────────────────────────

--- a/src/stream-relay.ts
+++ b/src/stream-relay.ts
@@ -1,5 +1,280 @@
 /**
  * Stream Relay — throttled streaming output + typing heartbeat + message splitting.
- * Will be implemented in T11.
+ *
+ * Consumes an AsyncIterable<string> of text chunks and delivers them to Octo
+ * via the stream API (start/send/end). Falls back to plain sendMessage when
+ * the stream API is unavailable.
+ *
+ * Design constraints:
+ * - Knows nothing about Claude SDK — input is a generic async text stream.
+ * - All Octo API calls go through the api.ts functions (no raw fetch).
+ * - Typing indicators keep the user informed while chunks accumulate.
  */
-export {};
+
+import type { ChannelType } from "./octo/types.js";
+import {
+  sendTyping,
+  sendMessage,
+  streamStart,
+  streamSend,
+  streamEnd,
+} from "./octo/api.js";
+
+// ─── Constants ──────────────────────────────────────────────────────────────
+
+/** Interval (ms) between typing indicator pings. */
+const TYPING_INTERVAL_MS = 5_000;
+
+/** Minimum interval (ms) between stream flushes. */
+const FLUSH_INTERVAL_MS = 800;
+
+/** Maximum characters per message segment when falling back to plain send. */
+const MAX_SEGMENT_CHARS = 3_500;
+
+// ─── Message Splitting ─────────────────────────────────────────────────────
+
+/**
+ * Split a long text into segments at natural boundaries.
+ *
+ * Priority: paragraph break (\n\n) > newline (\n) > space > hard cut.
+ * Each segment is at most `maxChars` characters.
+ */
+export function splitMessage(text: string, maxChars: number = MAX_SEGMENT_CHARS): string[] {
+  if (text.length <= maxChars) return [text];
+
+  const segments: string[] = [];
+  let remaining = text;
+
+  while (remaining.length > 0) {
+    if (remaining.length <= maxChars) {
+      segments.push(remaining);
+      break;
+    }
+
+    const chunk = remaining.slice(0, maxChars);
+    let splitAt = -1;
+
+    // 1. Paragraph break (\n\n) — prefer the last one within range.
+    const paraIdx = chunk.lastIndexOf("\n\n");
+    if (paraIdx > 0) {
+      splitAt = paraIdx + 2; // include the double newline in the current segment
+    }
+
+    // 2. Newline (\n)
+    if (splitAt === -1) {
+      const nlIdx = chunk.lastIndexOf("\n");
+      if (nlIdx > 0) {
+        splitAt = nlIdx + 1;
+      }
+    }
+
+    // 3. Space
+    if (splitAt === -1) {
+      const spIdx = chunk.lastIndexOf(" ");
+      if (spIdx > 0) {
+        splitAt = spIdx + 1;
+      }
+    }
+
+    // 4. Hard cut
+    if (splitAt === -1) {
+      splitAt = maxChars;
+    }
+
+    segments.push(remaining.slice(0, splitAt));
+    remaining = remaining.slice(splitAt);
+  }
+
+  return segments;
+}
+
+// ─── Payload Encoding ───────────────────────────────────────────────────────
+
+/** Encode a text message payload to base64 for the stream API. */
+function encodeStreamPayload(content: string): string {
+  const payload = JSON.stringify({ type: 1, content });
+  return Buffer.from(payload, "utf-8").toString("base64");
+}
+
+// ─── StreamRelay ────────────────────────────────────────────────────────────
+
+export class StreamRelay {
+  /**
+   * Deliver an async stream of text chunks to an Octo channel.
+   *
+   * 1. Starts a typing indicator heartbeat (5 s interval).
+   * 2. Attempts the stream API path (start → throttled sends → end).
+   * 3. On stream API failure, falls back to plain sendMessage with splitting.
+   * 4. Always cleans up the typing heartbeat.
+   */
+  async deliver(
+    channelId: string,
+    channelType: ChannelType,
+    chunks: AsyncIterable<string>,
+    apiUrl: string,
+    botToken: string,
+  ): Promise<void> {
+    // --- Typing heartbeat ---
+    const typingParams = { apiUrl, botToken, channelId, channelType };
+    // Fire one immediately — don't wait for the first interval tick.
+    sendTyping(typingParams).catch(() => {});
+    const typingTimer = setInterval(() => {
+      sendTyping(typingParams).catch(() => {});
+    }, TYPING_INTERVAL_MS);
+
+    try {
+      await this._deliverViaStream(channelId, channelType, chunks, apiUrl, botToken);
+    } finally {
+      clearInterval(typingTimer);
+    }
+  }
+
+  // ── Stream API path ─────────────────────────────────────────────────────
+
+  private async _deliverViaStream(
+    channelId: string,
+    channelType: ChannelType,
+    chunks: AsyncIterable<string>,
+    apiUrl: string,
+    botToken: string,
+  ): Promise<void> {
+    let accumulated = "";
+    let streamNo: string | null = null;
+    let lastFlushTime = 0;
+    let flushTimer: ReturnType<typeof setTimeout> | null = null;
+    let streamFailed = false;
+
+    // Pending flush promise so we can await the final timer-triggered flush.
+    let pendingFlush: Promise<void> | null = null;
+
+    const flush = async (): Promise<void> => {
+      if (accumulated.length === 0) return;
+
+      const payload = encodeStreamPayload(accumulated);
+
+      try {
+        if (streamNo === null) {
+          // First flush — start the stream.
+          streamNo = await streamStart({
+            apiUrl,
+            botToken,
+            channelId,
+            channelType,
+            payload,
+          });
+        } else {
+          await streamSend({
+            apiUrl,
+            botToken,
+            streamNo,
+            channelId,
+            channelType,
+            payload,
+          });
+        }
+        lastFlushTime = Date.now();
+      } catch {
+        // Stream API unavailable — mark failed so we fall back after iteration.
+        streamFailed = true;
+      }
+    };
+
+    const scheduleFlush = (): void => {
+      if (flushTimer !== null) return; // already scheduled
+      const elapsed = Date.now() - lastFlushTime;
+      const delay = Math.max(0, FLUSH_INTERVAL_MS - elapsed);
+      flushTimer = setTimeout(() => {
+        flushTimer = null;
+        pendingFlush = flush();
+      }, delay);
+    };
+
+    // --- Consume chunks ---
+    for await (const chunk of chunks) {
+      if (streamFailed) {
+        // Keep accumulating for fallback delivery.
+        accumulated += chunk;
+        continue;
+      }
+
+      accumulated += chunk;
+
+      const elapsed = Date.now() - lastFlushTime;
+      if (elapsed >= FLUSH_INTERVAL_MS) {
+        // Enough time has passed — flush immediately.
+        await flush();
+      } else {
+        scheduleFlush();
+      }
+    }
+
+    // --- Final flush ---
+    if (flushTimer !== null) {
+      clearTimeout(flushTimer);
+      flushTimer = null;
+    }
+    // Await any in-flight timer-triggered flush before the final one.
+    if (pendingFlush) {
+      await pendingFlush;
+      pendingFlush = null;
+    }
+
+    if (streamFailed) {
+      // Fallback: deliver entire accumulated text via plain messages.
+      await this._deliverFallback(channelId, channelType, accumulated, apiUrl, botToken);
+      return;
+    }
+
+    // Flush any remaining buffered text.
+    if (accumulated.length > 0 && streamNo !== null) {
+      const payload = encodeStreamPayload(accumulated);
+      try {
+        await streamSend({
+          apiUrl,
+          botToken,
+          streamNo,
+          channelId,
+          channelType,
+          payload,
+        });
+      } catch {
+        // If the final send fails, fall back to plain messages.
+        await streamEnd({ apiUrl, botToken, streamNo, channelId, channelType }).catch(() => {});
+        await this._deliverFallback(channelId, channelType, accumulated, apiUrl, botToken);
+        return;
+      }
+    }
+
+    // End the stream.
+    if (streamNo !== null) {
+      await streamEnd({ apiUrl, botToken, streamNo, channelId, channelType }).catch(() => {});
+    } else if (accumulated.length > 0) {
+      // Never started a stream (no flush happened) — send as plain message.
+      await this._deliverFallback(channelId, channelType, accumulated, apiUrl, botToken);
+    }
+    // If accumulated is empty and no stream started, the agent produced no output — nothing to send.
+  }
+
+  // ── Fallback: plain sendMessage with splitting ──────────────────────────
+
+  private async _deliverFallback(
+    channelId: string,
+    channelType: ChannelType,
+    text: string,
+    apiUrl: string,
+    botToken: string,
+  ): Promise<void> {
+    if (text.length === 0) return;
+
+    const segments = splitMessage(text);
+    for (const segment of segments) {
+      await sendMessage({
+        apiUrl,
+        botToken,
+        channelId,
+        channelType,
+        content: segment,
+      });
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Implement `StreamRelay` class — throttled streaming output + typing heartbeat + message splitting.

## Changes

**src/stream-relay.ts** (+230 lines):
- `StreamRelay.deliver(channelId, channelType, chunks, apiUrl, botToken)` — consumes `AsyncIterable<string>` and delivers to Octo
- **Typing heartbeat**: 5s interval via `sendTyping`, fires immediately on start, cleaned up in `finally`
- **Throttled flush**: 800ms interval, accumulated (not incremental) text sent via stream API lifecycle (`streamStart` → `streamSend` → `streamEnd`)
- **Fallback**: when stream API throws, degrades to plain `sendMessage` with automatic splitting
- `splitMessage(text, maxChars)` — exported utility, splits at natural boundaries: paragraph (\\n\\n) > newline (\\n) > space > hard cut, 3500 char max per segment
- **Payload encoding**: base64-encoded JSON `{ type: 1, content }` for stream API

**src/__tests__/stream-relay.test.ts** (+348 lines):
- 8 `splitMessage` tests: single segment, exact boundary, paragraph/newline/space/hard split, empty string, reassembly
- 11 `StreamRelay` tests: stream lifecycle (start → send → end), typing indicator, fallback on stream failure, long text splitting, empty stream, timer cleanup on success/error, chunk accumulation, channel params

## Verification

```
npx tsc --noEmit  # zero errors
npm test          # 56 tests passed (37 protocol + 19 stream-relay)
```

## Task

T11 from Phase 2. No dependencies on other Phase 2 tasks.