### PR TITLE
feat: implement entry point orchestration (T12)

### DIFF
--- a/src/__tests__/stream-relay.test.ts
+++ b/src/__tests__/stream-relay.test.ts
@@ -1,0 +1,299 @@
+/**
+ * Tests for StreamRelay — throttled flush, stream lifecycle, fallback, splitting.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { splitMessage } from "../stream-relay.js";
+
+// ─── splitMessage ───────────────────────────────────────────────────────────
+
+describe("splitMessage", () => {
+  it("returns single segment when text fits", () => {
+    const text = "hello world";
+    expect(splitMessage(text, 100)).toEqual(["hello world"]);
+  });
+
+  it("returns single segment when text equals maxChars exactly", () => {
+    const text = "a".repeat(3500);
+    expect(splitMessage(text)).toEqual([text]);
+  });
+
+  it("splits at paragraph boundary (\\n\\n)", () => {
+    const para1 = "a".repeat(1000);
+    const para2 = "b".repeat(1000);
+    const para3 = "c".repeat(1000);
+    const text = `${para1}\n\n${para2}\n\n${para3}`;
+    const segments = splitMessage(text, 2500);
+    expect(segments.length).toBeGreaterThanOrEqual(2);
+    expect(segments[0]).toContain(para1);
+    expect(segments.join("")).toBe(text);
+  });
+
+  it("splits at newline when no paragraph break", () => {
+    const line1 = "a".repeat(2000);
+    const line2 = "b".repeat(2000);
+    const text = `${line1}\n${line2}`;
+    const segments = splitMessage(text, 2500);
+    expect(segments.length).toBe(2);
+    expect(segments[0]).toBe(`${line1}\n`);
+    expect(segments[1]).toBe(line2);
+  });
+
+  it("splits at space when no newline", () => {
+    const word1 = "a".repeat(2000);
+    const word2 = "b".repeat(2000);
+    const text = `${word1} ${word2}`;
+    const segments = splitMessage(text, 2500);
+    expect(segments.length).toBe(2);
+    expect(segments[0]).toBe(`${word1} `);
+    expect(segments[1]).toBe(word2);
+  });
+
+  it("hard cuts when no natural boundary", () => {
+    const text = "a".repeat(7000);
+    const segments = splitMessage(text, 3500);
+    expect(segments.length).toBe(2);
+    expect(segments[0]).toBe("a".repeat(3500));
+    expect(segments[1]).toBe("a".repeat(3500));
+  });
+
+  it("handles empty string", () => {
+    expect(splitMessage("")).toEqual([""]);
+  });
+
+  it("reassembles to original for multi-segment split", () => {
+    const text = Array.from({ length: 20 }, (_, i) => `Paragraph ${i} content.`).join("\n\n");
+    const segments = splitMessage(text, 100);
+    expect(segments.join("")).toBe(text);
+  });
+});
+
+// ─── Shared mock state via vi.hoisted ───────────────────────────────────────
+
+interface ApiCall {
+  fn: string;
+  args: Record<string, unknown>;
+}
+
+const mockState = vi.hoisted(() => {
+  const calls: ApiCall[] = [];
+  let streamStartFail = false;
+  let sendMessageFail = false;
+  return {
+    calls,
+    get streamStartFail() { return streamStartFail; },
+    set streamStartFail(v: boolean) { streamStartFail = v; },
+    get sendMessageFail() { return sendMessageFail; },
+    set sendMessageFail(v: boolean) { sendMessageFail = v; },
+    reset() {
+      calls.length = 0;
+      streamStartFail = false;
+      sendMessageFail = false;
+    },
+  };
+});
+
+vi.mock("../octo/api.js", () => ({
+  sendTyping: vi.fn(async (params: Record<string, unknown>) => {
+    mockState.calls.push({ fn: "sendTyping", args: params });
+  }),
+  sendMessage: vi.fn(async (params: Record<string, unknown>) => {
+    mockState.calls.push({ fn: "sendMessage", args: params });
+    if (mockState.sendMessageFail) throw new Error("sendMessage failed");
+    return { message_id: "msg_1", client_msg_no: "c1", message_seq: 1 };
+  }),
+  streamStart: vi.fn(async (params: Record<string, unknown>) => {
+    mockState.calls.push({ fn: "streamStart", args: params });
+    if (mockState.streamStartFail) throw new Error("stream API unavailable");
+    return "stream_001";
+  }),
+  streamSend: vi.fn(async (params: Record<string, unknown>) => {
+    mockState.calls.push({ fn: "streamSend", args: params });
+  }),
+  streamEnd: vi.fn(async (params: Record<string, unknown>) => {
+    mockState.calls.push({ fn: "streamEnd", args: params });
+  }),
+}));
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+async function* asyncChunks(items: string[]): AsyncIterable<string> {
+  for (const item of items) {
+    yield item;
+  }
+}
+
+// ─── StreamRelay ────────────────────────────────────────────────────────────
+
+// Import after mock setup so vi.mock hoisting takes effect.
+const { StreamRelay } = await import("../stream-relay.js");
+
+describe("StreamRelay", () => {
+  let relay: StreamRelay;
+
+  const CH_ID = "test_channel";
+  const CH_TYPE = 2; // Group
+  const API_URL = "https://api.test";
+  const BOT_TOKEN = "bf_test";
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockState.reset();
+    relay = new StreamRelay();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("delivers short text via stream start + end", async () => {
+    const chunks = asyncChunks(["Hello, world!"]);
+    const promise = relay.deliver(CH_ID, CH_TYPE, chunks, API_URL, BOT_TOKEN);
+    await vi.runAllTimersAsync();
+    await promise;
+
+    const streamCalls = mockState.calls.filter((c) => c.fn.startsWith("stream"));
+    expect(streamCalls.some((c) => c.fn === "streamStart")).toBe(true);
+    expect(streamCalls.some((c) => c.fn === "streamEnd")).toBe(true);
+  });
+
+  it("sends typing indicator at the start", async () => {
+    const chunks = asyncChunks(["Hi"]);
+    const promise = relay.deliver(CH_ID, CH_TYPE, chunks, API_URL, BOT_TOKEN);
+    await vi.runAllTimersAsync();
+    await promise;
+
+    const typingCalls = mockState.calls.filter((c) => c.fn === "sendTyping");
+    expect(typingCalls.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("falls back to sendMessage when stream API fails", async () => {
+    mockState.streamStartFail = true;
+
+    const chunks = asyncChunks(["Fallback text"]);
+    const promise = relay.deliver(CH_ID, CH_TYPE, chunks, API_URL, BOT_TOKEN);
+    await vi.runAllTimersAsync();
+    await promise;
+
+    const sendCalls = mockState.calls.filter((c) => c.fn === "sendMessage");
+    expect(sendCalls.length).toBe(1);
+    expect((sendCalls[0].args as { content: string }).content).toBe("Fallback text");
+  });
+
+  it("splits long fallback text into segments", async () => {
+    mockState.streamStartFail = true;
+
+    const longText = "word ".repeat(1500); // ~7500 chars
+    const chunks = asyncChunks([longText]);
+    const promise = relay.deliver(CH_ID, CH_TYPE, chunks, API_URL, BOT_TOKEN);
+    await vi.runAllTimersAsync();
+    await promise;
+
+    const sendCalls = mockState.calls.filter((c) => c.fn === "sendMessage");
+    expect(sendCalls.length).toBeGreaterThanOrEqual(2);
+    const reassembled = sendCalls.map((c) => (c.args as { content: string }).content).join("");
+    expect(reassembled).toBe(longText);
+  });
+
+  it("handles empty stream (no output)", async () => {
+    const chunks = asyncChunks([]);
+    const promise = relay.deliver(CH_ID, CH_TYPE, chunks, API_URL, BOT_TOKEN);
+    await vi.runAllTimersAsync();
+    await promise;
+
+    const nonTyping = mockState.calls.filter((c) => c.fn !== "sendTyping");
+    expect(nonTyping.length).toBe(0);
+  });
+
+  it("cleans up typing timer on completion", async () => {
+    const chunks = asyncChunks(["done"]);
+    const promise = relay.deliver(CH_ID, CH_TYPE, chunks, API_URL, BOT_TOKEN);
+    await vi.runAllTimersAsync();
+    await promise;
+
+    const countAfter = mockState.calls.filter((c) => c.fn === "sendTyping").length;
+    await vi.advanceTimersByTimeAsync(30_000);
+    const countLater = mockState.calls.filter((c) => c.fn === "sendTyping").length;
+    expect(countLater).toBe(countAfter);
+  });
+
+  it("cleans up typing timer on error", async () => {
+    mockState.streamStartFail = true;
+    mockState.sendMessageFail = true;
+
+    const chunks = asyncChunks(["fail"]);
+    const promise = relay.deliver(CH_ID, CH_TYPE, chunks, API_URL, BOT_TOKEN);
+    // Attach a no-op catch to prevent Node's PromiseRejectionHandledWarning
+    // (the rejection is still observable via the original `promise` reference).
+    const guarded = promise.catch(() => {});
+    await vi.runAllTimersAsync();
+    await guarded;
+
+    // Verify the promise did reject.
+    await expect(promise).rejects.toThrow("sendMessage failed");
+
+    const countAfter = mockState.calls.filter((c) => c.fn === "sendTyping").length;
+    await vi.advanceTimersByTimeAsync(30_000);
+    const countLater = mockState.calls.filter((c) => c.fn === "sendTyping").length;
+    expect(countLater).toBe(countAfter);
+  });
+
+  it("accumulates chunks between flushes", async () => {
+    // Multiple chunks yielded synchronously: first chunk flushes immediately
+    // (lastFlushTime=0), remaining chunks accumulate until final flush.
+    const chunks = asyncChunks(["Hello", ", ", "world", "!"]);
+    const promise = relay.deliver(CH_ID, CH_TYPE, chunks, API_URL, BOT_TOKEN);
+    await vi.runAllTimersAsync();
+    await promise;
+
+    // Find the last stream payload (streamStart or streamSend) — it has the full text.
+    const payloadCalls = mockState.calls.filter(
+      (c) => c.fn === "streamStart" || c.fn === "streamSend",
+    );
+    expect(payloadCalls.length).toBeGreaterThanOrEqual(1);
+    const lastPayload = (payloadCalls[payloadCalls.length - 1].args as { payload: string }).payload;
+    const decoded = JSON.parse(Buffer.from(lastPayload, "base64").toString("utf-8")) as { content: string };
+    // The last flush should contain all accumulated text.
+    expect(decoded.content).toBe("Hello, world!");
+  });
+
+  it("passes correct channelId and channelType to stream calls", async () => {
+    const chunks = asyncChunks(["test"]);
+    const promise = relay.deliver(CH_ID, CH_TYPE, chunks, API_URL, BOT_TOKEN);
+    await vi.runAllTimersAsync();
+    await promise;
+
+    for (const call of mockState.calls) {
+      if (["sendTyping", "streamStart", "streamEnd", "streamSend"].includes(call.fn)) {
+        expect(call.args.channelId).toBe(CH_ID);
+        expect(call.args.channelType).toBe(CH_TYPE);
+      }
+    }
+  });
+
+  it("stream lifecycle: start → send(s) → end in order", async () => {
+    const chunks = asyncChunks(["test output"]);
+    const promise = relay.deliver(CH_ID, CH_TYPE, chunks, API_URL, BOT_TOKEN);
+    await vi.runAllTimersAsync();
+    await promise;
+
+    const streamCalls = mockState.calls
+      .filter((c) => c.fn.startsWith("stream"))
+      .map((c) => c.fn);
+    expect(streamCalls[0]).toBe("streamStart");
+    expect(streamCalls[streamCalls.length - 1]).toBe("streamEnd");
+  });
+
+  it("sends accumulated text (not incremental) in each stream flush", async () => {
+    const chunks = asyncChunks(["test data"]);
+    const promise = relay.deliver(CH_ID, CH_TYPE, chunks, API_URL, BOT_TOKEN);
+    await vi.runAllTimersAsync();
+    await promise;
+
+    // The streamStart payload should contain the full accumulated text
+    const startCalls = mockState.calls.filter((c) => c.fn === "streamStart");
+    const payload = (startCalls[0].args as { payload: string }).payload;
+    const decoded = JSON.parse(Buffer.from(payload, "base64").toString("utf-8")) as { content: string };
+    expect(decoded.content).toBe("test data");
+  });
+});

--- a/src/agent-bridge.ts
+++ b/src/agent-bridge.ts
@@ -1,6 +1,76 @@
 /**
  * Agent Bridge — Claude Agent SDK query() invocation.
  * Outputs AsyncIterable<string> — does not know about Octo API.
- * Will be implemented in T10.
  */
-export {};
+
+import { query as sdkQuery } from '@anthropic-ai/claude-agent-sdk';
+import type { Config } from './config.js';
+
+/**
+ * Build the prompt string from history, group context, and current message.
+ *
+ * Format:
+ * [Group context]
+ * <groupContext if non-empty>
+ *
+ * [Conversation history]
+ * <historyPrefix if non-empty>
+ *
+ * [Current message]
+ * <message>
+ */
+export function buildPrompt(historyPrefix: string, groupContext: string, message: string): string {
+  const parts: string[] = [];
+  if (groupContext) {
+    parts.push(`[Group context]\n${groupContext}`);
+  }
+  if (historyPrefix) {
+    parts.push(`[Conversation history]\n${historyPrefix}`);
+  }
+  parts.push(`[Current message]\n${message}`);
+  return parts.join('\n\n');
+}
+
+/**
+ * Query Claude Agent SDK and yield text chunks as they arrive.
+ * Does not reference any Octo API — pure SDK interaction.
+ *
+ * @param prompt - Full prompt string (built by buildPrompt)
+ * @param config - Application config (sdk.* fields used)
+ * @yields string chunks of assistant text output
+ */
+export async function* queryAgent(prompt: string, config: Config): AsyncIterable<string> {
+  const stream = sdkQuery({
+    prompt,
+    options: {
+      cwd: config.cwd,
+      systemPrompt: config.sdk.systemPrompt,
+      allowedTools: config.sdk.allowedTools,
+      permissionMode: config.sdk.permissionMode as any,
+      maxTurns: config.sdk.maxTurns,
+      model: config.sdk.model,
+      settingSources: config.sdk.settingSources as any[],
+      allowDangerouslySkipPermissions: config.sdk.permissionMode === 'bypassPermissions',
+    },
+  });
+
+  try {
+    for await (const message of stream) {
+      if (message.type === 'assistant') {
+        for (const block of message.message.content) {
+          if (block.type === 'text' && block.text) {
+            yield block.text;
+          }
+        }
+      } else if (message.type === 'result') {
+        if (message.subtype !== 'success') {
+          const errorResult = message as any;
+          const errorMsg = errorResult.error || errorResult.subtype || 'Processing failed';
+          yield `\n[Error: ${errorMsg}]`;
+        }
+      }
+    }
+  } finally {
+    stream.close();
+  }
+}

--- a/src/gateway.ts
+++ b/src/gateway.ts
@@ -1,5 +1,256 @@
 /**
  * Gateway — WS lifecycle management + bot registration + token refresh.
- * Will be implemented in T7.
  */
-export {};
+
+import { WKSocket } from './octo/socket.js';
+import { registerBot, sendHeartbeat } from './octo/api.js';
+import type { Config } from './config.js';
+import type { BotMessage } from './octo/types.js';
+import { existsSync, writeFileSync, unlinkSync, readFileSync, mkdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+
+export type MessageHandler = (msg: BotMessage) => void;
+
+export class OctoGateway {
+  private socket: WKSocket | null = null;
+  private robotId = '';
+  private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+  private lockFilePath: string;
+  private onMessage: MessageHandler | null = null;
+
+  // Token refresh state
+  private isRefreshing = false;
+  private lastRefreshTime = 0;
+  private readonly REFRESH_COOLDOWN_MS = 60_000;
+
+  // Heartbeat failure tracking
+  private heartbeatFailCount = 0;
+  private readonly MAX_HEARTBEAT_FAILURES = 3;
+
+  constructor(private readonly config: Config) {
+    this.lockFilePath = join(config.dataDir, 'gateway.lock');
+  }
+
+  get botId(): string {
+    return this.robotId;
+  }
+
+  /** Set the message handler. Called for every incoming BotMessage. */
+  setMessageHandler(handler: MessageHandler): void {
+    this.onMessage = handler;
+  }
+
+  /** Start the gateway: acquire lock → register bot → connect WS → start heartbeat */
+  async start(): Promise<void> {
+    this.acquireLock();
+    await this.registerAndConnect();
+    this.startHeartbeat();
+    this.setupShutdownHandlers();
+  }
+
+  /** Gracefully stop: disconnect WS + clear heartbeat + release lock */
+  async stop(): Promise<void> {
+    this.stopHeartbeat();
+    if (this.socket) {
+      await this.socket.disconnectAndWait();
+      this.socket = null;
+    }
+    this.releaseLock();
+  }
+
+  // --- Lock file ---
+
+  private acquireLock(): void {
+    const dir = dirname(this.lockFilePath);
+    mkdirSync(dir, { recursive: true });
+
+    if (existsSync(this.lockFilePath)) {
+      const content = readFileSync(this.lockFilePath, 'utf-8').trim();
+      const pid = parseInt(content, 10);
+      if (pid && !isNaN(pid)) {
+        try {
+          process.kill(pid, 0); // signal 0 = check existence
+          throw new Error(
+            `Another instance is running (PID ${pid}). Lock file: ${this.lockFilePath}`,
+          );
+        } catch (err: unknown) {
+          const e = err as NodeJS.ErrnoException;
+          if (e.code === 'ESRCH') {
+            console.log(`Removing stale lock file (PID ${pid} not found)`);
+          } else if (e.message?.includes('Another instance')) {
+            throw err;
+          } else if (e.code === 'EPERM') {
+            throw new Error(
+              `Another instance is running (PID ${pid}). Lock file: ${this.lockFilePath}`,
+            );
+          }
+        }
+      }
+    }
+    writeFileSync(this.lockFilePath, String(process.pid), { mode: 0o600 });
+  }
+
+  private releaseLock(): void {
+    try {
+      if (existsSync(this.lockFilePath)) {
+        const content = readFileSync(this.lockFilePath, 'utf-8').trim();
+        if (content === String(process.pid)) {
+          unlinkSync(this.lockFilePath);
+        }
+      }
+    } catch {
+      /* best effort */
+    }
+  }
+
+  // --- Bot registration + WS connection ---
+
+  private async registerAndConnect(): Promise<void> {
+    const reg = await registerBot({
+      apiUrl: this.config.apiUrl,
+      botToken: this.config.botToken,
+      agentPlatform: 'cc-channel-octo',
+      agentVersion: '0.1.0',
+    });
+
+    this.robotId = reg.robot_id;
+
+    console.log(`Bot registered: robot_id=${reg.robot_id}`);
+
+    this.socket = new WKSocket({
+      wsUrl: reg.ws_url,
+      uid: reg.robot_id,
+      token: reg.im_token,
+      onMessage: (msg) => this.handleMessage(msg),
+      onConnected: () => {
+        console.log('WS connected');
+        this.heartbeatFailCount = 0;
+      },
+      onDisconnected: () => {
+        console.log('WS disconnected');
+      },
+      onError: (err) => {
+        console.error('WS error:', err.message);
+        if (err.message.includes('Kicked') || err.message.includes('Connect failed')) {
+          void this.attemptTokenRefresh();
+        }
+      },
+    });
+
+    this.socket.connect();
+  }
+
+  private handleMessage(msg: BotMessage): void {
+    if (msg.from_uid === this.robotId) return;
+    this.onMessage?.(msg);
+  }
+
+  // --- Token refresh ---
+
+  private async attemptTokenRefresh(): Promise<void> {
+    if (this.isRefreshing) return;
+
+    const now = Date.now();
+    if (now - this.lastRefreshTime < this.REFRESH_COOLDOWN_MS) {
+      const remaining = Math.ceil((this.REFRESH_COOLDOWN_MS - (now - this.lastRefreshTime)) / 1000);
+      console.log(`Token refresh cooldown (${remaining}s remaining)`);
+      return;
+    }
+
+    this.isRefreshing = true;
+    this.lastRefreshTime = now;
+
+    try {
+      console.log('Attempting token refresh...');
+
+      if (this.socket) {
+        await this.socket.disconnectAndWait();
+        this.socket = null;
+      }
+
+      const reg = await registerBot({
+        apiUrl: this.config.apiUrl,
+        botToken: this.config.botToken,
+        forceRefresh: true,
+        agentPlatform: 'cc-channel-octo',
+        agentVersion: '0.1.0',
+      });
+
+      this.robotId = reg.robot_id;
+      console.log('Token refreshed, reconnecting...');
+
+      this.socket = new WKSocket({
+        wsUrl: reg.ws_url,
+        uid: reg.robot_id,
+        token: reg.im_token,
+        onMessage: (msg) => this.handleMessage(msg),
+        onConnected: () => {
+          console.log('WS reconnected after token refresh');
+          this.heartbeatFailCount = 0;
+        },
+        onDisconnected: () => {
+          console.log('WS disconnected');
+        },
+        onError: (err) => {
+          console.error('WS error:', err.message);
+          if (err.message.includes('Kicked') || err.message.includes('Connect failed')) {
+            void this.attemptTokenRefresh();
+          }
+        },
+      });
+
+      this.socket.connect();
+    } catch (err) {
+      console.error('Token refresh failed:', err);
+    } finally {
+      this.isRefreshing = false;
+    }
+  }
+
+  // --- Heartbeat (API-level, 30s interval) ---
+
+  private startHeartbeat(): void {
+    this.stopHeartbeat();
+    this.heartbeatFailCount = 0;
+    this.heartbeatTimer = setInterval(async () => {
+      try {
+        await sendHeartbeat({
+          apiUrl: this.config.apiUrl,
+          botToken: this.config.botToken,
+        });
+        this.heartbeatFailCount = 0;
+      } catch (err) {
+        this.heartbeatFailCount++;
+        console.error(
+          `Heartbeat failed (${this.heartbeatFailCount}/${this.MAX_HEARTBEAT_FAILURES}):`,
+          err,
+        );
+        if (this.heartbeatFailCount >= this.MAX_HEARTBEAT_FAILURES) {
+          console.error('Max heartbeat failures reached, triggering reconnect...');
+          this.heartbeatFailCount = 0;
+          void this.attemptTokenRefresh();
+        }
+      }
+    }, 30_000);
+  }
+
+  private stopHeartbeat(): void {
+    if (this.heartbeatTimer) {
+      clearInterval(this.heartbeatTimer);
+      this.heartbeatTimer = null;
+    }
+  }
+
+  // --- Graceful shutdown ---
+
+  private setupShutdownHandlers(): void {
+    const shutdown = async (signal: string) => {
+      console.log(`Received ${signal}, shutting down...`);
+      await this.stop();
+      process.exit(0);
+    };
+
+    process.once('SIGINT', () => void shutdown('SIGINT'));
+    process.once('SIGTERM', () => void shutdown('SIGTERM'));
+  }
+}

--- a/src/group-context.ts
+++ b/src/group-context.ts
@@ -1,5 +1,185 @@
 /**
  * Group Context — group chat message cache + maxContextChars budget + mention mapping.
- * Will be implemented in T9.
  */
-export {};
+
+import type { DbAdapter, PreparedStatement } from './db-adapter.js';
+import { getGroupMembers, fetchUserInfo } from './octo/api.js';
+
+interface GroupMessage {
+  fromUid: string;
+  fromName: string;
+  content: string;
+  timestamp: number;
+}
+
+interface MemberRow {
+  uid: string;
+  name: string;
+}
+
+const REFRESH_INTERVAL_MS = 60 * 60 * 1000;
+
+export class GroupContext {
+  private readonly messageCache = new Map<string, GroupMessage[]>();
+  private readonly memberMap = new Map<string, string>();
+  private readonly nameToUid = new Map<string, string>();
+  private readonly lastRefresh = new Map<string, number>();
+
+  private readonly adapter: DbAdapter;
+  private readonly maxContextChars: number;
+  private readonly maxWindowSize: number;
+
+  private upsertMember!: PreparedStatement;
+  private selectMembers!: PreparedStatement;
+
+  constructor(adapter: DbAdapter, maxContextChars: number) {
+    this.adapter = adapter;
+    this.maxContextChars = maxContextChars;
+    this.maxWindowSize = 100;
+    this.initStatements();
+  }
+
+  private initStatements(): void {
+    this.upsertMember = this.adapter.prepare(
+      'INSERT INTO group_members (group_id, uid, name, updated_at) VALUES (?, ?, ?, ?) ON CONFLICT(group_id, uid) DO UPDATE SET name = excluded.name, updated_at = excluded.updated_at',
+    );
+    this.selectMembers = this.adapter.prepare(
+      'SELECT uid, name FROM group_members WHERE group_id = ?',
+    );
+  }
+
+  pushMessage(
+    channelId: string,
+    fromUid: string,
+    fromName: string,
+    content: string,
+    timestamp: number,
+  ): void {
+    let window = this.messageCache.get(channelId);
+    if (!window) {
+      window = [];
+      this.messageCache.set(channelId, window);
+    }
+    window.push({ fromUid, fromName, content, timestamp });
+    while (window.length > this.maxWindowSize) {
+      window.shift();
+    }
+    this.learnMember(channelId, fromUid, fromName);
+  }
+
+  learnMember(channelId: string, uid: string, name: string): void {
+    if (!uid || !name) return;
+    const existing = this.memberMap.get(uid);
+    if (existing !== name) {
+      this.memberMap.set(uid, name);
+      this.nameToUid.set(name, uid);
+      try {
+        this.upsertMember.run(channelId, uid, name, Date.now());
+      } catch (err) {
+        console.error(`group-context: upsert member failed: ${String(err)}`);
+      }
+    }
+  }
+
+  async refreshMembers(channelId: string, apiUrl: string, botToken: string): Promise<void> {
+    const now = Date.now();
+    const last = this.lastRefresh.get(channelId) ?? 0;
+    if (now - last < REFRESH_INTERVAL_MS) return;
+    this.lastRefresh.set(channelId, now);
+
+    try {
+      const members = await getGroupMembers({ apiUrl, botToken, groupNo: channelId });
+      for (const m of members) {
+        if (!m.uid || !m.name) continue;
+        this.memberMap.set(m.uid, m.name);
+        this.nameToUid.set(m.name, m.uid);
+        try {
+          this.upsertMember.run(channelId, m.uid, m.name, now);
+        } catch (err) {
+          console.error(`group-context: upsert member failed: ${String(err)}`);
+        }
+      }
+    } catch (err) {
+      console.error(`group-context: refreshMembers(${channelId}) failed: ${String(err)}`);
+    }
+  }
+
+  async fetchAndLearnUser(uid: string, apiUrl: string, botToken: string): Promise<string | undefined> {
+    const cached = this.memberMap.get(uid);
+    if (cached) return cached;
+    try {
+      const info = await fetchUserInfo({ apiUrl, botToken, uid });
+      if (info?.name) {
+        this.memberMap.set(uid, info.name);
+        this.nameToUid.set(info.name, uid);
+        return info.name;
+      }
+    } catch (err) {
+      console.error(`group-context: fetchUserInfo(${uid}) failed: ${String(err)}`);
+    }
+    return undefined;
+  }
+
+  buildContext(channelId: string): string {
+    const window = this.messageCache.get(channelId);
+    if (!window || window.length === 0) return '';
+
+    const header = '[Recent group messages]\n';
+    const trailer = '\n';
+    const budget = this.maxContextChars - header.length - trailer.length;
+    if (budget <= 0) return '';
+
+    const selected: string[] = [];
+    let used = 0;
+    for (let i = window.length - 1; i >= 0; i--) {
+      const m = window[i];
+      const line = `${m.fromName}：${m.content}`;
+      const cost = line.length + (selected.length > 0 ? 1 : 0);
+      if (used + cost > budget) break;
+      selected.push(line);
+      used += cost;
+    }
+    if (selected.length === 0) return '';
+    selected.reverse();
+    return `${header}${selected.join('\n')}${trailer}`;
+  }
+
+  resolveMentions(text: string): string[] {
+    const uids: string[] = [];
+    const seen = new Set<string>();
+    const regex = /@(\S+)/g;
+    let match: RegExpExecArray | null;
+    while ((match = regex.exec(text)) !== null) {
+      const name = match[1];
+      let uid = this.nameToUid.get(name);
+      if (!uid) {
+        // Try progressively shorter prefixes — handles trailing punctuation.
+        for (let end = name.length - 1; end > 0 && !uid; end--) {
+          uid = this.nameToUid.get(name.slice(0, end));
+        }
+      }
+      if (uid && !seen.has(uid)) {
+        seen.add(uid);
+        uids.push(uid);
+      }
+    }
+    return uids;
+  }
+
+  getName(uid: string): string | undefined {
+    return this.memberMap.get(uid);
+  }
+
+  loadMembersFromDb(channelId: string): void {
+    try {
+      const rows = this.selectMembers.all(channelId) as MemberRow[];
+      for (const r of rows) {
+        if (!r.uid || !r.name) continue;
+        this.memberMap.set(r.uid, r.name);
+        this.nameToUid.set(r.name, r.uid);
+      }
+    } catch (err) {
+      console.error(`group-context: loadMembersFromDb(${channelId}) failed: ${String(err)}`);
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,166 @@
 /**
  * cc-channel-octo — Entry point.
  * Bridge Claude Code (via Claude Agent SDK) to Octo IM.
+ *
+ * Orchestrates: loadConfig → createAdapter → SessionStore.init →
+ * OctoGateway.start → setMessageHandler wiring the full pipeline.
  */
 
-// Placeholder — will be implemented in Phase 2 (T12)
-console.log("cc-channel-octo starting...");
+import { loadConfig } from './config.js';
+import { createAdapter } from './db-adapter.js';
+import { SessionStore } from './session-store.js';
+import { OctoGateway } from './gateway.js';
+import { SessionRouter } from './session-router.js';
+import { GroupContext } from './group-context.js';
+import { buildPrompt, queryAgent } from './agent-bridge.js';
+import { StreamRelay } from './stream-relay.js';
+import { sendMessage } from './octo/api.js';
+import { ChannelType, MessageType } from './octo/types.js';
+import type { BotMessage } from './octo/types.js';
+import { join } from 'node:path';
+
+async function main(): Promise<void> {
+  // --- Config ---
+  const config = loadConfig();
+  console.log(
+    `[cc-channel-octo] Config loaded: apiUrl=${config.apiUrl}, cwd=${config.cwd}, ` +
+    `dataDir=${config.dataDir}, sdk.model=${config.sdk.model ?? 'default'}, ` +
+    `sdk.allowedTools=[${config.sdk.allowedTools.join(',')}], ` +
+    `sdk.permissionMode=${config.sdk.permissionMode}, ` +
+    `rateLimit=${config.rateLimit.maxPerMinute} req/min, ` +
+    `context.maxContextChars=${config.context.maxContextChars}, ` +
+    `context.historyLimit=${config.context.historyLimit}`,
+  );
+
+  // --- Database ---
+  const dbPath = join(config.dataDir, 'cc-octo.db');
+  const adapter = createAdapter(dbPath);
+  const store = new SessionStore(adapter);
+  store.init();
+
+  // Clean expired sessions on startup
+  const cleaned = store.cleanExpired();
+  if (cleaned > 0) {
+    console.log(`[cc-channel-octo] Cleaned ${cleaned} expired session(s)`);
+  }
+
+  // --- Group context ---
+  const groupContext = new GroupContext(adapter, config.context.maxContextChars);
+
+  // --- Stream relay ---
+  const streamRelay = new StreamRelay();
+
+  // --- Gateway ---
+  const gateway = new OctoGateway(config);
+  await gateway.start();
+
+  console.log(`[cc-channel-octo] Bot started: id=${gateway.botId}`);
+
+  // --- Session router ---
+  const router = new SessionRouter(config, gateway.botId);
+
+  // --- Message handler ---
+  gateway.setMessageHandler((msg: BotMessage) => {
+    void handleMessage(msg, config, store, router, groupContext, streamRelay);
+  });
+
+  console.log('[cc-channel-octo] Ready — listening for messages');
+}
+
+async function handleMessage(
+  msg: BotMessage,
+  config: ReturnType<typeof loadConfig>,
+  store: SessionStore,
+  router: SessionRouter,
+  groupContext: GroupContext,
+  streamRelay: StreamRelay,
+): Promise<void> {
+  const channelId = msg.channel_id ?? '';
+  const channelType = msg.channel_type ?? ChannelType.DM;
+  const isGroup = channelType === ChannelType.Group || channelType === ChannelType.CommunityTopic;
+  const fromName = (msg.payload as Record<string, unknown>).from_name as string | undefined;
+
+  // --- Cache group messages for context (all messages, not just @bot) ---
+  if (isGroup && msg.payload.type === MessageType.Text && msg.payload.content) {
+    groupContext.pushMessage(
+      channelId,
+      msg.from_uid,
+      fromName ?? msg.from_uid,
+      msg.payload.content,
+      msg.timestamp,
+    );
+  }
+
+  // --- Route: filter, mention gate, rate limit ---
+  const result = await router.route(msg);
+  if (!result || !result.shouldProcess) return;
+
+  const { sessionKey } = result;
+
+  try {
+    // --- Session ---
+    store.getOrCreate(sessionKey, channelId, channelType);
+
+    // --- Group context: refresh members + build context string ---
+    let contextStr = '';
+    if (isGroup) {
+      await groupContext.refreshMembers(channelId, config.apiUrl, config.botToken);
+      contextStr = groupContext.buildContext(channelId);
+    }
+
+    // --- Build history prefix ---
+    const userContent = msg.payload.content ?? '';
+    store.appendUser(sessionKey, userContent);
+    const historyPrefix = store.buildHistoryPrefix(sessionKey, config.context.historyLimit);
+
+    // --- Build prompt + query agent ---
+    const prompt = buildPrompt(historyPrefix, contextStr, userContent);
+    const rawChunks = queryAgent(prompt, config);
+
+    // Tee the generator: collect full text while streaming to Octo
+    const collected: string[] = [];
+    async function* teeChunks(): AsyncIterable<string> {
+      for await (const chunk of rawChunks) {
+        collected.push(chunk);
+        yield chunk;
+      }
+    }
+
+    // --- Stream output to Octo ---
+    await streamRelay.deliver(channelId, channelType, teeChunks(), config.apiUrl, config.botToken);
+
+    // --- Store assistant response in history ---
+    const fullResponse = collected.join('');
+    if (fullResponse) {
+      store.appendAssistant(sessionKey, fullResponse);
+    }
+
+    // --- Resolve mentions in group reply ---
+    if (isGroup && fullResponse) {
+      const mentionUids = groupContext.resolveMentions(fullResponse);
+      if (mentionUids.length > 0) {
+        console.log(`[cc-channel-octo] Resolved mentions: ${mentionUids.join(', ')}`);
+      }
+    }
+
+  } catch (err) {
+    console.error(`[cc-channel-octo] Error processing message (session=${sessionKey}):`, err);
+    // Best-effort error reply
+    try {
+      await sendMessage({
+        apiUrl: config.apiUrl,
+        botToken: config.botToken,
+        channelId,
+        channelType,
+        content: 'An error occurred while processing your message. Please try again.',
+      });
+    } catch {
+      /* swallow — don't crash on reply failure */
+    }
+  }
+}
+
+main().catch((err) => {
+  console.error('[cc-channel-octo] Fatal error:', err);
+  process.exit(1);
+});

--- a/src/session-router.ts
+++ b/src/session-router.ts
@@ -1,5 +1,142 @@
 /**
  * Session Router — routing + concurrency control + mention gate + rate limiting.
- * Will be implemented in T8.
  */
-export {};
+
+import type { Config } from './config.js';
+import type { BotMessage } from './octo/types.js';
+import { ChannelType, MessageType } from './octo/types.js';
+import { sendMessage } from './octo/api.js';
+
+export interface RouteResult {
+  sessionKey: string;
+  shouldProcess: boolean;
+  message: BotMessage;
+}
+
+interface TokenBucket {
+  tokens: number;
+  lastRefill: number;
+}
+
+export class SessionRouter {
+  private readonly config: Config;
+  private readonly robotId: string;
+  private readonly inboundQueues = new Map<string, Promise<void>>();
+  private readonly tokenBuckets = new Map<string, TokenBucket>();
+
+  constructor(config: Config, robotId: string) {
+    this.config = config;
+    this.robotId = robotId;
+  }
+
+  async route(msg: BotMessage): Promise<RouteResult | null> {
+    const key = this.sessionKey(msg);
+    const prev = this.inboundQueues.get(key) ?? Promise.resolve();
+    let resolveGate!: () => void;
+    const gate = new Promise<void>((r) => {
+      resolveGate = r;
+    });
+    this.inboundQueues.set(key, gate);
+
+    try {
+      await prev;
+      return await this.processMessage(msg, key);
+    } finally {
+      resolveGate();
+      if (this.inboundQueues.get(key) === gate) {
+        this.inboundQueues.delete(key);
+      }
+    }
+  }
+
+  private sessionKey(msg: BotMessage): string {
+    if (msg.channel_type === ChannelType.DM) {
+      return msg.from_uid;
+    }
+    return `${msg.channel_id ?? ''}:${msg.from_uid}`;
+  }
+
+  private isBlockedBot(uid: string): boolean {
+    return this.config.botBlocklist?.includes(uid) ?? false;
+  }
+
+  private isGroupLike(channelType: ChannelType | undefined): boolean {
+    return channelType === ChannelType.Group || channelType === ChannelType.CommunityTopic;
+  }
+
+  private isMentioned(msg: BotMessage): boolean {
+    const mention = msg.payload.mention;
+    if (!mention) return false;
+    if (mention.uids?.includes(this.robotId)) return true;
+    if (mention.all) return true;
+    if (mention.ais) return true;
+    return false;
+  }
+
+  private async processMessage(msg: BotMessage, key: string): Promise<RouteResult | null> {
+    // Skip messages from self.
+    if (msg.from_uid === this.robotId) return null;
+
+    // DM blocklist filter.
+    if (msg.channel_type === ChannelType.DM && this.isBlockedBot(msg.from_uid)) {
+      return null;
+    }
+
+    // Group: drop messages from other bots (blocklisted or self) entirely.
+    if (this.isGroupLike(msg.channel_type) && this.isBlockedBot(msg.from_uid)) {
+      return null;
+    }
+
+    // Group mention gate.
+    if (this.isGroupLike(msg.channel_type) && !this.isMentioned(msg)) {
+      return null;
+    }
+
+    // Non-text message → reply with notice.
+    if (msg.payload.type !== MessageType.Text) {
+      await this.replySafe(msg, '暂不支持此类消息，请发送文字');
+      return { sessionKey: key, shouldProcess: false, message: msg };
+    }
+
+    // Rate limit.
+    if (!this.checkRateLimit(key)) {
+      await this.replySafe(msg, '请稍后再试');
+      return { sessionKey: key, shouldProcess: false, message: msg };
+    }
+
+    return { sessionKey: key, shouldProcess: true, message: msg };
+  }
+
+  private checkRateLimit(key: string): boolean {
+    const now = Date.now();
+    const maxPerMinute = this.config.rateLimit.maxPerMinute;
+    let bucket = this.tokenBuckets.get(key);
+    if (!bucket) {
+      bucket = { tokens: maxPerMinute, lastRefill: now };
+      this.tokenBuckets.set(key, bucket);
+    }
+    const elapsed = now - bucket.lastRefill;
+    const refill = (elapsed / 60_000) * maxPerMinute;
+    bucket.tokens = Math.min(maxPerMinute, bucket.tokens + refill);
+    bucket.lastRefill = now;
+
+    if (bucket.tokens < 1) return false;
+    bucket.tokens -= 1;
+    return true;
+  }
+
+  private async replySafe(msg: BotMessage, content: string): Promise<void> {
+    if (!msg.channel_id || msg.channel_type === undefined) return;
+    try {
+      await sendMessage({
+        apiUrl: this.config.apiUrl,
+        botToken: this.config.botToken,
+        channelId: msg.channel_id,
+        channelType: msg.channel_type,
+        content,
+      });
+    } catch (err) {
+      console.error(`session-router: reply failed: ${String(err)}`);
+    }
+  }
+}

--- a/src/stream-relay.ts
+++ b/src/stream-relay.ts
@@ -1,5 +1,280 @@
 /**
  * Stream Relay — throttled streaming output + typing heartbeat + message splitting.
- * Will be implemented in T11.
+ *
+ * Consumes an AsyncIterable<string> of text chunks and delivers them to Octo
+ * via the stream API (start/send/end). Falls back to plain sendMessage when
+ * the stream API is unavailable.
+ *
+ * Design constraints:
+ * - Knows nothing about Claude SDK — input is a generic async text stream.
+ * - All Octo API calls go through the api.ts functions (no raw fetch).
+ * - Typing indicators keep the user informed while chunks accumulate.
  */
-export {};
+
+import type { ChannelType } from "./octo/types.js";
+import {
+  sendTyping,
+  sendMessage,
+  streamStart,
+  streamSend,
+  streamEnd,
+} from "./octo/api.js";
+
+// ─── Constants ──────────────────────────────────────────────────────────────
+
+/** Interval (ms) between typing indicator pings. */
+const TYPING_INTERVAL_MS = 5_000;
+
+/** Minimum interval (ms) between stream flushes. */
+const FLUSH_INTERVAL_MS = 800;
+
+/** Maximum characters per message segment when falling back to plain send. */
+const MAX_SEGMENT_CHARS = 3_500;
+
+// ─── Message Splitting ─────────────────────────────────────────────────────
+
+/**
+ * Split a long text into segments at natural boundaries.
+ *
+ * Priority: paragraph break (\n\n) > newline (\n) > space > hard cut.
+ * Each segment is at most `maxChars` characters.
+ */
+export function splitMessage(text: string, maxChars: number = MAX_SEGMENT_CHARS): string[] {
+  if (text.length <= maxChars) return [text];
+
+  const segments: string[] = [];
+  let remaining = text;
+
+  while (remaining.length > 0) {
+    if (remaining.length <= maxChars) {
+      segments.push(remaining);
+      break;
+    }
+
+    const chunk = remaining.slice(0, maxChars);
+    let splitAt = -1;
+
+    // 1. Paragraph break (\n\n) — prefer the last one within range.
+    const paraIdx = chunk.lastIndexOf("\n\n");
+    if (paraIdx > 0) {
+      splitAt = paraIdx + 2; // include the double newline in the current segment
+    }
+
+    // 2. Newline (\n)
+    if (splitAt === -1) {
+      const nlIdx = chunk.lastIndexOf("\n");
+      if (nlIdx > 0) {
+        splitAt = nlIdx + 1;
+      }
+    }
+
+    // 3. Space
+    if (splitAt === -1) {
+      const spIdx = chunk.lastIndexOf(" ");
+      if (spIdx > 0) {
+        splitAt = spIdx + 1;
+      }
+    }
+
+    // 4. Hard cut
+    if (splitAt === -1) {
+      splitAt = maxChars;
+    }
+
+    segments.push(remaining.slice(0, splitAt));
+    remaining = remaining.slice(splitAt);
+  }
+
+  return segments;
+}
+
+// ─── Payload Encoding ───────────────────────────────────────────────────────
+
+/** Encode a text message payload to base64 for the stream API. */
+function encodeStreamPayload(content: string): string {
+  const payload = JSON.stringify({ type: 1, content });
+  return Buffer.from(payload, "utf-8").toString("base64");
+}
+
+// ─── StreamRelay ────────────────────────────────────────────────────────────
+
+export class StreamRelay {
+  /**
+   * Deliver an async stream of text chunks to an Octo channel.
+   *
+   * 1. Starts a typing indicator heartbeat (5 s interval).
+   * 2. Attempts the stream API path (start → throttled sends → end).
+   * 3. On stream API failure, falls back to plain sendMessage with splitting.
+   * 4. Always cleans up the typing heartbeat.
+   */
+  async deliver(
+    channelId: string,
+    channelType: ChannelType,
+    chunks: AsyncIterable<string>,
+    apiUrl: string,
+    botToken: string,
+  ): Promise<void> {
+    // --- Typing heartbeat ---
+    const typingParams = { apiUrl, botToken, channelId, channelType };
+    // Fire one immediately — don't wait for the first interval tick.
+    sendTyping(typingParams).catch(() => {});
+    const typingTimer = setInterval(() => {
+      sendTyping(typingParams).catch(() => {});
+    }, TYPING_INTERVAL_MS);
+
+    try {
+      await this._deliverViaStream(channelId, channelType, chunks, apiUrl, botToken);
+    } finally {
+      clearInterval(typingTimer);
+    }
+  }
+
+  // ── Stream API path ─────────────────────────────────────────────────────
+
+  private async _deliverViaStream(
+    channelId: string,
+    channelType: ChannelType,
+    chunks: AsyncIterable<string>,
+    apiUrl: string,
+    botToken: string,
+  ): Promise<void> {
+    let accumulated = "";
+    let streamNo: string | null = null;
+    let lastFlushTime = 0;
+    let flushTimer: ReturnType<typeof setTimeout> | null = null;
+    let streamFailed = false;
+
+    // Pending flush promise so we can await the final timer-triggered flush.
+    let pendingFlush: Promise<void> | null = null;
+
+    const flush = async (): Promise<void> => {
+      if (accumulated.length === 0) return;
+
+      const payload = encodeStreamPayload(accumulated);
+
+      try {
+        if (streamNo === null) {
+          // First flush — start the stream.
+          streamNo = await streamStart({
+            apiUrl,
+            botToken,
+            channelId,
+            channelType,
+            payload,
+          });
+        } else {
+          await streamSend({
+            apiUrl,
+            botToken,
+            streamNo,
+            channelId,
+            channelType,
+            payload,
+          });
+        }
+        lastFlushTime = Date.now();
+      } catch {
+        // Stream API unavailable — mark failed so we fall back after iteration.
+        streamFailed = true;
+      }
+    };
+
+    const scheduleFlush = (): void => {
+      if (flushTimer !== null) return; // already scheduled
+      const elapsed = Date.now() - lastFlushTime;
+      const delay = Math.max(0, FLUSH_INTERVAL_MS - elapsed);
+      flushTimer = setTimeout(() => {
+        flushTimer = null;
+        pendingFlush = flush();
+      }, delay);
+    };
+
+    // --- Consume chunks ---
+    for await (const chunk of chunks) {
+      if (streamFailed) {
+        // Keep accumulating for fallback delivery.
+        accumulated += chunk;
+        continue;
+      }
+
+      accumulated += chunk;
+
+      const elapsed = Date.now() - lastFlushTime;
+      if (elapsed >= FLUSH_INTERVAL_MS) {
+        // Enough time has passed — flush immediately.
+        await flush();
+      } else {
+        scheduleFlush();
+      }
+    }
+
+    // --- Final flush ---
+    if (flushTimer !== null) {
+      clearTimeout(flushTimer);
+      flushTimer = null;
+    }
+    // Await any in-flight timer-triggered flush before the final one.
+    if (pendingFlush) {
+      await pendingFlush;
+      pendingFlush = null;
+    }
+
+    if (streamFailed) {
+      // Fallback: deliver entire accumulated text via plain messages.
+      await this._deliverFallback(channelId, channelType, accumulated, apiUrl, botToken);
+      return;
+    }
+
+    // Flush any remaining buffered text.
+    if (accumulated.length > 0 && streamNo !== null) {
+      const payload = encodeStreamPayload(accumulated);
+      try {
+        await streamSend({
+          apiUrl,
+          botToken,
+          streamNo,
+          channelId,
+          channelType,
+          payload,
+        });
+      } catch {
+        // If the final send fails, fall back to plain messages.
+        await streamEnd({ apiUrl, botToken, streamNo, channelId, channelType }).catch(() => {});
+        await this._deliverFallback(channelId, channelType, accumulated, apiUrl, botToken);
+        return;
+      }
+    }
+
+    // End the stream.
+    if (streamNo !== null) {
+      await streamEnd({ apiUrl, botToken, streamNo, channelId, channelType }).catch(() => {});
+    } else if (accumulated.length > 0) {
+      // Never started a stream (no flush happened) — send as plain message.
+      await this._deliverFallback(channelId, channelType, accumulated, apiUrl, botToken);
+    }
+    // If accumulated is empty and no stream started, the agent produced no output — nothing to send.
+  }
+
+  // ── Fallback: plain sendMessage with splitting ──────────────────────────
+
+  private async _deliverFallback(
+    channelId: string,
+    channelType: ChannelType,
+    text: string,
+    apiUrl: string,
+    botToken: string,
+  ): Promise<void> {
+    if (text.length === 0) return;
+
+    const segments = splitMessage(text);
+    for (const segment of segments) {
+      await sendMessage({
+        apiUrl,
+        botToken,
+        channelId,
+        channelType,
+        content: segment,
+      });
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Implements T12 — the entry point (`src/index.ts`) that wires up all Phase 2 modules into the complete message pipeline.

### Startup Sequence

```
loadConfig() → createAdapter(dbPath) → SessionStore.init()
→ cleanExpired() → GroupContext + StreamRelay
→ OctoGateway.start() (lock → register → WS → heartbeat)
→ SessionRouter(config, botId) → setMessageHandler()
```

### Message Pipeline (`handleMessage`)

1. Cache group messages for context (all messages, not just @bot)
2. `SessionRouter.route()` — filter self/blocklist, mention gate, rate limit
3. `SessionStore.getOrCreate()` + `appendUser()`
4. `GroupContext.refreshMembers()` + `buildContext()` (group chats only)
5. `buildHistoryPrefix()` from session store
6. `buildPrompt()` + `queryAgent()` via Claude Agent SDK
7. `teeChunks()` wrapper — collects full response text while streaming
8. `StreamRelay.deliver()` — stream output to Octo
9. `appendAssistant()` — store full response in session history
10. `resolveMentions()` — log resolved @mentions (group chats)

### Key Design Decisions

- **Generator tee pattern**: `queryAgent()` returns an `AsyncIterable<string>` that can only be consumed once. `teeChunks()` wraps it to simultaneously feed `StreamRelay.deliver()` and collect the full text for `appendAssistant()`.
- **Error recovery**: failed message processing sends a best-effort error reply; reply failures are swallowed to prevent crash cascades.
- **Startup logging**: prints config summary (no tokens), bot ID, expired session cleanup count.
- **Group context caching**: all group messages are cached for context, not just @bot messages.

### Dependencies

This PR merges T7-T11 branches to compile against all modules:
- T7: gateway.ts (PR #5)
- T8: session-router.ts (PR #3)
- T9: group-context.ts (PR #3)
- T10: agent-bridge.ts (PR #5)
- T11: stream-relay.ts (PR #4)

### Files changed (1 only, as scoped)

- `src/index.ts` (+161 lines)

### Verification

```
npx tsc --noEmit  # zero errors
npm test          # 56 tests passed
```