### PR TITLE
docs: add CONTRIBUTING.md and Apache-2.0 LICENSE (T15 + T17)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,215 @@
+# Contributing to cc-channel-octo
+
+Thank you for your interest in contributing to cc-channel-octo! This document covers everything you need to get started.
+
+## Table of Contents
+
+- [Development Setup](#development-setup)
+- [Project Structure](#project-structure)
+- [Code Style](#code-style)
+- [Testing](#testing)
+- [Pull Request Process](#pull-request-process)
+- [Protocol Layer Sync](#protocol-layer-sync)
+- [Security](#security)
+
+## Development Setup
+
+### Prerequisites
+
+- **Node.js** ≥ 22
+- **npm** ≥ 10
+- **Claude Code** installed and authenticated (`claude --version`)
+- A valid Octo Bot token (`bf_*`)
+
+### Getting Started
+
+```bash
+# Clone the repository
+git clone https://github.com/Mininglamp-OSS/cc-channel-octo.git
+cd cc-channel-octo
+
+# Install dependencies
+npm install
+
+# Copy and edit the configuration
+cp config.example.json config.json
+# Edit config.json with your bot token, API URL, and working directory
+
+# Type-check
+npm run type-check
+
+# Run tests
+npm test
+
+# Build
+npm run build
+
+# Start the gateway
+npm start
+```
+
+### Useful Commands
+
+| Command | Description |
+|---------|-------------|
+| `npm run build` | Compile TypeScript to `dist/` |
+| `npm run dev` | Watch mode compilation |
+| `npm run type-check` | Type-check without emitting |
+| `npm run lint` | Run ESLint |
+| `npm test` | Run tests (vitest) |
+| `npm run test:watch` | Run tests in watch mode |
+| `npm start` | Start the gateway |
+
+## Project Structure
+
+```
+cc-channel-octo/
+├── src/
+│   ├── index.ts              # Entry point — orchestrates all modules
+│   ├── config.ts              # Configuration loading (env > file > defaults)
+│   ├── gateway.ts             # WS lifecycle + bot registration + token refresh
+│   ├── session-router.ts      # Routing + concurrency + mention gate + rate limiting
+│   ├── agent-bridge.ts        # Claude Agent SDK query() invocation
+│   ├── stream-relay.ts        # Throttled streaming output + typing heartbeat
+│   ├── session-store.ts       # SQLite persistence (better-sqlite3)
+│   ├── group-context.ts       # Group chat context cache + mention mapping
+│   ├── db-adapter.ts          # Thin SQLite adapter interface
+│   ├── __tests__/             # Test files
+│   └── octo/                  # Octo protocol layer (forked)
+│       ├── socket.ts          # WuKongIM binary protocol
+│       ├── api.ts             # Octo Bot REST API
+│       └── types.ts           # Protocol type definitions
+├── ARCHITECTURE.md            # Detailed design document
+├── CLAUDE.md                  # Claude Code project instructions
+├── config.example.json        # Configuration template
+└── package.json
+```
+
+See [ARCHITECTURE.md](./ARCHITECTURE.md) for the full design document.
+
+## Code Style
+
+### Language
+
+- All code, comments, commit messages, PR titles, and PR descriptions **must be in English**.
+- Internal team chat may use any language; all repository artifacts are English-only.
+
+### TypeScript
+
+- **Strict mode** enabled — no implicit `any`, no unchecked index access.
+- Use `.js` extensions in imports (NodeNext module resolution).
+- Prefer explicit types over `any`. Use `unknown` + type guards when the shape is truly unknown.
+- Prefer `const` over `let`. Never use `var`.
+- Error handling: catch and log errors explicitly. **Never** use `.catch(() => {})` to swallow errors silently.
+
+### Formatting
+
+- ESLint with `@typescript-eslint` recommended rules.
+- No unused variables (warning level).
+- No explicit `any` (warning level).
+
+## Testing
+
+### Writing Tests
+
+- Test files live in `src/__tests__/`.
+- We use [vitest](https://vitest.dev/) as the test runner.
+- Every PR that changes source code **must** include tests for the changed behavior.
+- Mock external dependencies (Octo API, Claude Agent SDK) — don't make real network calls.
+- For SQLite tests, use an in-memory database via `createAdapter(':memory:')`.
+
+### What to Test
+
+- **Unit tests**: individual functions and class methods in isolation.
+- **Integration tests**: module interactions (e.g., SessionRouter + GroupContext).
+- **Edge cases**: empty inputs, boundary values, error paths, concurrent access.
+
+### Running Tests
+
+```bash
+# Run all tests
+npm test
+
+# Run tests in watch mode
+npm run test:watch
+
+# Run a specific test file
+npx vitest run src/__tests__/session-router.test.ts
+```
+
+### Pre-commit Checklist
+
+Before every commit:
+
+1. `npm run type-check` — zero errors
+2. `npm test` — all tests pass
+3. `npm run lint` — no errors (warnings acceptable)
+4. `git add <specific files>` — never use `git add -A`
+5. `git status` — verify only intended files are staged
+6. `git branch --show-current` — confirm you're on the right branch
+
+## Pull Request Process
+
+1. **Branch naming**: `<author>/description` (e.g., `wangdachui/fix-rate-limiter`).
+2. **One concern per PR**. Don't mix unrelated changes.
+3. **Search before opening**. Check for existing open PRs that address the same issue.
+4. **Rebase on main** before pushing: `git fetch origin main && git rebase origin/main`.
+5. **PR description** must include:
+   - What changed and why
+   - Files modified
+   - Test results (`npm run type-check && npm test` output)
+   - Any breaking changes or migration notes
+6. **All tests must pass**. PRs with failing tests will not be reviewed.
+7. **Review states** — use them correctly:
+   - `APPROVED` — code is ready to merge
+   - `CHANGES_REQUESTED` — blocking issues that must be fixed
+   - `COMMENTED` — discussion only, no approval or rejection
+8. **Merge authority**: only the repository owner merges PRs unless explicitly delegated.
+
+## Protocol Layer Sync
+
+The `src/octo/` directory is forked from [openclaw-channel-octo](https://github.com/Mininglamp-OSS/openclaw-channel-octo). It is **not** a shared package — we maintain our own copy independently.
+
+### Before Each Release
+
+1. Diff our `src/octo/` against the upstream `openclaw-channel-octo` source:
+   ```bash
+   # Clone or update the upstream repo
+   git clone --depth 1 https://github.com/Mininglamp-OSS/openclaw-channel-octo.git /tmp/oco-upstream
+
+   # Compare
+   diff -u /tmp/oco-upstream/src/socket.ts src/octo/socket.ts
+   diff -u /tmp/oco-upstream/src/types.ts src/octo/types.ts
+   diff -u /tmp/oco-upstream/src/api-fetch.ts src/octo/api.ts
+   ```
+
+2. Review upstream changes for:
+   - **Security fixes** (AES-CBC padding, DH parameter validation, int64 parsing) — must be ported
+   - **Protocol changes** (new packet types, field additions) — evaluate and port if relevant
+   - **Bug fixes** (reconnect logic, framing edge cases) — port unless our fork already diverged
+
+3. Document any ported changes in the commit message with a reference to the upstream commit.
+
+### What NOT to Sync
+
+- OpenClaw-specific features (COS upload, GROUP.md API, OBO, persona, thread binding)
+- Dependencies we removed (axios, cos-nodejs-sdk-v5)
+- LogSink interface (we use console directly)
+
+## Security
+
+### Reporting Vulnerabilities
+
+If you discover a security vulnerability, **do not** open a public issue. Instead, email the maintainers directly or use GitHub's private vulnerability reporting feature.
+
+### Security Considerations for Contributors
+
+- **Never** hardcode secrets, tokens, or credentials in source code.
+- `config.json` is in `.gitignore` for a reason — it contains the bot token.
+- The `dataDir` directory (default `./data`) contains SQLite databases with chat history. Default permissions are `0700`.
+- When modifying the protocol layer (`src/octo/`), pay special attention to cryptographic operations (AES-CBC, DH key exchange).
+- The `bypassPermissions` + `allowedTools` security model is intentional for headless operation. Security depends on `cwd` isolation — see [ARCHITECTURE.md](./ARCHITECTURE.md) for details.
+
+## License
+
+By contributing to cc-channel-octo, you agree that your contributions will be licensed under the [Apache License 2.0](./LICENSE).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,191 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by the Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding any notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2026 Mininglamp-OSS
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.


### PR DESCRIPTION
## T15: CONTRIBUTING.md

Comprehensive contributor guide covering:
- **Development setup**: prerequisites, install, useful commands
- **Project structure**: file-by-file overview with cross-reference to ARCHITECTURE.md
- **Code style**: English-only artifacts, strict TypeScript, no silent error swallowing
- **Testing**: vitest patterns, mock guidance, in-memory SQLite for DB tests
- **Pre-commit checklist**: type-check → test → lint → selective git add → verify branch
- **PR process**: naming, scope, rebase, review states (APPROVED/CHANGES_REQUESTED/COMMENTED)
- **Protocol layer sync**: release-time diff procedure against upstream openclaw-channel-octo, what to port (security fixes, protocol changes) vs what to skip (OpenClaw-specific features)
- **Security**: vulnerability reporting, no hardcoded secrets, dataDir permissions, bypassPermissions design rationale

## T17: LICENSE

Apache License 2.0, Copyright 2026 Mininglamp-OSS.

Consistent with:
- `package.json` (`"license": "Apache-2.0"`)
- openclaw-channel-octo upstream license

## Verification

- `npx tsc --noEmit` — zero errors ✅
- `npm test` — 95/95 passing ✅
- 2 new files, no source code changes