### PR TITLE
test: add config, gateway, and routeAndHandle concurrency tests (T13)

### DIFF
--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -1,0 +1,352 @@
+/**
+ * Config tests.
+ *
+ * Coverage:
+ *  - loadConfig three-level priority (env > file > defaults)
+ *  - parseCsv / parseIntStrict boundary cases
+ *  - Required field validation (botToken / apiUrl)
+ *  - Invalid JSON error message includes file path
+ *  - _-prefix key filtering
+ *  - Full CC_OCTO_* env override coverage
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { join } from 'node:path';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { loadConfig } from '../config.js';
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+let tmpDir: string;
+const savedEnv: Record<string, string | undefined> = {};
+const CC_VARS = [
+  'CC_OCTO_BOT_TOKEN', 'CC_OCTO_API_URL', 'CC_OCTO_CWD', 'CC_OCTO_DATA_DIR',
+  'CC_OCTO_SDK_MODEL', 'CC_OCTO_SDK_ALLOWED_TOOLS', 'CC_OCTO_SDK_PERMISSION_MODE',
+  'CC_OCTO_SDK_MAX_TURNS', 'CC_OCTO_SDK_SYSTEM_PROMPT', 'CC_OCTO_SDK_SETTING_SOURCES',
+  'CC_OCTO_RATE_LIMIT_MAX_PER_MINUTE', 'CC_OCTO_CONTEXT_MAX_CHARS',
+  'CC_OCTO_CONTEXT_HISTORY_LIMIT', 'CC_OCTO_BOT_BLOCKLIST',
+];
+
+function setup() {
+  tmpDir = mkdtempSync(join(tmpdir(), 'cc-octo-config-test-'));
+  for (const v of CC_VARS) {
+    savedEnv[v] = process.env[v];
+    delete process.env[v];
+  }
+}
+
+function teardown() {
+  for (const v of CC_VARS) {
+    if (savedEnv[v] !== undefined) {
+      process.env[v] = savedEnv[v];
+    } else {
+      delete process.env[v];
+    }
+  }
+  rmSync(tmpDir, { recursive: true, force: true });
+}
+
+function writeConfig(obj: Record<string, unknown>, filename = 'config.json'): string {
+  const path = join(tmpDir, filename);
+  writeFileSync(path, JSON.stringify(obj));
+  return path;
+}
+
+// ─── 1. Defaults ────────────────────────────────────────────────────────────
+
+describe('loadConfig defaults', () => {
+  beforeEach(setup);
+  afterEach(teardown);
+
+  it('returns correct defaults when only required fields are provided via file', () => {
+    const path = writeConfig({ botToken: 'bf_test', apiUrl: 'https://api.test' });
+    const cfg = loadConfig(path);
+
+    expect(cfg.botToken).toBe('bf_test');
+    expect(cfg.apiUrl).toBe('https://api.test');
+    expect(cfg.cwd).toBe(process.cwd());
+    expect(cfg.dataDir).toBe('./data');
+    expect(cfg.sdk.allowedTools).toEqual(['Read', 'Write', 'Edit', 'Bash', 'Glob', 'Grep', 'WebFetch', 'WebSearch']);
+    expect(cfg.sdk.permissionMode).toBe('bypassPermissions');
+    expect(cfg.sdk.settingSources).toEqual(['user']);
+    expect(cfg.rateLimit.maxPerMinute).toBe(5);
+    expect(cfg.context.maxContextChars).toBe(6000);
+    expect(cfg.context.historyLimit).toBe(40);
+    expect(cfg.botBlocklist).toBeUndefined();
+  });
+});
+
+// ─── 2. Three-Level Priority ────────────────────────────────────────────────
+
+describe('three-level priority: env > file > defaults', () => {
+  beforeEach(setup);
+  afterEach(teardown);
+
+  it('file overrides defaults', () => {
+    const path = writeConfig({
+      botToken: 'bf_file',
+      apiUrl: 'https://file.test',
+      dataDir: '/custom/data',
+      rateLimit: { maxPerMinute: 10 },
+    });
+    const cfg = loadConfig(path);
+    expect(cfg.dataDir).toBe('/custom/data');
+    expect(cfg.rateLimit.maxPerMinute).toBe(10);
+  });
+
+  it('env overrides file', () => {
+    const path = writeConfig({
+      botToken: 'bf_file',
+      apiUrl: 'https://file.test',
+      dataDir: '/from-file',
+    });
+    process.env.CC_OCTO_DATA_DIR = '/from-env';
+    const cfg = loadConfig(path);
+    expect(cfg.dataDir).toBe('/from-env');
+  });
+
+  it('env overrides defaults when no config file', () => {
+    process.env.CC_OCTO_BOT_TOKEN = 'bf_env';
+    process.env.CC_OCTO_API_URL = 'https://env.test';
+    process.env.CC_OCTO_DATA_DIR = '/env-data';
+    const cfg = loadConfig(join(tmpDir, 'nonexistent.json'));
+    expect(cfg.botToken).toBe('bf_env');
+    expect(cfg.apiUrl).toBe('https://env.test');
+    expect(cfg.dataDir).toBe('/env-data');
+  });
+});
+
+// ─── 3. Required Fields ────────────────────────────────────────────────────
+
+describe('required field validation', () => {
+  beforeEach(setup);
+  afterEach(teardown);
+
+  it('throws when botToken is missing', () => {
+    const path = writeConfig({ apiUrl: 'https://api.test' });
+    expect(() => loadConfig(path)).toThrow(/botToken/);
+  });
+
+  it('throws when apiUrl is missing', () => {
+    const path = writeConfig({ botToken: 'bf_test' });
+    expect(() => loadConfig(path)).toThrow(/apiUrl/);
+  });
+
+  it('throws when both are missing', () => {
+    const path = writeConfig({});
+    expect(() => loadConfig(path)).toThrow(/botToken/);
+  });
+});
+
+// ─── 4. Invalid JSON ───────────────────────────────────────────────────────
+
+describe('invalid config file', () => {
+  beforeEach(setup);
+  afterEach(teardown);
+
+  it('throws with file path in error message', () => {
+    const path = join(tmpDir, 'bad.json');
+    writeFileSync(path, '{invalid json!!!');
+    expect(() => loadConfig(path)).toThrow(new RegExp(`Failed to parse config file ${path.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`));
+  });
+});
+
+// ─── 5. Underscore-Prefix Key Filtering ─────────────────────────────────────
+
+describe('_-prefix key filtering', () => {
+  beforeEach(setup);
+  afterEach(teardown);
+
+  it('strips keys starting with _ (e.g. _comment)', () => {
+    const path = writeConfig({
+      _comment: 'This is a comment',
+      _version: '1.0',
+      botToken: 'bf_test',
+      apiUrl: 'https://api.test',
+    });
+    const cfg = loadConfig(path);
+    expect(cfg.botToken).toBe('bf_test');
+    // _comment should not appear anywhere in the config
+    expect((cfg as unknown as Record<string, unknown>)['_comment']).toBeUndefined();
+  });
+});
+
+// ─── 6. Env Override Full Coverage ──────────────────────────────────────────
+
+describe('CC_OCTO_* env override coverage', () => {
+  beforeEach(setup);
+  afterEach(teardown);
+
+  it('CC_OCTO_BOT_TOKEN + CC_OCTO_API_URL', () => {
+    process.env.CC_OCTO_BOT_TOKEN = 'bf_env_tok';
+    process.env.CC_OCTO_API_URL = 'https://env-api';
+    const cfg = loadConfig(join(tmpDir, 'nope.json'));
+    expect(cfg.botToken).toBe('bf_env_tok');
+    expect(cfg.apiUrl).toBe('https://env-api');
+  });
+
+  it('CC_OCTO_CWD', () => {
+    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
+    process.env.CC_OCTO_CWD = '/env-cwd';
+    expect(loadConfig(path).cwd).toBe('/env-cwd');
+  });
+
+  it('CC_OCTO_SDK_MODEL', () => {
+    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
+    process.env.CC_OCTO_SDK_MODEL = 'claude-opus-4-0-20250514';
+    expect(loadConfig(path).sdk.model).toBe('claude-opus-4-0-20250514');
+  });
+
+  it('CC_OCTO_SDK_ALLOWED_TOOLS (csv)', () => {
+    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
+    process.env.CC_OCTO_SDK_ALLOWED_TOOLS = 'Read, Grep, Glob';
+    expect(loadConfig(path).sdk.allowedTools).toEqual(['Read', 'Grep', 'Glob']);
+  });
+
+  it('CC_OCTO_SDK_PERMISSION_MODE', () => {
+    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
+    process.env.CC_OCTO_SDK_PERMISSION_MODE = 'acceptEdits';
+    expect(loadConfig(path).sdk.permissionMode).toBe('acceptEdits');
+  });
+
+  it('CC_OCTO_SDK_MAX_TURNS', () => {
+    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
+    process.env.CC_OCTO_SDK_MAX_TURNS = '10';
+    expect(loadConfig(path).sdk.maxTurns).toBe(10);
+  });
+
+  it('CC_OCTO_SDK_SYSTEM_PROMPT', () => {
+    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
+    process.env.CC_OCTO_SDK_SYSTEM_PROMPT = 'You are a helpful bot';
+    expect(loadConfig(path).sdk.systemPrompt).toBe('You are a helpful bot');
+  });
+
+  it('CC_OCTO_SDK_SETTING_SOURCES (csv)', () => {
+    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
+    process.env.CC_OCTO_SDK_SETTING_SOURCES = 'user, project';
+    expect(loadConfig(path).sdk.settingSources).toEqual(['user', 'project']);
+  });
+
+  it('CC_OCTO_RATE_LIMIT_MAX_PER_MINUTE', () => {
+    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
+    process.env.CC_OCTO_RATE_LIMIT_MAX_PER_MINUTE = '20';
+    expect(loadConfig(path).rateLimit.maxPerMinute).toBe(20);
+  });
+
+  it('CC_OCTO_CONTEXT_MAX_CHARS', () => {
+    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
+    process.env.CC_OCTO_CONTEXT_MAX_CHARS = '3000';
+    expect(loadConfig(path).context.maxContextChars).toBe(3000);
+  });
+
+  it('CC_OCTO_CONTEXT_HISTORY_LIMIT', () => {
+    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
+    process.env.CC_OCTO_CONTEXT_HISTORY_LIMIT = '20';
+    expect(loadConfig(path).context.historyLimit).toBe(20);
+  });
+
+  it('CC_OCTO_BOT_BLOCKLIST (csv)', () => {
+    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
+    process.env.CC_OCTO_BOT_BLOCKLIST = 'bot-a, bot-b, bot-c';
+    expect(loadConfig(path).botBlocklist).toEqual(['bot-a', 'bot-b', 'bot-c']);
+  });
+});
+
+// ─── 7. parseIntStrict Boundary Cases ───────────────────────────────────────
+
+describe('parseIntStrict via env', () => {
+  beforeEach(setup);
+  afterEach(teardown);
+
+  it('rejects hex string (0xff)', () => {
+    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
+    process.env.CC_OCTO_SDK_MAX_TURNS = '0xff';
+    expect(() => loadConfig(path)).toThrow(/Invalid integer/);
+  });
+
+  it('rejects negative number', () => {
+    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
+    process.env.CC_OCTO_SDK_MAX_TURNS = '-5';
+    expect(() => loadConfig(path)).toThrow(/Invalid integer/);
+  });
+
+  it('rejects zero', () => {
+    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
+    process.env.CC_OCTO_SDK_MAX_TURNS = '0';
+    expect(() => loadConfig(path)).toThrow(/Invalid integer/);
+  });
+
+  it('rejects scientific notation', () => {
+    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
+    process.env.CC_OCTO_SDK_MAX_TURNS = '1e3';
+    expect(() => loadConfig(path)).toThrow(/Invalid integer/);
+  });
+
+  it('rejects float', () => {
+    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
+    process.env.CC_OCTO_SDK_MAX_TURNS = '3.14';
+    expect(() => loadConfig(path)).toThrow(/Invalid integer/);
+  });
+
+  it('rejects empty string (env var set but empty)', () => {
+    // Empty string env vars are falsy, so CC_OCTO_SDK_MAX_TURNS="" won't trigger parseIntStrict.
+    // But let's verify the behavior: empty string should not override.
+    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
+    process.env.CC_OCTO_SDK_MAX_TURNS = '';
+    const cfg = loadConfig(path);
+    expect(cfg.sdk.maxTurns).toBeUndefined(); // empty string = falsy = no override
+  });
+
+  it('rejects non-numeric string', () => {
+    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
+    process.env.CC_OCTO_SDK_MAX_TURNS = 'abc';
+    expect(() => loadConfig(path)).toThrow(/Invalid integer/);
+  });
+
+  it('accepts valid positive integer', () => {
+    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
+    process.env.CC_OCTO_SDK_MAX_TURNS = '42';
+    expect(loadConfig(path).sdk.maxTurns).toBe(42);
+  });
+});
+
+// ─── 8. parseCsv Edge Cases ─────────────────────────────────────────────────
+
+describe('parseCsv via env', () => {
+  beforeEach(setup);
+  afterEach(teardown);
+
+  it('trims whitespace around items', () => {
+    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
+    process.env.CC_OCTO_SDK_ALLOWED_TOOLS = '  Read ,  Grep  , Glob  ';
+    expect(loadConfig(path).sdk.allowedTools).toEqual(['Read', 'Grep', 'Glob']);
+  });
+
+  it('filters empty segments from trailing commas', () => {
+    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
+    process.env.CC_OCTO_SDK_ALLOWED_TOOLS = 'Read,,Grep,,,';
+    expect(loadConfig(path).sdk.allowedTools).toEqual(['Read', 'Grep']);
+  });
+
+  it('single item without commas', () => {
+    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
+    process.env.CC_OCTO_SDK_ALLOWED_TOOLS = 'Read';
+    expect(loadConfig(path).sdk.allowedTools).toEqual(['Read']);
+  });
+});
+
+// ─── 9. Config File Missing ─────────────────────────────────────────────────
+
+describe('missing config file', () => {
+  beforeEach(setup);
+  afterEach(teardown);
+
+  it('falls back to defaults + env when config file does not exist', () => {
+    process.env.CC_OCTO_BOT_TOKEN = 'bf_env';
+    process.env.CC_OCTO_API_URL = 'https://env-api';
+    const cfg = loadConfig(join(tmpDir, 'missing.json'));
+    expect(cfg.botToken).toBe('bf_env');
+    expect(cfg.sdk.permissionMode).toBe('bypassPermissions'); // default
+  });
+});

--- a/src/__tests__/gateway.test.ts
+++ b/src/__tests__/gateway.test.ts
@@ -1,0 +1,318 @@
+/**
+ * Gateway tests.
+ *
+ * Coverage:
+ *  - Process lock: acquireLock / releaseLock / stale PID detection
+ *  - Token refresh cooldown (60s window)
+ *  - Heartbeat consecutive failures trigger reconnect
+ *  - createSocket factory verification
+ *
+ * We test OctoGateway by mocking the Octo API (registerBot / sendHeartbeat)
+ * and WKSocket. The lock file tests use real filesystem.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { join } from 'node:path';
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+
+// Mock Octo modules before importing Gateway
+vi.mock('../octo/api.js', () => ({
+  registerBot: vi.fn(),
+  sendHeartbeat: vi.fn(),
+}));
+
+vi.mock('../octo/socket.js', () => {
+  const MockWKSocket = vi.fn().mockImplementation(() => ({
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    disconnectAndWait: vi.fn().mockResolvedValue(undefined),
+    updateCredentials: vi.fn(),
+  }));
+  return { WKSocket: MockWKSocket };
+});
+
+import { OctoGateway } from '../gateway.js';
+import { registerBot, sendHeartbeat } from '../octo/api.js';
+import { WKSocket } from '../octo/socket.js';
+import type { Config } from '../config.js';
+
+let tmpDir: string;
+
+function makeConfig(overrides?: Partial<Config>): Config {
+  return {
+    botToken: 'bf_test',
+    apiUrl: 'https://test.example.com',
+    cwd: '/tmp/cwd',
+    dataDir: tmpDir,
+    sdk: {
+      allowedTools: ['Read'],
+      permissionMode: 'bypassPermissions',
+      settingSources: ['user'],
+    },
+    rateLimit: { maxPerMinute: 5 },
+    context: { maxContextChars: 6000, historyLimit: 40 },
+    ...overrides,
+  };
+}
+
+function setupMocks() {
+  vi.mocked(registerBot).mockResolvedValue({
+    robot_id: 'bot-123',
+    im_token: 'im-token-abc',
+    ws_url: 'wss://ws.test/v1',
+    api_url: 'https://api.test',
+    owner_uid: 'owner-1',
+    owner_channel_id: 'owner-ch',
+  });
+  vi.mocked(sendHeartbeat).mockResolvedValue(undefined as never);
+}
+
+// ─── 1. Process Lock ────────────────────────────────────────────────────────
+
+describe('Process lock', () => {
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'cc-octo-gw-test-'));
+    vi.clearAllMocks();
+    setupMocks();
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('acquireLock creates lock file with current PID', async () => {
+    const gw = new OctoGateway(makeConfig());
+    await gw.start();
+
+    const lockPath = join(tmpDir, 'gateway.lock');
+    expect(existsSync(lockPath)).toBe(true);
+    expect(readFileSync(lockPath, 'utf-8').trim()).toBe(String(process.pid));
+
+    await gw.stop();
+  });
+
+  it('releaseLock removes lock file', async () => {
+    const gw = new OctoGateway(makeConfig());
+    await gw.start();
+    await gw.stop();
+
+    const lockPath = join(tmpDir, 'gateway.lock');
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  it('stale PID detection: removes lock from dead process', async () => {
+    const lockPath = join(tmpDir, 'gateway.lock');
+    // Write a lock with a PID that definitely doesn't exist
+    writeFileSync(lockPath, '999999999', { mode: 0o600 });
+
+    const gw = new OctoGateway(makeConfig());
+    // Should not throw — stale lock is detected and removed
+    await gw.start();
+
+    expect(readFileSync(lockPath, 'utf-8').trim()).toBe(String(process.pid));
+    await gw.stop();
+  });
+
+  it('rejects when another live process holds the lock', async () => {
+    const lockPath = join(tmpDir, 'gateway.lock');
+    // Write a lock with current process PID (which is alive)
+    // Use PID 1 (init/launchd) which is always alive
+    writeFileSync(lockPath, '1', { mode: 0o600 });
+
+    const gw = new OctoGateway(makeConfig());
+    await expect(gw.start()).rejects.toThrow(/Another instance is running/);
+  });
+});
+
+// ─── 2. Bot Registration + Socket Creation ──────────────────────────────────
+
+describe('Bot registration and socket', () => {
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'cc-octo-gw-test-'));
+    vi.clearAllMocks();
+    setupMocks();
+  });
+
+  afterEach(async () => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('registers bot and exposes robotId', async () => {
+    const gw = new OctoGateway(makeConfig());
+    await gw.start();
+
+    expect(registerBot).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiUrl: 'https://test.example.com',
+        botToken: 'bf_test',
+      }),
+    );
+    expect(gw.botId).toBe('bot-123');
+
+    await gw.stop();
+  });
+
+  it('createSocket is called with registration response', async () => {
+    const gw = new OctoGateway(makeConfig());
+    await gw.start();
+
+    expect(WKSocket).toHaveBeenCalledWith(
+      expect.objectContaining({
+        wsUrl: 'wss://ws.test/v1',
+        uid: 'bot-123',
+        token: 'im-token-abc',
+      }),
+    );
+
+    await gw.stop();
+  });
+
+  it('message handler filters out self messages', async () => {
+    const messages: unknown[] = [];
+    const gw = new OctoGateway(makeConfig());
+    gw.setMessageHandler((msg) => messages.push(msg));
+
+    await gw.start();
+
+    // Get the onMessage callback passed to WKSocket
+    const socketCall = vi.mocked(WKSocket).mock.calls[0][0];
+    const onMessage = socketCall.onMessage;
+
+    // Message from self — should be filtered
+    onMessage({ message_id: '1', message_seq: 1, from_uid: 'bot-123', timestamp: 0, payload: { type: 1 } });
+    expect(messages).toHaveLength(0);
+
+    // Message from other user — should pass through
+    onMessage({ message_id: '2', message_seq: 2, from_uid: 'user-1', timestamp: 0, payload: { type: 1 } });
+    expect(messages).toHaveLength(1);
+
+    await gw.stop();
+  });
+});
+
+// ─── 3. Token Refresh Cooldown ──────────────────────────────────────────────
+
+describe('Token refresh cooldown', () => {
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'cc-octo-gw-test-'));
+    vi.clearAllMocks();
+    setupMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('does not refresh within 60s cooldown', async () => {
+    const gw = new OctoGateway(makeConfig());
+    await gw.start();
+
+    const initialCallCount = vi.mocked(registerBot).mock.calls.length;
+
+    // Simulate WS error that triggers refresh
+    const socketOpts = vi.mocked(WKSocket).mock.calls[0][0];
+    socketOpts.onError!(new Error('Kicked by server'));
+
+    // Wait for refresh to complete
+    await vi.advanceTimersByTimeAsync(100);
+    const afterFirstRefresh = vi.mocked(registerBot).mock.calls.length;
+    expect(afterFirstRefresh).toBe(initialCallCount + 1);
+
+    // Try another refresh within cooldown
+    socketOpts.onError!(new Error('Kicked by server'));
+    await vi.advanceTimersByTimeAsync(100);
+
+    // Should NOT have triggered another registerBot call
+    expect(vi.mocked(registerBot).mock.calls.length).toBe(afterFirstRefresh);
+
+    await gw.stop();
+  });
+
+  it('allows refresh after cooldown expires', async () => {
+    const gw = new OctoGateway(makeConfig());
+    await gw.start();
+
+    const socketOpts = vi.mocked(WKSocket).mock.calls[0][0];
+
+    // First refresh
+    socketOpts.onError!(new Error('Kicked by server'));
+    await vi.advanceTimersByTimeAsync(100);
+    const afterFirst = vi.mocked(registerBot).mock.calls.length;
+
+    // Advance past cooldown (60s)
+    await vi.advanceTimersByTimeAsync(61_000);
+
+    // Second refresh — should work now
+    // Need to get the new socket's onError since a new WKSocket was created
+    const newSocketOpts = vi.mocked(WKSocket).mock.calls[vi.mocked(WKSocket).mock.calls.length - 1][0];
+    newSocketOpts.onError!(new Error('Kicked by server'));
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(vi.mocked(registerBot).mock.calls.length).toBe(afterFirst + 1);
+
+    await gw.stop();
+  });
+});
+
+// ─── 4. Heartbeat Failures ──────────────────────────────────────────────────
+
+describe('Heartbeat consecutive failures', () => {
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'cc-octo-gw-test-'));
+    vi.clearAllMocks();
+    setupMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('triggers reconnect after 3 consecutive heartbeat failures', async () => {
+    vi.mocked(sendHeartbeat).mockRejectedValue(new Error('network error'));
+
+    const gw = new OctoGateway(makeConfig());
+    await gw.start();
+
+    const initialRegCalls = vi.mocked(registerBot).mock.calls.length;
+
+    // Each heartbeat fires every 30s. Need 3 failures.
+    await vi.advanceTimersByTimeAsync(30_000); // failure 1
+    await vi.advanceTimersByTimeAsync(30_000); // failure 2
+    await vi.advanceTimersByTimeAsync(30_000); // failure 3 → triggers reconnect
+
+    // Allow async reconnect to complete
+    await vi.advanceTimersByTimeAsync(100);
+
+    // registerBot should have been called again (token refresh)
+    expect(vi.mocked(registerBot).mock.calls.length).toBeGreaterThan(initialRegCalls);
+
+    await gw.stop();
+  });
+
+  it('resets failure count on successful heartbeat', async () => {
+    let failCount = 0;
+    vi.mocked(sendHeartbeat).mockImplementation(async () => {
+      failCount++;
+      if (failCount <= 2) throw new Error('network error');
+      // Third call succeeds
+    });
+
+    const gw = new OctoGateway(makeConfig());
+    await gw.start();
+    const initialRegCalls = vi.mocked(registerBot).mock.calls.length;
+
+    await vi.advanceTimersByTimeAsync(30_000); // failure 1
+    await vi.advanceTimersByTimeAsync(30_000); // failure 2
+    await vi.advanceTimersByTimeAsync(30_000); // success — resets counter
+
+    // Should NOT have triggered reconnect
+    expect(vi.mocked(registerBot).mock.calls.length).toBe(initialRegCalls);
+
+    await gw.stop();
+  });
+});

--- a/src/__tests__/session-router.test.ts
+++ b/src/__tests__/session-router.test.ts
@@ -256,3 +256,158 @@ describe('SessionRouter', () => {
     expect(order).toEqual([0, 1, 2, 3, 4]);
   });
 });
+
+// ─── routeAndHandle: Concurrency + Lock Integration ─────────────────────────
+
+describe('routeAndHandle concurrency', () => {
+  let router: SessionRouter;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    router = new SessionRouter(makeConfig({ rateLimit: { maxPerMinute: 100 } }), ROBOT_ID);
+  });
+
+  it('same session key: route + handler execute serially (FIFO)', async () => {
+    const order: number[] = [];
+
+    const promises = [];
+    for (let i = 0; i < 5; i++) {
+      const idx = i;
+      promises.push(
+        router.routeAndHandle(
+          makeMsg({
+            message_id: String(idx),
+            channel_type: ChannelType.DM,
+            from_uid: 'same-user',
+          }),
+          async () => {
+            // Simulate async work to expose ordering bugs
+            await new Promise((r) => setTimeout(r, 1));
+            order.push(idx);
+          },
+        ),
+      );
+    }
+    await Promise.all(promises);
+    expect(order).toEqual([0, 1, 2, 3, 4]);
+  });
+
+  it('different session keys run in parallel', async () => {
+    let maxConcurrent = 0;
+    let current = 0;
+
+    const promises = [];
+    for (let i = 0; i < 3; i++) {
+      promises.push(
+        router.routeAndHandle(
+          makeMsg({
+            message_id: String(i),
+            channel_type: ChannelType.DM,
+            from_uid: `user-${i}`, // different session keys
+          }),
+          async () => {
+            current++;
+            maxConcurrent = Math.max(maxConcurrent, current);
+            await new Promise((r) => setTimeout(r, 10));
+            current--;
+          },
+        ),
+      );
+    }
+    await Promise.all(promises);
+    expect(maxConcurrent).toBeGreaterThan(1);
+  });
+
+  it('handler runs inside the lock (max 1 concurrent per session)', async () => {
+    let maxConcurrent = 0;
+    let current = 0;
+
+    const promises = [];
+    for (let i = 0; i < 5; i++) {
+      promises.push(
+        router.routeAndHandle(
+          makeMsg({
+            message_id: String(i),
+            channel_type: ChannelType.DM,
+            from_uid: 'same-user',
+          }),
+          async () => {
+            current++;
+            maxConcurrent = Math.max(maxConcurrent, current);
+            await new Promise((r) => setTimeout(r, 5));
+            current--;
+          },
+        ),
+      );
+    }
+    await Promise.all(promises);
+    expect(maxConcurrent).toBe(1);
+  });
+
+  it('routeAndHandle does not call handler for non-processable messages', async () => {
+    const handlerCalls: string[] = [];
+
+    // Group message without mention — should not be processed
+    await router.routeAndHandle(
+      makeMsg({
+        channel_type: ChannelType.Group,
+        payload: { type: MessageType.Text, content: 'no mention' },
+      }),
+      async (result) => {
+        handlerCalls.push(result.sessionKey);
+      },
+    );
+
+    expect(handlerCalls).toHaveLength(0);
+  });
+
+  it('routeAndHandle calls handler for processable messages', async () => {
+    const handlerCalls: string[] = [];
+
+    // DM text message — should be processed
+    await router.routeAndHandle(
+      makeMsg({
+        channel_type: ChannelType.DM,
+        from_uid: 'user-1',
+        payload: { type: MessageType.Text, content: 'hello' },
+      }),
+      async (result) => {
+        handlerCalls.push(result.sessionKey);
+      },
+    );
+
+    expect(handlerCalls).toEqual(['user-1']);
+  });
+
+  it('burst of same-session messages: FIFO order + max-1 concurrent', async () => {
+    const order: number[] = [];
+    let maxConcurrent = 0;
+    let current = 0;
+
+    const burst = 10;
+    const promises = [];
+    for (let i = 0; i < burst; i++) {
+      const idx = i;
+      promises.push(
+        router.routeAndHandle(
+          makeMsg({
+            message_id: String(idx),
+            channel_type: ChannelType.DM,
+            from_uid: 'burst-user',
+          }),
+          async () => {
+            current++;
+            maxConcurrent = Math.max(maxConcurrent, current);
+            await new Promise((r) => setTimeout(r, 1));
+            order.push(idx);
+            current--;
+          },
+        ),
+      );
+    }
+    await Promise.all(promises);
+
+    expect(maxConcurrent).toBe(1);
+    expect(order).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+  });
+});


### PR DESCRIPTION
## T13: Test Supplement — config, gateway, routeAndHandle concurrency

### T13-a: config.test.ts (33 tests)
- `loadConfig` three-level priority (env > file > defaults)
- Required field validation (botToken / apiUrl throw on missing)
- Invalid JSON error includes file path
- `_`-prefix key filtering (e.g. `_comment`)
- Full `CC_OCTO_*` env override coverage (all 14 variables)
- `parseIntStrict`: rejects hex (`0xff`), negative, zero, scientific notation (`1e3`), float (`3.14`), non-numeric
- `parseCsv`: trims whitespace, filters empty segments, single item
- Missing config file fallback

### T13-b: gateway.test.ts (11 tests)
- Process lock: acquire/release lifecycle, stale PID detection, live PID rejection
- Bot registration + WKSocket factory verification
- Message handler self-filter
- Token refresh 60s cooldown (blocks within window, allows after)
- Heartbeat 3x consecutive failure → reconnect trigger
- Heartbeat failure count reset on success

### T13-c: session-router.test.ts extended (6 new tests)
- `routeAndHandle`: same-session FIFO serial execution
- `routeAndHandle`: different-session parallel execution
- Max-1 concurrent handler per session key
- Non-processable messages skip handler
- Processable messages invoke handler
- 10-message burst: FIFO + max-1 concurrent assertion

### Verification
- `npm test` → 145 tests all passing (was 95)
- No source files modified