### PR TITLE
fix(security): replace Math.random DH seed with crypto.randomBytes + fix spread stack overflow (Q4+Q5)

### DIFF
--- a/src/__tests__/octo/protocol.test.ts
+++ b/src/__tests__/octo/protocol.test.ts
@@ -569,3 +569,35 @@ describe("Edge cases", () => {
     expect(remaining.length).toBe(0);
   });
 });
+
+// ─── 6. Large-Payload Safety (Q5 regression) ───────────────────────────────
+
+describe("Large-payload safety (>64K, no stack overflow)", () => {
+  it("Encoder.writeBytes handles >64K bytes without stack overflow", () => {
+    const enc = new Encoder();
+    const largeArray = new Array(100_000).fill(0x42);
+    enc.writeBytes(largeArray);
+    const result = enc.toUint8Array();
+    expect(result.length).toBe(100_000);
+    expect(result[0]).toBe(0x42);
+    expect(result[99_999]).toBe(0x42);
+  });
+
+  it("Encoder.writeString / Decoder.readString round-trip for large UTF-8 string", () => {
+    const enc = new Encoder();
+    // 20K CJK chars = ~60K UTF-8 bytes, fits in Int16 length prefix (max 65535)
+    const longStr = "中".repeat(20_000);
+    enc.writeString(longStr);
+    const dec = new Decoder(enc.toUint8Array());
+    expect(dec.readString()).toBe(longStr);
+  });
+
+  it("Encoder.writeString / Decoder.readString round-trip for >64K ASCII", () => {
+    const enc = new Encoder();
+    // 65000 ASCII chars = 65000 bytes, still fits in Int16 (max 65535)
+    const longStr = "A".repeat(65_000);
+    enc.writeString(longStr);
+    const dec = new Decoder(enc.toUint8Array());
+    expect(dec.readString()).toBe(longStr);
+  });
+});

--- a/src/octo/socket.ts
+++ b/src/octo/socket.ts
@@ -8,6 +8,7 @@ import { generateKeyPair, sharedKey } from "curve25519-js";
 import { Buffer } from "buffer";
 import CryptoJS from "crypto-js";
 import { Md5 } from "md5-typescript";
+import { randomBytes } from "node:crypto";
 import type { BotMessage, MessagePayload } from "./types.js";
 
 // ─── WuKongIM Binary Protocol Constants ─────────────────────────────────────
@@ -31,7 +32,7 @@ const PROTO_VERSION = 4;
 export class Encoder {
   private w: number[] = [];
   writeByte(b: number) { this.w.push(b & 0xff); }
-  writeBytes(b: number[]) { this.w.push(...b); }
+  writeBytes(b: number[]) { for (let i = 0; i < b.length; i++) this.w[this.w.length] = b[i]; }
   writeInt16(b: number) { this.w.push((b >> 8) & 0xff, b & 0xff); }
   writeInt32(b: number) { this.w.push((b >> 24) & 0xff, (b >> 16) & 0xff, (b >> 8) & 0xff, b & 0xff); }
   writeInt64(n: bigint) {
@@ -44,7 +45,7 @@ export class Encoder {
     if (s && s.length > 0) {
       const arr = stringToUint(s);
       this.writeInt16(arr.length);
-      this.w.push(...arr);
+      for (let i = 0; i < arr.length; i++) this.w[this.w.length] = arr[i];
     } else {
       this.writeInt16(0);
     }
@@ -121,15 +122,11 @@ export class Decoder {
 }
 
 function stringToUint(str: string): number[] {
-  const encoded = unescape(encodeURIComponent(str));
-  const arr: number[] = [];
-  for (let i = 0; i < encoded.length; i++) arr.push(encoded.charCodeAt(i));
-  return arr;
+  return Array.from(new TextEncoder().encode(str));
 }
 
 function uintToString(array: number[]): string {
-  const encoded = String.fromCharCode(...array);
-  return decodeURIComponent(escape(encoded));
+  return new TextDecoder().decode(new Uint8Array(array));
 }
 
 function encodeVariableLength(len: number): number[] {
@@ -146,7 +143,7 @@ function encodeVariableLength(len: number): number[] {
 // ─── AES-CBC Encryption Helpers ─────────────────────────────────────────────
 
 function aesDecrypt(data: Uint8Array, aesKey: string, aesIV: string): Uint8Array {
-  const str = String.fromCharCode(...Array.from(data));
+  const str = Buffer.from(data).toString("binary");
   const ciphertext = CryptoJS.enc.Base64.parse(str);
   const decrypted = CryptoJS.AES.decrypt(
     CryptoJS.enc.Base64.stringify(ciphertext),
@@ -360,7 +357,7 @@ export class WKSocket extends EventEmitter {
       if (this.ws !== ws) return; // stale guard
       this.tempBuffer = [];
       // Generate DH key pair
-      const seed = Uint8Array.from(stringToUint(generateDeviceID()));
+      const seed = randomBytes(32);
       const keyPair = generateKeyPair(seed);
       this.dhPrivateKey = keyPair.private;
       const pubKey = Buffer.from(keyPair.public).toString("base64");
@@ -517,7 +514,7 @@ export class WKSocket extends EventEmitter {
   }
 
   private handleRawData(data: Uint8Array): void {
-    this.tempBuffer.push(...Array.from(data));
+    for (let i = 0; i < data.length; i++) this.tempBuffer.push(data[i]);
 
     try {
       let lenBefore: number;


### PR DESCRIPTION
## Changes

### Q4: DH key seed — crypto.randomBytes(32) instead of Math.random()

`generateDeviceID()` used `Math.random()` to generate the seed for the Curve25519 DH key pair. `Math.random()` is not a cryptographically secure PRNG — its internal state can be predicted from observed outputs. Since the device ID (derived from the same PRNG) is transmitted in cleartext in the CONNECT packet, an attacker observing WS traffic could potentially recover the PRNG state and derive the DH private key, breaking all payload encryption.

**Fix:** Use `crypto.randomBytes(32)` from Node.js `node:crypto` for the DH seed. `generateDeviceID()` is still used for the device ID string (non-security-critical).

### Q5: Spread/fromCharCode stack overflow on large payloads

Six sites in socket.ts used `...spread` or `String.fromCharCode(...array)` patterns that hit the V8 maximum call stack size (~10K arguments) on large payloads:

| Site | Before | After |
|------|--------|-------|
| `Encoder.writeBytes` | `this.w.push(...b)` | for loop |
| `Encoder.writeString` | `this.w.push(...arr)` | for loop |
| `stringToUint` | `unescape(encodeURIComponent())` | `TextEncoder` |
| `uintToString` | `String.fromCharCode(...array)` | `TextDecoder` |
| `aesDecrypt` | `String.fromCharCode(...Array.from(data))` | `Buffer.toString('binary')` |
| `handleRawData` | `tempBuffer.push(...Array.from(data))` | for loop |

### Tests

3 new regression tests in `protocol.test.ts`:
- `writeBytes` with 100K bytes
- `writeString/readString` round-trip with 60K UTF-8 bytes (20K CJK chars)
- `writeString/readString` round-trip with 65K ASCII bytes

### Verification

- `tsc --noEmit`: ✅ clean
- `eslint src/octo/socket.ts`: 0 errors (13 pre-existing warnings)
- `vitest run`: 153 tests pass (40 protocol tests = 37 existing + 3 new)

**Scope:** Only `src/octo/socket.ts` and `src/__tests__/octo/protocol.test.ts` modified.