### PR TITLE
fix(Q2): add default 30s timeout to postJson — prevent session deadlock

### DIFF
--- a/src/__tests__/api-timeout.test.ts
+++ b/src/__tests__/api-timeout.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Tests for postJson default timeout behavior (Q2 fix).
+ *
+ * Verifies that postJson applies a 30s default timeout when no signal is provided,
+ * and respects caller-provided signals when explicitly passed.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { postJson } from "../octo/api.js";
+
+// Mock the global fetch before any postJson calls.
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+describe("postJson default timeout", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it("applies default timeout when no signal is provided", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve('{"result": "ok"}'),
+    });
+
+    await postJson("https://api.example.com", "test-token", "/v1/bot/test", {
+      key: "value",
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const options = mockFetch.mock.calls[0][1] as RequestInit;
+    // After Q2 fix, postJson should always pass a signal (30s default)
+    expect(options.signal).toBeDefined();
+    expect(options.signal).toBeInstanceOf(AbortSignal);
+    expect((options.signal as AbortSignal).aborted).toBe(false);
+  });
+
+  it("uses caller-provided signal when explicitly passed", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve('{"result": "ok"}'),
+    });
+
+    const controller = new AbortController();
+    await postJson(
+      "https://api.example.com",
+      "test-token",
+      "/v1/bot/test",
+      { key: "value" },
+      controller.signal,
+    );
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const options = mockFetch.mock.calls[0][1] as RequestInit;
+    expect(options.signal).toBe(controller.signal);
+  });
+
+  it("rejects with abort error when timeout fires", async () => {
+    const shortSignal = AbortSignal.timeout(1);
+
+    mockFetch.mockImplementation(
+      (_url: string, opts: RequestInit) =>
+        new Promise((resolve, reject) => {
+          const timer = setTimeout(
+            () => resolve({ ok: true, text: () => "" }),
+            60_000,
+          );
+          opts?.signal?.addEventListener("abort", () => {
+            clearTimeout(timer);
+            reject(new DOMException("The operation was aborted.", "AbortError"));
+          });
+        }),
+    );
+
+    await expect(
+      postJson(
+        "https://api.example.com",
+        "test-token",
+        "/v1/bot/test",
+        {},
+        shortSignal,
+      ),
+    ).rejects.toThrow();
+  });
+
+  it("sends correct headers including Authorization", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve(""),
+    });
+
+    await postJson("https://api.example.com", "my-token", "/v1/bot/test", {});
+
+    const options = mockFetch.mock.calls[0][1] as RequestInit;
+    const headers = options.headers as Record<string, string>;
+    expect(headers["Content-Type"]).toBe("application/json");
+    expect(headers["Authorization"]).toBe("Bearer my-token");
+  });
+
+  it("strips trailing slashes from apiUrl", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve(""),
+    });
+
+    await postJson(
+      "https://api.example.com///",
+      "token",
+      "/v1/bot/test",
+      {},
+    );
+
+    const url = mockFetch.mock.calls[0][0] as string;
+    expect(url).toBe("https://api.example.com/v1/bot/test");
+  });
+
+  it("throws on non-ok response with status and body", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: "Not Found",
+      text: () => Promise.resolve("endpoint not found"),
+    });
+
+    await expect(
+      postJson("https://api.example.com", "token", "/v1/bot/missing", {}),
+    ).rejects.toThrow(
+      "Octo API /v1/bot/missing failed (404): endpoint not found",
+    );
+  });
+
+  it("returns undefined for empty response body", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve(""),
+    });
+
+    const result = await postJson(
+      "https://api.example.com",
+      "token",
+      "/v1/bot/test",
+      {},
+    );
+    expect(result).toBeUndefined();
+  });
+
+  it("parses JSON response with int64 message_id protection", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      text: () =>
+        Promise.resolve('{"message_id": 123456789012345678, "data": "ok"}'),
+    });
+
+    const result = await postJson<{ message_id: string; data: string }>(
+      "https://api.example.com",
+      "token",
+      "/v1/bot/test",
+      {},
+    );
+    expect(result).toBeDefined();
+    expect(result!.message_id).toBe("123456789012345678");
+    expect(result!.data).toBe("ok");
+  });
+});

--- a/src/octo/api.ts
+++ b/src/octo/api.ts
@@ -50,6 +50,7 @@ export async function postJson<T>(
   signal?: AbortSignal,
 ): Promise<T | undefined> {
   const url = `${apiUrl.replace(/\/+$/, "")}${path}`;
+  const effectiveSignal = signal ?? AbortSignal.timeout(DEFAULT_TIMEOUT_MS);
   const response = await fetch(url, {
     method: "POST",
     headers: {
@@ -57,7 +58,7 @@ export async function postJson<T>(
       Authorization: `Bearer ${botToken}`,
     },
     body: JSON.stringify(payload),
-    signal,
+    signal: effectiveSignal,
   });
 
   if (!response.ok) {
@@ -265,7 +266,7 @@ export async function getChannelMessages(params: {
         end_message_seq: params.endMessageSeq ?? 0,
         pull_mode: 1,
       }),
-      signal: params.signal,
+      signal: params.signal ?? AbortSignal.timeout(DEFAULT_TIMEOUT_MS),
     });
 
     if (!response.ok) {


### PR DESCRIPTION
## Q2: postJson 无默认超时 → session 死锁

### Problem

`postJson` passed the caller's `signal` directly to `fetch` without a fallback. All callers (`sendMessage`, `sendTyping`, `sendHeartbeat`, `stream*`) pass no signal. A hanging Octo API (network partition, DNS timeout, unresponsive server) blocks the session's promise chain indefinitely → all subsequent messages for that session queue forever.

### Fix

```typescript
const effectiveSignal = signal ?? AbortSignal.timeout(DEFAULT_TIMEOUT_MS);
```

One line in `postJson` ensures every call gets a 30s timeout (`DEFAULT_TIMEOUT_MS`, already defined but unused) unless the caller provides their own signal. Caller-provided signals are respected unchanged.

Also applied the same fix to `getChannelMessages` (dead code, but consistent).

### Impact

- `sendMessage`: now protected ✅
- `sendTyping`: now protected ✅  
- `sendHeartbeat`: now protected ✅
- `streamStart/Send/End`: now protected ✅
- `registerBot`: already passes signal from caller → unchanged ✅
- `getGroupMembers`: already has `AbortSignal.timeout(DEFAULT_TIMEOUT_MS)` → unchanged ✅
- `fetchUserInfo`: already has `AbortSignal.timeout(5000)` → unchanged ✅

### Tests

8 new tests in `api-timeout.test.ts`:
1. Default timeout applied when no signal provided
2. Caller-provided signal respected
3. Abort error when timeout fires
4. Correct headers including Authorization
5. URL trailing slash normalization
6. Error response with status and body
7. Empty response returns undefined
8. int64 message_id JSON protection

### Verification

- `tsc --noEmit`: zero errors
- `vitest run`: 161/161 passed (153 existing + 8 new)
- Only `src/octo/api.ts` changed (+3 lines / -2 lines)