### PR TITLE
fix: remove non-functional stream API path (Q1)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -93,7 +93,7 @@ Forked from [openclaw-channel-octo](https://github.com/Mininglamp-OSS/openclaw-c
 6. Inside handler (still under lock):
    a. session-store: getOrCreate session, build history prefix
    b. agent-bridge: buildPrompt (history + message) → query() → AsyncIterable<string>
-   c. stream-relay: typing heartbeat + throttled stream flushes to Octo
+   c. stream-relay: typing heartbeat + sendMessage delivery to Octo
    d. session-store: append user message + assistant response
 7. Lock released → next queued message for this session proceeds
 ```

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -38,7 +38,7 @@ This document describes the internal architecture of cc-channel-octo: a standalo
 └─────────────────────────────────────────────────────────────┘
          ▲                                      │
          │ WuKongIM binary protocol             │ Octo REST API
-         │ (WebSocket)                          │ (stream/send)
+         │ (WebSocket)                          │ (send/typing)
          ▼                                      ▼
 ┌─────────────────────────────────────────────────────────────┐
 │                      Octo Server                            │
@@ -56,7 +56,7 @@ Forked from [openclaw-channel-octo](https://github.com/Mininglamp-OSS/openclaw-c
 | File | Responsibility |
 |---|---|
 | `types.ts` | Octo Bot API types, channel/message enums, mention payloads |
-| `api.ts` | REST API functions: register, send, typing, heartbeat, stream start/send/end, group members, user info, channel message sync |
+| `api.ts` | REST API functions: register, send, typing, heartbeat, group members, user info, channel message sync |
 | `socket.ts` | WuKongIM binary protocol over WebSocket: DH key exchange (curve25519), AES-CBC encryption, binary framing (variable-length encoding), CONNECT/CONNACK/RECV/RECVACK/PING/PONG, reconnect with exponential backoff + jitter |
 
 **Protocol details.** The WuKongIM protocol uses a custom binary framing format (not protobuf). Each frame has a 1-byte header (packet type in upper nibble, flags in lower nibble) followed by a variable-length body size and the body. Encryption is AES-128-CBC with keys derived from a Diffie-Hellman exchange (curve25519) during CONNECT/CONNACK. The salt from CONNACK provides the IV. Message IDs are 64-bit integers transmitted as big-endian — the API layer uses `parseOctoJson` to convert 16+ digit numeric IDs to strings before `JSON.parse` to avoid JavaScript precision loss.
@@ -77,7 +77,7 @@ Forked from [openclaw-channel-octo](https://github.com/Mininglamp-OSS/openclaw-c
 | `session-router.ts` | Message routing pipeline: self-message filter → bot blocklist → group mention gate (`uids` or `ais`, NOT `all`) → rate limiting (token bucket, per-session, debounced notification) → non-text rejection. **Critical design: `routeAndHandle` holds a per-session lock across both routing and handler execution** — this eliminates the TOCTOU gap between "should I process this?" and "processing it". |
 | `group-context.ts` | Group chat context management: in-memory message window (100 messages per channel, budget-capped to `maxContextChars`), member name cache (SQLite-backed, hourly API refresh), bidirectional uid↔name mapping, `@name` mention resolution via regex. Context string is built BEFORE the current message is cached to avoid duplication. |
 | `agent-bridge.ts` | Claude Agent SDK integration. Builds a structured prompt (`[Group context]` + `[Conversation history]` + `[Current message]`), calls `query()` with configured permissions/tools/model, yields text chunks as `AsyncIterable<string>`. Includes a hardcoded system prompt that instructs the agent to reject credential exfiltration attempts. **Knows nothing about Octo.** |
-| `stream-relay.ts` | Streaming output delivery. Typing indicator heartbeat (5s). Stream API path: `start` → throttled `send` (800ms minimum interval, full accumulated text each flush) → `end`. Falls back to plain `sendMessage` with intelligent splitting (paragraph > newline > space > hard cut, 3500 char segments) when the stream API is unavailable. Mutex guard prevents timer flush and loop flush from racing. |
+| `stream-relay.ts` | Output delivery. Typing indicator heartbeat (5s). Delivers agent output via plain `sendMessage` with intelligent splitting (paragraph > newline > space > hard cut, 3500 char segments). |
 | `index.ts` | Entry point orchestrator. Wires all modules in sequence: config → adapter → store → cleanup → group-context → stream-relay → gateway → router → message handler. The `handleMessage` function coordinates the full pipeline under the router's session lock. |
 
 ## Data Flow
@@ -184,20 +184,15 @@ Final Config object
 
 All 14 config fields are overridable via environment variables. See [README.md](./README.md) for the full reference table.
 
-## Streaming Output
+## Output Delivery
 
-The stream relay implements a two-tier delivery strategy:
+The stream relay delivers agent output via plain `sendMessage` with intelligent text splitting. Split priority: paragraph break (`\n\n`) > newline (`\n`) > space > hard cut. Maximum segment size: 3500 characters.
 
-**Primary: Stream API.** Uses Octo's `stream/start` → `stream/send` → `stream/end` endpoints. Each `send` transmits the full accumulated text (not incremental deltas), base64-encoded as a JSON payload. Flushes are throttled to ≥800ms intervals to avoid API flooding. A mutex guard (`isFlushing`) prevents concurrent flushes from a timer callback and the main iteration loop.
-
-**Fallback: Plain messages.** When the stream API returns an error (e.g. older Octo servers), the relay switches to `sendMessage` with intelligent text splitting. Split priority: paragraph break (`\n\n`) > newline (`\n`) > space > hard cut. Maximum segment size: 3500 characters.
-
-Both paths maintain a typing indicator heartbeat at 5-second intervals so the user sees activity during long agent runs.
+A typing indicator heartbeat runs at 5-second intervals so the user sees activity during long agent runs.
 
 ## Error Handling
 
 - **Agent errors:** Caught per-message, best-effort error reply sent to user, does not crash the process.
-- **Stream API failures:** Automatic fallback to plain messages, no user-visible error.
 - **WebSocket disconnects:** Exponential backoff reconnect (3s base, 60s max, ±25% jitter). Three consecutive rapid disconnects (<5s each) trigger token refresh instead of reconnect.
 - **Heartbeat failures:** Three consecutive API heartbeat failures trigger reconnect via token refresh.
 - **Token refresh:** 60-second cooldown prevents refresh storms. Re-registers bot and establishes new WebSocket connection.

--- a/src/__tests__/e2e.test.ts
+++ b/src/__tests__/e2e.test.ts
@@ -10,9 +10,6 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 vi.mock('../octo/api.js', () => ({
   sendMessage: vi.fn().mockResolvedValue(undefined),
   sendTyping: vi.fn().mockResolvedValue(undefined),
-  streamStart: vi.fn().mockResolvedValue('stream-001'),
-  streamSend: vi.fn().mockResolvedValue(undefined),
-  streamEnd: vi.fn().mockResolvedValue(undefined),
   getGroupMembers: vi.fn().mockResolvedValue([]),
   sendHeartbeat: vi.fn().mockResolvedValue(undefined),
   registerBot: vi.fn().mockResolvedValue({
@@ -47,9 +44,6 @@ import { buildPrompt, queryAgent } from '../agent-bridge.js';
 import {
   sendMessage,
   sendTyping,
-  streamStart,
-  streamSend,
-  streamEnd,
 } from '../octo/api.js';
 import { ChannelType, MessageType } from '../octo/types.js';
 import type { BotMessage } from '../octo/types.js';
@@ -248,9 +242,8 @@ describe('E2E smoke tests', () => {
     const prompt = (queryAgent as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
     expect(prompt).toContain('[Current message]\nHi there');
 
-    // Stream output was sent
-    expect(streamStart).toHaveBeenCalled();
-    expect(streamEnd).toHaveBeenCalled();
+    // Output was sent via sendMessage
+    expect(sendMessage).toHaveBeenCalled();
 
     // Session history stored
     const history = store.buildHistoryPrefix(USER_UID, 40);
@@ -267,8 +260,8 @@ describe('E2E smoke tests', () => {
     // queryAgent was called
     expect(queryAgent).toHaveBeenCalledTimes(1);
 
-    // Stream output was sent to group channel
-    expect(streamStart).toHaveBeenCalled();
+    // Output was sent to group channel
+    expect(sendMessage).toHaveBeenCalled();
 
     // Session history stored (group session key = channel_id:from_uid)
     const sessionKey = `${GROUP_CHANNEL}:${USER_UID}`;
@@ -286,8 +279,8 @@ describe('E2E smoke tests', () => {
     // queryAgent should NOT be called
     expect(queryAgent).not.toHaveBeenCalled();
 
-    // No stream output
-    expect(streamStart).not.toHaveBeenCalled();
+    // No output sent
+    expect(sendMessage).not.toHaveBeenCalled();
 
     // But message IS cached in group context
     const ctx = groupContext.buildContext(GROUP_CHANNEL);
@@ -370,7 +363,7 @@ describe('E2E smoke tests', () => {
     await simulateMessage(msg, config, store, router, groupContext, streamRelay);
 
     expect(queryAgent).not.toHaveBeenCalled();
-    expect(streamStart).not.toHaveBeenCalled();
+    expect(sendMessage).not.toHaveBeenCalled();
   });
 
   // --- 8. Group context not duplicated in prompt ---

--- a/src/__tests__/stream-relay.test.ts
+++ b/src/__tests__/stream-relay.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for StreamRelay — throttled flush, stream lifecycle, fallback, splitting.
+ * Tests for StreamRelay — typing heartbeat, message splitting, plain sendMessage delivery.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
@@ -66,6 +66,16 @@ describe("splitMessage", () => {
     const segments = splitMessage(text, 100);
     expect(segments.join("")).toBe(text);
   });
+
+  it("throws on maxChars <= 0", () => {
+    expect(() => splitMessage("hello", 0)).toThrow("maxChars must be >= 1");
+    expect(() => splitMessage("hello", -5)).toThrow("maxChars must be >= 1");
+  });
+
+  it("works with maxChars = 1", () => {
+    const segments = splitMessage("abc", 1);
+    expect(segments).toEqual(["a", "b", "c"]);
+  });
 });
 
 // ─── Shared mock state via vi.hoisted ───────────────────────────────────────
@@ -77,21 +87,13 @@ interface ApiCall {
 
 const mockState = vi.hoisted(() => {
   const calls: ApiCall[] = [];
-  let streamStartFail = false;
-  let streamSendFailAfter = -1; // Fail streamSend after N successful calls.
   let sendMessageFail = false;
   return {
     calls,
-    get streamStartFail() { return streamStartFail; },
-    set streamStartFail(v: boolean) { streamStartFail = v; },
-    get streamSendFailAfter() { return streamSendFailAfter; },
-    set streamSendFailAfter(v: number) { streamSendFailAfter = v; },
     get sendMessageFail() { return sendMessageFail; },
     set sendMessageFail(v: boolean) { sendMessageFail = v; },
     reset() {
       calls.length = 0;
-      streamStartFail = false;
-      streamSendFailAfter = -1;
       sendMessageFail = false;
     },
   };
@@ -105,23 +107,6 @@ vi.mock("../octo/api.js", () => ({
     mockState.calls.push({ fn: "sendMessage", args: params });
     if (mockState.sendMessageFail) throw new Error("sendMessage failed");
     return { message_id: "msg_1", client_msg_no: "c1", message_seq: 1 };
-  }),
-  streamStart: vi.fn(async (params: Record<string, unknown>) => {
-    mockState.calls.push({ fn: "streamStart", args: params });
-    if (mockState.streamStartFail) throw new Error("stream API unavailable");
-    return "stream_001";
-  }),
-  streamSend: vi.fn(async (params: Record<string, unknown>) => {
-    mockState.calls.push({ fn: "streamSend", args: params });
-    if (mockState.streamSendFailAfter >= 0) {
-      const sendCount = mockState.calls.filter((c) => c.fn === "streamSend").length;
-      if (sendCount > mockState.streamSendFailAfter) {
-        throw new Error("streamSend failed");
-      }
-    }
-  }),
-  streamEnd: vi.fn(async (params: Record<string, unknown>) => {
-    mockState.calls.push({ fn: "streamEnd", args: params });
   }),
 }));
 
@@ -144,7 +129,7 @@ describe("StreamRelay", () => {
   const CH_ID = "test_channel";
   const CH_TYPE = 2; // Group
   const API_URL = "https://api.test";
-  const BOT_TOKEN = "bf_test";
+  const BOT_TOKEN = "***";
 
   beforeEach(() => {
     vi.useFakeTimers();
@@ -156,15 +141,15 @@ describe("StreamRelay", () => {
     vi.useRealTimers();
   });
 
-  it("delivers short text via stream start + end", async () => {
+  it("delivers text via sendMessage", async () => {
     const chunks = asyncChunks(["Hello, world!"]);
     const promise = relay.deliver(CH_ID, CH_TYPE, chunks, API_URL, BOT_TOKEN);
     await vi.runAllTimersAsync();
     await promise;
 
-    const streamCalls = mockState.calls.filter((c) => c.fn.startsWith("stream"));
-    expect(streamCalls.some((c) => c.fn === "streamStart")).toBe(true);
-    expect(streamCalls.some((c) => c.fn === "streamEnd")).toBe(true);
+    const sendCalls = mockState.calls.filter((c) => c.fn === "sendMessage");
+    expect(sendCalls.length).toBe(1);
+    expect((sendCalls[0].args as { content: string }).content).toBe("Hello, world!");
   });
 
   it("sends typing indicator at the start", async () => {
@@ -177,22 +162,7 @@ describe("StreamRelay", () => {
     expect(typingCalls.length).toBeGreaterThanOrEqual(1);
   });
 
-  it("falls back to sendMessage when stream API fails", async () => {
-    mockState.streamStartFail = true;
-
-    const chunks = asyncChunks(["Fallback text"]);
-    const promise = relay.deliver(CH_ID, CH_TYPE, chunks, API_URL, BOT_TOKEN);
-    await vi.runAllTimersAsync();
-    await promise;
-
-    const sendCalls = mockState.calls.filter((c) => c.fn === "sendMessage");
-    expect(sendCalls.length).toBe(1);
-    expect((sendCalls[0].args as { content: string }).content).toBe("Fallback text");
-  });
-
-  it("splits long fallback text into segments", async () => {
-    mockState.streamStartFail = true;
-
+  it("splits long text into segments", async () => {
     const longText = "word ".repeat(1500); // ~7500 chars
     const chunks = asyncChunks([longText]);
     const promise = relay.deliver(CH_ID, CH_TYPE, chunks, API_URL, BOT_TOKEN);
@@ -228,18 +198,14 @@ describe("StreamRelay", () => {
   });
 
   it("cleans up typing timer on error", async () => {
-    mockState.streamStartFail = true;
     mockState.sendMessageFail = true;
 
     const chunks = asyncChunks(["fail"]);
     const promise = relay.deliver(CH_ID, CH_TYPE, chunks, API_URL, BOT_TOKEN);
-    // Attach a no-op catch to prevent Node's PromiseRejectionHandledWarning
-    // (the rejection is still observable via the original `promise` reference).
     const guarded = promise.catch(() => {});
     await vi.runAllTimersAsync();
     await guarded;
 
-    // Verify the promise did reject.
     await expect(promise).rejects.toThrow("sendMessage failed");
 
     const countAfter = mockState.calls.filter((c) => c.fn === "sendTyping").length;
@@ -248,102 +214,30 @@ describe("StreamRelay", () => {
     expect(countLater).toBe(countAfter);
   });
 
-  it("accumulates chunks between flushes", async () => {
-    // Multiple chunks yielded synchronously: first chunk flushes immediately
-    // (lastFlushTime=0), remaining chunks accumulate until final flush.
+  it("accumulates multiple chunks before sending", async () => {
     const chunks = asyncChunks(["Hello", ", ", "world", "!"]);
     const promise = relay.deliver(CH_ID, CH_TYPE, chunks, API_URL, BOT_TOKEN);
     await vi.runAllTimersAsync();
     await promise;
 
-    // Find the last stream payload (streamStart or streamSend) — it has the full text.
-    const payloadCalls = mockState.calls.filter(
-      (c) => c.fn === "streamStart" || c.fn === "streamSend",
-    );
-    expect(payloadCalls.length).toBeGreaterThanOrEqual(1);
-    const lastPayload = (payloadCalls[payloadCalls.length - 1].args as { payload: string }).payload;
-    const decoded = JSON.parse(Buffer.from(lastPayload, "base64").toString("utf-8")) as { content: string };
-    // The last flush should contain all accumulated text.
-    expect(decoded.content).toBe("Hello, world!");
+    const sendCalls = mockState.calls.filter((c) => c.fn === "sendMessage");
+    expect(sendCalls.length).toBe(1);
+    expect((sendCalls[0].args as { content: string }).content).toBe("Hello, world!");
   });
 
-  it("passes correct channelId and channelType to stream calls", async () => {
+  it("passes correct channelId and channelType to all calls", async () => {
     const chunks = asyncChunks(["test"]);
     const promise = relay.deliver(CH_ID, CH_TYPE, chunks, API_URL, BOT_TOKEN);
     await vi.runAllTimersAsync();
     await promise;
 
     for (const call of mockState.calls) {
-      if (["sendTyping", "streamStart", "streamEnd", "streamSend"].includes(call.fn)) {
-        expect(call.args.channelId).toBe(CH_ID);
-        expect(call.args.channelType).toBe(CH_TYPE);
-      }
+      expect(call.args.channelId).toBe(CH_ID);
+      expect(call.args.channelType).toBe(CH_TYPE);
     }
   });
 
-  it("stream lifecycle: start → send(s) → end in order", async () => {
-    const chunks = asyncChunks(["test output"]);
-    const promise = relay.deliver(CH_ID, CH_TYPE, chunks, API_URL, BOT_TOKEN);
-    await vi.runAllTimersAsync();
-    await promise;
-
-    const streamCalls = mockState.calls
-      .filter((c) => c.fn.startsWith("stream"))
-      .map((c) => c.fn);
-    expect(streamCalls[0]).toBe("streamStart");
-    expect(streamCalls[streamCalls.length - 1]).toBe("streamEnd");
-  });
-
-  it("sends accumulated text (not incremental) in each stream flush", async () => {
-    const chunks = asyncChunks(["test data"]);
-    const promise = relay.deliver(CH_ID, CH_TYPE, chunks, API_URL, BOT_TOKEN);
-    await vi.runAllTimersAsync();
-    await promise;
-
-    // The streamStart payload should contain the full accumulated text
-    const startCalls = mockState.calls.filter((c) => c.fn === "streamStart");
-    const payload = (startCalls[0].args as { payload: string }).payload;
-    const decoded = JSON.parse(Buffer.from(payload, "base64").toString("utf-8")) as { content: string };
-    expect(decoded.content).toBe("test data");
-  });
-
-  // ── Review fix: mid-stream failure calls streamEnd ─────────────────────
-
-  it("calls streamEnd on mid-stream failure before fallback", async () => {
-    // First streamSend succeeds (via streamStart), then streamSend fails on the next flush.
-    mockState.streamSendFailAfter = 0; // Fail from the 1st streamSend
-
-    // Yield two chunks: first triggers streamStart, second triggers a streamSend that fails.
-    const chunks = asyncChunks(["first", " second"]);
-    const promise = relay.deliver(CH_ID, CH_TYPE, chunks, API_URL, BOT_TOKEN);
-    await vi.runAllTimersAsync();
-    await promise;
-
-    // streamEnd should be called to close the dangling stream.
-    const endCalls = mockState.calls.filter((c) => c.fn === "streamEnd");
-    expect(endCalls.length).toBeGreaterThanOrEqual(1);
-
-    // Fallback sendMessage should deliver the content.
-    const sendCalls = mockState.calls.filter((c) => c.fn === "sendMessage");
-    expect(sendCalls.length).toBeGreaterThanOrEqual(1);
-  });
-
-  // ── Review fix: splitMessage maxChars guard ────────────────────────────
-
-  it("splitMessage throws on maxChars <= 0", async () => {
-    expect(() => splitMessage("hello", 0)).toThrow("maxChars must be >= 1");
-    expect(() => splitMessage("hello", -5)).toThrow("maxChars must be >= 1");
-  });
-
-  it("splitMessage works with maxChars = 1", () => {
-    const segments = splitMessage("abc", 1);
-    expect(segments).toEqual(["a", "b", "c"]);
-  });
-
-  // ── P0 fix: source iterable exception cleans up timer + stream ───────
-
-  it("cleans up flushTimer and stream when source iterable throws", async () => {
-    // Create an iterable that yields one chunk then throws.
+  it("cleans up typing timer when source iterable throws", async () => {
     async function* throwingChunks(): AsyncIterable<string> {
       yield "partial";
       throw new Error("source exploded");
@@ -355,14 +249,13 @@ describe("StreamRelay", () => {
     await vi.runAllTimersAsync();
     await guarded;
 
-    // Verify it rejected with the source error.
     await expect(promise).rejects.toThrow("source exploded");
 
-    // streamEnd should have been called to close the started stream.
-    const endCalls = mockState.calls.filter((c) => c.fn === "streamEnd");
-    expect(endCalls.length).toBeGreaterThanOrEqual(1);
+    // No sendMessage should have been called (source threw before accumulation completed).
+    const sendCalls = mockState.calls.filter((c) => c.fn === "sendMessage");
+    expect(sendCalls.length).toBe(0);
 
-    // Typing timer should be cleaned up (no more typing calls after error).
+    // Typing timer should be cleaned up.
     const countAfter = mockState.calls.filter((c) => c.fn === "sendTyping").length;
     await vi.advanceTimersByTimeAsync(30_000);
     const countLater = mockState.calls.filter((c) => c.fn === "sendTyping").length;

--- a/src/octo/api.ts
+++ b/src/octo/api.ts
@@ -2,14 +2,12 @@
 // Source: https://github.com/Mininglamp-OSS/openclaw-channel-octo
 // Removed: COS upload, GROUP.md API, OBO, rich text, media, thread/group management,
 //          read receipts, bot groups list, group info, mention prefs, space members.
-// Added: stream start/send/end API functions.
 
 import {
   ChannelType,
   MessageType,
   type MentionEntity,
   type SendMessageResult,
-  type BotStreamStartResp,
 } from "./types.js";
 import { randomUUID } from "node:crypto";
 
@@ -337,72 +335,4 @@ export async function fetchUserInfo(params: {
     console.error(`octo: fetchUserInfo(${params.uid}) error: ${String(err)}`);
     return null;
   }
-}
-
-// ─── Stream API ─────────────────────────────────────────────────────────────
-
-/** Start a streaming message. Returns a stream_no for subsequent sends. */
-export async function streamStart(params: {
-  apiUrl: string;
-  botToken: string;
-  channelId: string;
-  channelType: ChannelType;
-  payload: string; // base64-encoded initial payload
-}): Promise<string> {
-  const result = await postJson<BotStreamStartResp>(
-    params.apiUrl,
-    params.botToken,
-    "/bot/stream/start",
-    {
-      channel_id: params.channelId,
-      channel_type: params.channelType,
-      payload: params.payload,
-    },
-  );
-  if (!result?.stream_no) {
-    throw new Error("streamStart: no stream_no in response");
-  }
-  return result.stream_no;
-}
-
-/** Send an update to an ongoing stream. */
-export async function streamSend(params: {
-  apiUrl: string;
-  botToken: string;
-  streamNo: string;
-  channelId: string;
-  channelType: ChannelType;
-  payload: string; // base64-encoded payload
-}): Promise<void> {
-  await postJson(
-    params.apiUrl,
-    params.botToken,
-    "/bot/stream/send",
-    {
-      stream_no: params.streamNo,
-      channel_id: params.channelId,
-      channel_type: params.channelType,
-      payload: params.payload,
-    },
-  );
-}
-
-/** End a stream. */
-export async function streamEnd(params: {
-  apiUrl: string;
-  botToken: string;
-  streamNo: string;
-  channelId: string;
-  channelType: ChannelType;
-}): Promise<void> {
-  await postJson(
-    params.apiUrl,
-    params.botToken,
-    "/bot/stream/end",
-    {
-      stream_no: params.streamNo,
-      channel_id: params.channelId,
-      channel_type: params.channelType,
-    },
-  );
 }

--- a/src/octo/types.ts
+++ b/src/octo/types.ts
@@ -106,22 +106,6 @@ export interface MessagePayload {
   [key: string]: unknown;
 }
 
-export interface BotStreamStartReq {
-  channel_id: string;
-  channel_type: ChannelType;
-  payload: string; // base64 encoded
-}
-
-export interface BotStreamStartResp {
-  stream_no: string;
-}
-
-export interface BotStreamEndReq {
-  stream_no: string;
-  channel_id: string;
-  channel_type: ChannelType;
-}
-
 export interface SendMessageResult {
   message_id: string;  // string due to int64 protection in postJson
   client_msg_no: string;

--- a/src/stream-relay.ts
+++ b/src/stream-relay.ts
@@ -1,9 +1,8 @@
 /**
- * Stream Relay — throttled streaming output + typing heartbeat + message splitting.
+ * Stream Relay — typing heartbeat + message splitting + plain sendMessage delivery.
  *
  * Consumes an AsyncIterable<string> of text chunks and delivers them to Octo
- * via the stream API (start/send/end). Falls back to plain sendMessage when
- * the stream API is unavailable.
+ * via plain sendMessage with intelligent splitting.
  *
  * Design constraints:
  * - Knows nothing about Claude SDK — input is a generic async text stream.
@@ -15,9 +14,6 @@ import type { ChannelType } from "./octo/types.js";
 import {
   sendTyping,
   sendMessage,
-  streamStart,
-  streamSend,
-  streamEnd,
 } from "./octo/api.js";
 
 // ─── Constants ──────────────────────────────────────────────────────────────
@@ -25,10 +21,7 @@ import {
 /** Interval (ms) between typing indicator pings. */
 const TYPING_INTERVAL_MS = 5_000;
 
-/** Minimum interval (ms) between stream flushes. */
-const FLUSH_INTERVAL_MS = 800;
-
-/** Maximum characters per message segment when falling back to plain send. */
+/** Maximum characters per message segment. */
 const MAX_SEGMENT_CHARS = 3_500;
 
 // ─── Message Splitting ─────────────────────────────────────────────────────
@@ -91,14 +84,6 @@ export function splitMessage(text: string, maxChars: number = MAX_SEGMENT_CHARS)
   return segments;
 }
 
-// ─── Payload Encoding ───────────────────────────────────────────────────────
-
-/** Encode a text message payload to base64 for the stream API. */
-function encodeStreamPayload(content: string): string {
-  const payload = JSON.stringify({ type: 1, content });
-  return Buffer.from(payload, "utf-8").toString("base64");
-}
-
 // ─── StreamRelay ────────────────────────────────────────────────────────────
 
 export class StreamRelay {
@@ -106,8 +91,8 @@ export class StreamRelay {
    * Deliver an async stream of text chunks to an Octo channel.
    *
    * 1. Starts a typing indicator heartbeat (5 s interval).
-   * 2. Attempts the stream API path (start → throttled sends → end).
-   * 3. On stream API failure, falls back to plain sendMessage with splitting.
+   * 2. Accumulates all chunks from the async iterable.
+   * 3. Sends the accumulated text via plain sendMessage with splitting.
    * 4. Always cleans up the typing heartbeat.
    */
   async deliver(
@@ -126,187 +111,28 @@ export class StreamRelay {
     }, TYPING_INTERVAL_MS);
 
     try {
-      await this._deliverViaStream(channelId, channelType, chunks, apiUrl, botToken);
+      // Accumulate all chunks.
+      let accumulated = "";
+      for await (const chunk of chunks) {
+        accumulated += chunk;
+      }
+
+      // Send accumulated text via plain messages with splitting.
+      if (accumulated.length > 0) {
+        const segments = splitMessage(accumulated);
+        for (const segment of segments) {
+          await sendMessage({
+            apiUrl,
+            botToken,
+            channelId,
+            channelType,
+            content: segment,
+          });
+        }
+      }
+      // If accumulated is empty, the agent produced no output — nothing to send.
     } finally {
       clearInterval(typingTimer);
-    }
-  }
-
-  // ── Stream API path ─────────────────────────────────────────────────────
-
-  private async _deliverViaStream(
-    channelId: string,
-    channelType: ChannelType,
-    chunks: AsyncIterable<string>,
-    apiUrl: string,
-    botToken: string,
-  ): Promise<void> {
-    let accumulated = "";
-    let streamNo: string | null = null;
-    let lastFlushTime = 0;
-    let lastSentLength = 0; // Track how much text was last sent to skip duplicate final sends.
-    let flushTimer: ReturnType<typeof setTimeout> | null = null;
-    let streamFailed = false;
-    let isFlushing = false; // Mutex guard — prevents timer flush and loop flush from racing.
-
-    // Pending flush promise so we can await the final timer-triggered flush.
-    let pendingFlush: Promise<void> | null = null;
-
-    const flush = async (): Promise<void> => {
-      if (accumulated.length === 0 || isFlushing) return;
-      if (accumulated.length === lastSentLength) return; // Nothing new since last send.
-
-      isFlushing = true;
-      // Snapshot length before await — new chunks may extend accumulated
-      // during the async send; we must record only what was actually sent.
-      const snapshotLen = accumulated.length;
-      const payload = encodeStreamPayload(accumulated);
-
-      try {
-        if (streamNo === null) {
-          // First flush — start the stream.
-          streamNo = await streamStart({
-            apiUrl,
-            botToken,
-            channelId,
-            channelType,
-            payload,
-          });
-        } else {
-          await streamSend({
-            apiUrl,
-            botToken,
-            streamNo,
-            channelId,
-            channelType,
-            payload,
-          });
-        }
-        lastSentLength = snapshotLen;
-        lastFlushTime = Date.now();
-      } catch {
-        // Stream API unavailable — mark failed so we fall back after iteration.
-        streamFailed = true;
-      } finally {
-        isFlushing = false;
-      }
-    };
-
-    const scheduleFlush = (): void => {
-      if (flushTimer !== null) return; // already scheduled
-      const elapsed = Date.now() - lastFlushTime;
-      const delay = Math.max(0, FLUSH_INTERVAL_MS - elapsed);
-      flushTimer = setTimeout(() => {
-        flushTimer = null;
-        pendingFlush = flush();
-      }, delay);
-    };
-
-    // --- Consume chunks (wrapped in try/catch/finally to clean up on source error) ---
-    try {
-      for await (const chunk of chunks) {
-        if (streamFailed) {
-          // Keep accumulating for fallback delivery.
-          accumulated += chunk;
-          continue;
-        }
-
-        accumulated += chunk;
-
-        const elapsed = Date.now() - lastFlushTime;
-        if (elapsed >= FLUSH_INTERVAL_MS) {
-          // Enough time has passed — flush immediately.
-          await flush();
-        } else {
-          scheduleFlush();
-        }
-      }
-    } catch (err) {
-      // Source iterable threw — close any started stream to prevent leak.
-      if (streamNo !== null) {
-        await streamEnd({ apiUrl, botToken, streamNo, channelId, channelType }).catch(() => {});
-        streamNo = null; // Prevent finally/pendingFlush from send-after-end
-      }
-      throw err;
-    } finally {
-      // Always clean up timer, even if source iterable throws.
-      if (flushTimer !== null) {
-        clearTimeout(flushTimer);
-        flushTimer = null;
-      }
-      // Await any in-flight timer-triggered flush before proceeding.
-      if (pendingFlush) {
-        await pendingFlush;
-        pendingFlush = null;
-      }
-      // If pendingFlush completed a streamStart after catch closed the old
-      // stream, close the new one too.
-      if (streamNo !== null && streamFailed) {
-        await streamEnd({ apiUrl, botToken, streamNo, channelId, channelType }).catch(() => {});
-        streamNo = null;
-      }
-    }
-
-    if (streamFailed) {
-      // Close the dangling stream before falling back.
-      if (streamNo !== null) {
-        await streamEnd({ apiUrl, botToken, streamNo, channelId, channelType }).catch(() => {});
-      }
-      // Fallback: deliver entire accumulated text via plain messages.
-      await this._deliverFallback(channelId, channelType, accumulated, apiUrl, botToken);
-      return;
-    }
-
-    // Flush any remaining buffered text (only if new content since last send).
-    if (accumulated.length > lastSentLength && streamNo !== null) {
-      const payload = encodeStreamPayload(accumulated);
-      try {
-        await streamSend({
-          apiUrl,
-          botToken,
-          streamNo,
-          channelId,
-          channelType,
-          payload,
-        });
-      } catch {
-        // If the final send fails, fall back to plain messages.
-        await streamEnd({ apiUrl, botToken, streamNo, channelId, channelType }).catch(() => {});
-        await this._deliverFallback(channelId, channelType, accumulated, apiUrl, botToken);
-        return;
-      }
-    }
-
-    // End the stream.
-    if (streamNo !== null) {
-      await streamEnd({ apiUrl, botToken, streamNo, channelId, channelType }).catch(() => {});
-    } else if (accumulated.length > 0) {
-      // Never started a stream (no flush happened) — send as plain message.
-      await this._deliverFallback(channelId, channelType, accumulated, apiUrl, botToken);
-    }
-    // If accumulated is empty and no stream started, the agent produced no output — nothing to send.
-  }
-
-  // ── Fallback: plain sendMessage with splitting ──────────────────────────
-
-  private async _deliverFallback(
-    channelId: string,
-    channelType: ChannelType,
-    text: string,
-    apiUrl: string,
-    botToken: string,
-  ): Promise<void> {
-    if (text.length === 0) return;
-
-    const segments = splitMessage(text);
-    for (const segment of segments) {
-      await sendMessage({
-        apiUrl,
-        botToken,
-        channelId,
-        channelType,
-        content: segment,
-      });
     }
   }
 }


### PR DESCRIPTION
## Summary

Remove the dead stream API path from StreamRelay. The Octo server's `/v1/bot` API group has no stream routes (`/bot/stream/start|send|end` do not exist). Streaming output has never worked — all messages have always been delivered via the `sendMessage` fallback path.

## Changes

### `src/stream-relay.ts` (-194 lines)
- Removed `_deliverViaStream` method with all stream API logic (flush throttle, mutex, pendingFlush)
- Removed `encodeStreamPayload` helper
- Removed `FLUSH_INTERVAL_MS` constant
- Simplified `deliver()` to: typing heartbeat → accumulate chunks → sendMessage with splitting
- Public API unchanged (deliver method signature identical)

### `src/octo/api.ts` (-68 lines)
- Deleted `streamStart`, `streamSend`, `streamEnd` functions
- Removed `BotStreamStartResp` import

### `src/octo/types.ts` (-16 lines)
- Deleted `BotStreamStartReq`, `BotStreamStartResp`, `BotStreamEndReq` interfaces

### `src/__tests__/stream-relay.test.ts` (rewritten)
- Removed all stream API mocks and stream-specific test cases
- Kept: splitMessage tests (10), typing tests, empty stream test, error cleanup tests
- Updated: delivery tests now assert sendMessage calls directly

### `src/__tests__/e2e.test.ts`
- Removed streamStart/streamSend/streamEnd mocks and imports
- Assertions updated: `expect(sendMessage).toHaveBeenCalled()` replaces `expect(streamStart).toHaveBeenCalled()`

### `ARCHITECTURE.md`
- Updated stream-relay module description
- Updated ASCII diagram label (stream/send → send/typing)
- Replaced 'Streaming Output' section with simplified 'Output Delivery'
- Removed 'Stream API failures' from error handling list

## Verification

- `npx tsc --noEmit` — zero errors
- `npx vitest run` — 149/149 tests pass (7 test files)

## Net impact

**-379 lines** of dead code removed. The simplified StreamRelay is ~40 lines of deliver logic instead of ~210.