### PR TITLE
fix: Q13 global rate limit + Q14 parseIntStrict allow 0 + Q17 getJson helper + Q18 crypto docs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -156,6 +156,16 @@ The bot accepts messages from any Octo user who can reach it. Users can send arb
 | **No network** | `Read, Write, Edit, Bash, Glob, Grep` | Full local automation |
 | **Full** (default) | All 8 tools | Maximum automation capability |
 
+### Known Cryptographic Weaknesses
+
+The WuKongIM protocol mandates specific cryptographic choices that cc-channel-octo must follow for compatibility:
+
+- **MD5 for AES key derivation.** The DH shared secret is hashed with MD5 to produce the AES-128 key. MD5 is cryptographically broken for collision resistance, but key derivation from a high-entropy DH secret is not vulnerable to collision attacks — the risk is theoretical, not practical. Replacing MD5 would break protocol compatibility with WuKongIM.
+- **AES-128-CBC without HMAC.** The protocol uses AES-128-CBC for message encryption without a separate MAC. This is susceptible to padding oracle attacks in theory, but the WebSocket transport is already TLS-encrypted, and the attacker model (modify ciphertext in transit) requires MITM on the TLS connection itself.
+- **crypto-js dependency.** AES and MD5 operations use `crypto-js` and `md5-typescript` instead of Node.js built-in `crypto`. These could be replaced to reduce supply chain risk, but would increase divergence from the upstream `openclaw-channel-octo` protocol layer, making security patch synchronization harder. Tracked as tech debt.
+
+These are protocol-level constraints, not implementation choices. Changing them requires WuKongIM server-side changes.
+
 ## Persistence
 
 All persistent state lives in a single SQLite database (`data/cc-octo.db`):

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -271,10 +271,10 @@ describe('parseIntStrict via env', () => {
     expect(() => loadConfig(path)).toThrow(/Invalid integer/);
   });
 
-  it('rejects zero', () => {
+  it('accepts zero for maxTurns', () => {
     const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
     process.env.CC_OCTO_SDK_MAX_TURNS = '0';
-    expect(() => loadConfig(path)).toThrow(/Invalid integer/);
+    expect(loadConfig(path).sdk.maxTurns).toBe(0);
   });
 
   it('rejects scientific notation', () => {

--- a/src/__tests__/q13-q14-q17.test.ts
+++ b/src/__tests__/q13-q14-q17.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Tests for Q13 (global rate limit), Q14 (parseIntStrict allows 0),
+ * Q17 (getGroupMembers via getJson helper).
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ─── Q13: Global rate limit ────────────────────────────────────────────────
+
+describe("SessionRouter global rate limit (Q13)", () => {
+  // We test via the public routeAndHandle API.
+  // The global limit is 10x per-session. Default maxPerMinute=5, so global=50.
+
+  it("global rate limit blocks after burst from many sessions", async () => {
+    // Import SessionRouter (no mock needed — it doesn't call external APIs for rate limiting).
+    const { SessionRouter } = await import("../session-router.js");
+    const { ChannelType, MessageType } = await import("../octo/types.js");
+
+    const config = {
+      botToken: "test",
+      apiUrl: "https://test",
+      cwd: ".",
+      dataDir: "./data",
+      sdk: { allowedTools: [], permissionMode: "bypassPermissions", settingSources: ["user"] },
+      rateLimit: { maxPerMinute: 2 }, // global = 2*10 = 20
+      context: { maxContextChars: 6000, historyLimit: 40 },
+    } as Parameters<typeof SessionRouter["prototype"]["routeAndHandle"]> extends never[]
+      ? never
+      : any;
+
+    const router = new SessionRouter(config, "bot_id");
+
+    let processedCount = 0;
+    const handler = async () => { processedCount++; };
+
+    // Send 20 messages from 20 different users (each within per-session limit).
+    for (let i = 0; i < 25; i++) {
+      const msg = {
+        message_id: `msg_${i}`,
+        message_seq: i,
+        from_uid: `user_${i}`,
+        channel_type: ChannelType.DM,
+        channel_id: `dm_${i}`,
+        timestamp: Date.now(),
+        payload: { type: MessageType.Text, content: "hi" },
+      };
+      await router.routeAndHandle(msg, handler);
+    }
+
+    // With global limit of 20, some messages should have been blocked.
+    expect(processedCount).toBeLessThan(25);
+    expect(processedCount).toBeGreaterThanOrEqual(20);
+  });
+});
+
+// ─── Q14: parseIntStrict allows 0 ──────────────────────────────────────────
+
+describe("parseIntStrict allows 0 (Q14)", () => {
+  it("accepts 0 for maxTurns", async () => {
+    // This is tested via config.test.ts 'accepts zero for maxTurns' test.
+    // Additional verification here: loadConfig with env var set to 0.
+    const { loadConfig } = await import("../config.js");
+    const { writeFileSync, mkdtempSync } = await import("node:fs");
+    const { join } = await import("node:path");
+    const { tmpdir } = await import("node:os");
+
+    const dir = mkdtempSync(join(tmpdir(), "q14-"));
+    const cfgPath = join(dir, "config.json");
+    writeFileSync(cfgPath, JSON.stringify({ botToken: "bf_t", apiUrl: "https://a" }));
+
+    process.env.CC_OCTO_SDK_MAX_TURNS = "0";
+    try {
+      const cfg = loadConfig(cfgPath);
+      expect(cfg.sdk.maxTurns).toBe(0);
+    } finally {
+      delete process.env.CC_OCTO_SDK_MAX_TURNS;
+    }
+  });
+
+  it("accepts 0 for historyLimit", async () => {
+    const { loadConfig } = await import("../config.js");
+    const { writeFileSync, mkdtempSync } = await import("node:fs");
+    const { join } = await import("node:path");
+    const { tmpdir } = await import("node:os");
+
+    const dir = mkdtempSync(join(tmpdir(), "q14-"));
+    const cfgPath = join(dir, "config.json");
+    writeFileSync(cfgPath, JSON.stringify({ botToken: "bf_t", apiUrl: "https://a" }));
+
+    process.env.CC_OCTO_CONTEXT_HISTORY_LIMIT = "0";
+    try {
+      const cfg = loadConfig(cfgPath);
+      expect(cfg.context.historyLimit).toBe(0);
+    } finally {
+      delete process.env.CC_OCTO_CONTEXT_HISTORY_LIMIT;
+    }
+  });
+
+  it("still rejects negative and non-numeric", async () => {
+    const { loadConfig } = await import("../config.js");
+    const { writeFileSync, mkdtempSync } = await import("node:fs");
+    const { join } = await import("node:path");
+    const { tmpdir } = await import("node:os");
+
+    const dir = mkdtempSync(join(tmpdir(), "q14-"));
+    const cfgPath = join(dir, "config.json");
+    writeFileSync(cfgPath, JSON.stringify({ botToken: "bf_t", apiUrl: "https://a" }));
+
+    process.env.CC_OCTO_SDK_MAX_TURNS = "-1";
+    try {
+      expect(() => loadConfig(cfgPath)).toThrow(/Invalid integer/);
+    } finally {
+      delete process.env.CC_OCTO_SDK_MAX_TURNS;
+    }
+
+    process.env.CC_OCTO_SDK_MAX_TURNS = "abc";
+    try {
+      expect(() => loadConfig(cfgPath)).toThrow(/Invalid integer/);
+    } finally {
+      delete process.env.CC_OCTO_SDK_MAX_TURNS;
+    }
+  });
+});
+
+// ─── Q17: getGroupMembers via getJson ──────────────────────────────────────
+
+describe("getGroupMembers via getJson (Q17)", () => {
+  let mockFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    mockFetch = vi.fn();
+    vi.stubGlobal("fetch", mockFetch);
+  });
+
+  it("includes error body in error message", async () => {
+    const { getGroupMembers } = await import("../octo/api.js");
+
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 403,
+      statusText: "Forbidden",
+      text: () => Promise.resolve("bot not in group"),
+    });
+
+    await expect(
+      getGroupMembers({ apiUrl: "https://api", botToken: "tok", groupNo: "g1" }),
+    ).rejects.toThrow("bot not in group");
+  });
+
+  it("applies default timeout signal", async () => {
+    const { getGroupMembers } = await import("../octo/api.js");
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve('{"members": []}'),
+    });
+
+    await getGroupMembers({ apiUrl: "https://api", botToken: "tok", groupNo: "g1" });
+
+    const options = mockFetch.mock.calls[0][1] as RequestInit;
+    expect(options.signal).toBeDefined();
+    expect(options.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("parses members from response", async () => {
+    const { getGroupMembers } = await import("../octo/api.js");
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      text: () =>
+        Promise.resolve(
+          JSON.stringify({
+            members: [
+              { uid: "u1", name: "Alice", role: 1 },
+              { uid: "u2", name: "Bob", role: 0 },
+            ],
+          }),
+        ),
+    });
+
+    const members = await getGroupMembers({
+      apiUrl: "https://api",
+      botToken: "tok",
+      groupNo: "g1",
+    });
+    expect(members).toHaveLength(2);
+    expect(members[0].uid).toBe("u1");
+    expect(members[1].name).toBe("Bob");
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -109,13 +109,13 @@ function parseCsv(value: string): string[] {
     .filter((s) => s.length > 0);
 }
 
-function parseIntStrict(value: string, name: string): number {
+function parseIntStrict(value: string, name: string, minValue = 1): number {
   if (!/^\d+$/.test(value)) {
     throw new Error(`Invalid integer for ${name}: ${value}`);
   }
   const n = Number(value);
-  if (!Number.isFinite(n) || n < 1) {
-    throw new Error(`Invalid integer for ${name}: ${value} (must be >= 1)`);
+  if (!Number.isFinite(n) || n < minValue) {
+    throw new Error(`Invalid integer for ${name}: ${value} (must be >= ${minValue})`);
   }
   return n;
 }
@@ -142,7 +142,7 @@ function applyEnv(cfg: Config): Config {
     next.sdk.permissionMode = env.CC_OCTO_SDK_PERMISSION_MODE;
   }
   if (env.CC_OCTO_SDK_MAX_TURNS) {
-    next.sdk.maxTurns = parseIntStrict(env.CC_OCTO_SDK_MAX_TURNS, 'CC_OCTO_SDK_MAX_TURNS');
+    next.sdk.maxTurns = parseIntStrict(env.CC_OCTO_SDK_MAX_TURNS, 'CC_OCTO_SDK_MAX_TURNS', 0);
   }
   if (env.CC_OCTO_SDK_SYSTEM_PROMPT) next.sdk.systemPrompt = env.CC_OCTO_SDK_SYSTEM_PROMPT;
   if (env.CC_OCTO_SDK_SETTING_SOURCES) {
@@ -153,6 +153,7 @@ function applyEnv(cfg: Config): Config {
     next.rateLimit.maxPerMinute = parseIntStrict(
       env.CC_OCTO_RATE_LIMIT_MAX_PER_MINUTE,
       'CC_OCTO_RATE_LIMIT_MAX_PER_MINUTE',
+      0,
     );
   }
 
@@ -160,12 +161,14 @@ function applyEnv(cfg: Config): Config {
     next.context.maxContextChars = parseIntStrict(
       env.CC_OCTO_CONTEXT_MAX_CHARS,
       'CC_OCTO_CONTEXT_MAX_CHARS',
+      0,
     );
   }
   if (env.CC_OCTO_CONTEXT_HISTORY_LIMIT) {
     next.context.historyLimit = parseIntStrict(
       env.CC_OCTO_CONTEXT_HISTORY_LIMIT,
       'CC_OCTO_CONTEXT_HISTORY_LIMIT',
+      0,
     );
   }
 

--- a/src/octo/api.ts
+++ b/src/octo/api.ts
@@ -178,6 +178,33 @@ export async function registerBot(params: {
   return result;
 }
 
+/**
+ * GET request helper with consistent error handling, timeout, and int64 protection.
+ */
+async function getJson<T>(
+  apiUrl: string,
+  botToken: string,
+  path: string,
+  signal?: AbortSignal,
+): Promise<T> {
+  const url = `${apiUrl.replace(/\/+$/, "")}${path}`;
+  const effectiveSignal = signal ?? AbortSignal.timeout(DEFAULT_TIMEOUT_MS);
+  const resp = await fetch(url, {
+    method: "GET",
+    headers: {
+      Authorization: `Bearer ${botToken}`,
+    },
+    signal: effectiveSignal,
+  });
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => "");
+    throw new Error(`Octo API ${path} failed (${resp.status}): ${text || resp.statusText}`);
+  }
+  const text = await resp.text();
+  if (!text) return {} as T;
+  return parseOctoJson<T>(text);
+}
+
 // ─── Group Members ──────────────────────────────────────────────────────────
 
 export interface GroupMember {
@@ -194,18 +221,11 @@ export async function getGroupMembers(params: {
   botToken: string;
   groupNo: string;
 }): Promise<GroupMember[]> {
-  const url = `${params.apiUrl.replace(/\/+$/, "")}/v1/bot/groups/${params.groupNo}/members`;
-  const resp = await fetch(url, {
-    method: "GET",
-    headers: {
-      Authorization: `Bearer ${params.botToken}`,
-    },
-    signal: AbortSignal.timeout(DEFAULT_TIMEOUT_MS),
-  });
-  if (!resp.ok) {
-    throw new Error(`getGroupMembers failed: ${resp.status}`);
-  }
-  const data = await resp.json() as Record<string, unknown>;
+  const data = await getJson<Record<string, unknown>>(
+    params.apiUrl,
+    params.botToken,
+    `/v1/bot/groups/${params.groupNo}/members`,
+  );
   const members = Array.isArray(data?.members)
     ? data.members
     : Array.isArray(data)

--- a/src/session-router.ts
+++ b/src/session-router.ts
@@ -22,11 +22,15 @@ interface TokenBucket {
 
 const BUCKET_STALE_MS = 5 * 60 * 1000; // 5 minutes
 
+/** Global rate limit: 10x per-session limit, shared across all sessions. */
+const GLOBAL_RATE_MULTIPLIER = 10;
+
 export class SessionRouter {
   private readonly config: Config;
   private readonly robotId: string;
   private readonly inboundQueues = new Map<string, Promise<void>>();
   private readonly tokenBuckets = new Map<string, TokenBucket>();
+  private globalBucket: TokenBucket | null = null;
 
   constructor(config: Config, robotId: string) {
     this.config = config;
@@ -128,7 +132,7 @@ export class SessionRouter {
 
     // Rate limit check BEFORE non-text check — prevents DM spam of non-text
     // messages from bypassing rate limiting entirely.
-    if (!this.checkRateLimit(key)) {
+    if (!this.checkGlobalRateLimit() || !this.checkRateLimit(key)) {
       // Debounce: only notify once per rate-limit window to avoid reply spam.
       const bucket = this.tokenBuckets.get(key);
       if (bucket && !bucket.notified) {
@@ -169,6 +173,22 @@ export class SessionRouter {
 
     if (bucket.tokens < 1) return false;
     bucket.tokens -= 1;
+    return true;
+  }
+
+  /** Global rate limit across all sessions (10x per-session limit). */
+  private checkGlobalRateLimit(): boolean {
+    const now = Date.now();
+    const globalMax = this.config.rateLimit.maxPerMinute * GLOBAL_RATE_MULTIPLIER;
+    if (!this.globalBucket) {
+      this.globalBucket = { tokens: globalMax, lastRefill: now, notified: false };
+    }
+    const elapsed = now - this.globalBucket.lastRefill;
+    const refill = (elapsed / 60_000) * globalMax;
+    this.globalBucket.tokens = Math.min(globalMax, this.globalBucket.tokens + refill);
+    this.globalBucket.lastRefill = now;
+    if (this.globalBucket.tokens < 1) return false;
+    this.globalBucket.tokens -= 1;
     return true;
   }
 


### PR DESCRIPTION
## P1 batch: Q13 + Q14 + Q17 + Q18

### Q13 — Global rate limit (session-router.ts)
Global token bucket (10x per-session limit) checked before per-session rate limit. Prevents distributed abuse where many unique sessions each stay within per-session limits but overwhelm the bot collectively.

### Q14 — parseIntStrict allows 0 (config.ts)
Added optional `minValue` parameter (default 1). `maxTurns`, `maxPerMinute`, `maxContextChars`, `historyLimit` now accept 0 via `minValue=0`. Negative and non-numeric still rejected.

### Q17 — getJson helper (api.ts)
New `getJson<T>()` paralleling `postJson`: consistent error handling (includes response body in error message), default 30s timeout, `parseOctoJson` int64 protection. `getGroupMembers` refactored to use it.

### Q18 — Crypto weakness documentation (ARCHITECTURE.md)
New 'Known Cryptographic Weaknesses' section: MD5 key derivation, AES-128-CBC without HMAC, crypto-js dependency — all documented as protocol-level constraints, not implementation choices.

### Tests
- 7 new tests (global rate limit burst, parseIntStrict accepts/rejects 0, getGroupMembers error body/timeout/parsing)
- Updated existing config test (0 now valid for maxTurns)

### Verification
- `tsc --noEmit`: zero errors
- `vitest run`: 190/190 passed (183 existing + 7 new)
- Files changed: session-router.ts / config.ts / api.ts / ARCHITECTURE.md / config.test.ts / q13-q14-q17.test.ts (+263/-19)