### PR TITLE
fix: P1 batch — context persistence, surrogate safety, empty reply, segment resilience (Q15, Q16, Q21, Q22, Q23)

### DIFF
--- a/src/__tests__/group-context.test.ts
+++ b/src/__tests__/group-context.test.ts
@@ -215,4 +215,58 @@ describe('GroupContext', () => {
     expect(name2).toBe('Alice');
     expect(fetchUserInfo).toHaveBeenCalledTimes(1);
   });
+
+  // --- Q15: pushMessage persists to SQLite ---
+
+  it('pushMessage persists messages to group_messages table', () => {
+    ctx.pushMessage('ch1', 'u1', 'Alice', 'hello world', 1000);
+    ctx.pushMessage('ch1', 'u2', 'Bob', 'hi there', 2000);
+
+    const rows = adapter.prepare(
+      'SELECT from_uid, from_name, content, timestamp FROM group_messages WHERE channel_id = ? ORDER BY id',
+    ).all('ch1') as Array<{ from_uid: string; from_name: string; content: string; timestamp: number }>;
+    expect(rows.length).toBe(2);
+    expect(rows[0].from_uid).toBe('u1');
+    expect(rows[0].content).toBe('hello world');
+    expect(rows[1].from_uid).toBe('u2');
+  });
+
+  it('loadMessagesFromDb restores messages after fresh GroupContext creation', () => {
+    // Push messages with first context
+    ctx.pushMessage('ch1', 'u1', 'Alice', 'msg1', 1000);
+    ctx.pushMessage('ch1', 'u2', 'Bob', 'msg2', 2000);
+
+    // Create a fresh GroupContext with same adapter
+    const ctx2 = new GroupContext(adapter, 6000);
+    ctx2.loadMessagesFromDb('ch1');
+
+    // Should restore messages and produce context
+    const context = ctx2.buildContext('ch1');
+    expect(context).toContain('Alice：msg1');
+    expect(context).toContain('Bob：msg2');
+  });
+
+  // --- Q16: loadAllFromDb ---
+
+  it('loadAllFromDb loads members and messages for all groups', () => {
+    // Setup: push data to two different groups
+    ctx.pushMessage('ch1', 'u1', 'Alice', 'hello', 1000);
+    ctx.pushMessage('ch2', 'u2', 'Bob', 'world', 2000);
+    ctx.learnMember('ch1', 'u1', 'Alice');
+    ctx.learnMember('ch2', 'u2', 'Bob');
+
+    // Create a fresh context and loadAllFromDb
+    const ctx2 = new GroupContext(adapter, 6000);
+    ctx2.loadAllFromDb();
+
+    // Members should be restored
+    expect(ctx2.getName('u1', 'ch1')).toBe('Alice');
+    expect(ctx2.getName('u2', 'ch2')).toBe('Bob');
+
+    // Messages should be restored
+    const context1 = ctx2.buildContext('ch1');
+    expect(context1).toContain('Alice：hello');
+    const context2 = ctx2.buildContext('ch2');
+    expect(context2).toContain('Bob：world');
+  });
 });

--- a/src/__tests__/stream-relay.test.ts
+++ b/src/__tests__/stream-relay.test.ts
@@ -76,6 +76,19 @@ describe("splitMessage", () => {
     const segments = splitMessage("abc", 1);
     expect(segments).toEqual(["a", "b", "c"]);
   });
+
+  it("does not split surrogate pairs on hard cut", () => {
+    // 😀 = U+1F600 = 😀 (2 code units)
+    const emoji = "😀";
+    // Fill to force a hard cut right at a surrogate pair boundary
+    const filler = "a".repeat(9); // 9 + 2 = 11 code units, maxChars=10 would cut inside emoji
+    const text = filler + emoji;  // 11 code units
+    const segments = splitMessage(text, 10);
+    // Should NOT split the surrogate pair — back up to 9
+    expect(segments[0]).toBe(filler);
+    expect(segments[1]).toBe(emoji);
+    expect(segments.join("")).toBe(text);
+  });
 });
 
 // ─── Shared mock state via vi.hoisted ───────────────────────────────────────
@@ -206,7 +219,8 @@ describe("StreamRelay", () => {
     await vi.runAllTimersAsync();
     await guarded;
 
-    await expect(promise).rejects.toThrow("sendMessage failed");
+    // Q23: sendMessage failures are swallowed per-segment; deliver() should not reject.
+    await expect(promise).resolves.toBeUndefined();
 
     const countAfter = mockState.calls.filter((c) => c.fn === "sendTyping").length;
     await vi.advanceTimersByTimeAsync(30_000);
@@ -260,5 +274,25 @@ describe("StreamRelay", () => {
     await vi.advanceTimersByTimeAsync(30_000);
     const countLater = mockState.calls.filter((c) => c.fn === "sendTyping").length;
     expect(countLater).toBe(countAfter);
+  });
+
+  it("continues sending remaining segments when one fails", async () => {
+    let callCount = 0;
+    const { sendMessage } = await import("../octo/api.js");
+    (sendMessage as ReturnType<typeof vi.fn>).mockImplementation(async (params: Record<string, unknown>) => {
+      mockState.calls.push({ fn: "sendMessage", args: params });
+      callCount++;
+      if (callCount === 2) throw new Error("transient failure");
+      return { message_id: "msg_1", client_msg_no: "c1", message_seq: 1 };
+    });
+
+    const longText = "word ".repeat(1500); // ~7500 chars → 3 segments
+    const chunks = asyncChunks([longText]);
+    const promise = relay.deliver(CH_ID, CH_TYPE, chunks, API_URL, BOT_TOKEN);
+    await vi.runAllTimersAsync();
+    await promise; // Should NOT throw
+
+    const sendCalls = mockState.calls.filter((c) => c.fn === "sendMessage");
+    expect(sendCalls.length).toBe(3); // All 3 segments attempted
   });
 });

--- a/src/group-context.ts
+++ b/src/group-context.ts
@@ -32,6 +32,9 @@ export class GroupContext {
 
   private upsertMember!: PreparedStatement;
   private selectMembers!: PreparedStatement;
+  private insertMessage!: PreparedStatement;
+  private selectRecentMessages!: PreparedStatement;
+  private deleteOldMessages!: PreparedStatement;
 
   constructor(adapter: DbAdapter, maxContextChars: number) {
     this.adapter = adapter;
@@ -41,11 +44,35 @@ export class GroupContext {
   }
 
   private initStatements(): void {
+    this.adapter.exec(`
+      CREATE TABLE IF NOT EXISTS group_messages (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        channel_id TEXT NOT NULL,
+        from_uid TEXT NOT NULL,
+        from_name TEXT NOT NULL,
+        content TEXT NOT NULL,
+        timestamp INTEGER NOT NULL
+      )
+    `);
+    this.adapter.exec(`
+      CREATE INDEX IF NOT EXISTS idx_group_messages_channel
+      ON group_messages (channel_id, id DESC)
+    `);
+
     this.upsertMember = this.adapter.prepare(
       'INSERT INTO group_members (group_id, uid, name, updated_at) VALUES (?, ?, ?, ?) ON CONFLICT(group_id, uid) DO UPDATE SET name = excluded.name, updated_at = excluded.updated_at',
     );
     this.selectMembers = this.adapter.prepare(
       'SELECT uid, name FROM group_members WHERE group_id = ?',
+    );
+    this.insertMessage = this.adapter.prepare(
+      'INSERT INTO group_messages (channel_id, from_uid, from_name, content, timestamp) VALUES (?, ?, ?, ?, ?)',
+    );
+    this.selectRecentMessages = this.adapter.prepare(
+      'SELECT from_uid, from_name, content, timestamp FROM group_messages WHERE channel_id = ? ORDER BY id DESC LIMIT ?',
+    );
+    this.deleteOldMessages = this.adapter.prepare(
+      'DELETE FROM group_messages WHERE channel_id = ? AND id NOT IN (SELECT id FROM group_messages WHERE channel_id = ? ORDER BY id DESC LIMIT ?)',
     );
   }
 
@@ -84,6 +111,14 @@ export class GroupContext {
       window.shift();
     }
     this.learnMember(channelId, fromUid, fromName);
+
+    try {
+      this.insertMessage.run(channelId, fromUid, fromName, content, timestamp);
+      // Trim old messages to keep DB bounded (keep 2x window for safety)
+      this.deleteOldMessages.run(channelId, channelId, this.maxWindowSize * 2);
+    } catch (err) {
+      console.error(`group-context: insert message failed: ${String(err)}`);
+    }
   }
 
   learnMember(channelId: string, uid: string, name: string): void {
@@ -223,6 +258,49 @@ export class GroupContext {
       }
     } catch (err) {
       console.error(`group-context: loadMembersFromDb(${channelId}) failed: ${String(err)}`);
+    }
+  }
+
+  loadMessagesFromDb(channelId: string): void {
+    try {
+      const rows = this.selectRecentMessages.all(channelId, this.maxWindowSize) as Array<{
+        from_uid: string;
+        from_name: string;
+        content: string;
+        timestamp: number;
+      }>;
+      if (rows.length === 0) return;
+      // Rows come in DESC order, reverse to chronological
+      rows.reverse();
+      const existing = this.messageCache.get(channelId);
+      if (existing && existing.length > 0) return; // Don't overwrite live data
+      // Map snake_case DB columns to camelCase GroupMessage
+      this.messageCache.set(channelId, rows.map(r => ({
+        fromUid: r.from_uid,
+        fromName: r.from_name,
+        content: r.content,
+        timestamp: r.timestamp,
+      })));
+    } catch (err) {
+      console.error(`group-context: loadMessagesFromDb(${channelId}) failed: ${String(err)}`);
+    }
+  }
+
+  /** Load all persisted members and messages from DB (call once at startup). */
+  loadAllFromDb(): void {
+    try {
+      const rows = this.adapter.prepare(
+        'SELECT DISTINCT group_id FROM group_members',
+      ).all() as Array<{ group_id: string }>;
+      for (const row of rows) {
+        this.loadMembersFromDb(row.group_id);
+        this.loadMessagesFromDb(row.group_id);
+      }
+      if (rows.length > 0) {
+        console.log(`[group-context] Loaded members + messages for ${rows.length} group(s) from DB`);
+      }
+    } catch (err) {
+      console.error(`group-context: loadAllFromDb failed: ${String(err)}`);
     }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,7 @@ async function main(): Promise<void> {
 
   // --- Group context ---
   const groupContext = new GroupContext(adapter, config.context.maxContextChars);
+  groupContext.loadAllFromDb();
 
   // --- Stream relay ---
   const streamRelay = new StreamRelay();
@@ -134,6 +135,15 @@ async function handleMessage(
       const fullResponse = collected.join('');
       if (fullResponse) {
         store.appendAssistant(sessionKey, fullResponse);
+      } else {
+        // Agent produced no output — send a feedback message so user isn't left hanging
+        await sendMessage({
+          apiUrl: config.apiUrl,
+          botToken: config.botToken,
+          channelId,
+          channelType,
+          content: '[No response generated. Please try rephrasing your question.]',
+        });
       }
 
     } catch (err) {

--- a/src/stream-relay.ts
+++ b/src/stream-relay.ts
@@ -72,9 +72,14 @@ export function splitMessage(text: string, maxChars: number = MAX_SEGMENT_CHARS)
       }
     }
 
-    // 4. Hard cut
+    // 4. Hard cut — avoid splitting surrogate pairs
     if (splitAt === -1) {
       splitAt = maxChars;
+      // If the cut falls between a surrogate pair, back up one code unit
+      const code = remaining.charCodeAt(splitAt - 1);
+      if (code >= 0xD800 && code <= 0xDBFF) {
+        splitAt--;
+      }
     }
 
     segments.push(remaining.slice(0, splitAt));
@@ -121,13 +126,18 @@ export class StreamRelay {
       if (accumulated.length > 0) {
         const segments = splitMessage(accumulated);
         for (const segment of segments) {
-          await sendMessage({
-            apiUrl,
-            botToken,
-            channelId,
-            channelType,
-            content: segment,
-          });
+          try {
+            await sendMessage({
+              apiUrl,
+              botToken,
+              channelId,
+              channelType,
+              content: segment,
+            });
+          } catch (err) {
+            console.error(`[stream-relay] sendMessage failed for segment (${segment.length} chars), continuing: ${String(err)}`);
+            // Continue sending remaining segments — don't let one failure drop the rest
+          }
         }
       }
       // If accumulated is empty, the agent produced no output — nothing to send.


### PR DESCRIPTION
## Summary

Five P1 fixes in one PR, covering stream relay reliability and group context persistence.

## Changes

### Q15 — Group message context persistence (`group-context.ts`)
- New `group_messages` SQLite table with index on `(channel_id, id DESC)`
- `pushMessage()` now persists to DB alongside in-memory cache
- DB trimmed to 2× window size (200 rows per channel) on each write
- New `loadMessagesFromDb(channelId)` method restores messages from DB
- Proper snake_case → camelCase mapping for DB rows

### Q16 — Load persisted data on startup (`group-context.ts` + `index.ts`)
- New `loadAllFromDb()` method queries all distinct group_ids and loads both members and messages
- Called once in `index.ts` during initialization, immediately after GroupContext creation
- Activates the previously-dead `loadMembersFromDb()` method

### Q21 — splitMessage surrogate pair safety (`stream-relay.ts`)
- Hard cut now checks if the character at `splitAt - 1` is a high surrogate (0xD800–0xDBFF)
- If so, backs up one code unit to keep the surrogate pair intact
- Prevents invalid Unicode in message segments

### Q22 — Empty reply feedback (`index.ts`)
- When agent produces no output, sends `[No response generated. Please try rephrasing your question.]`
- Previously, users saw typing indicator flash then nothing

### Q23 — Segment failure resilience (`stream-relay.ts`)
- Per-segment try/catch in `deliver()` — one `sendMessage` failure logs the error and continues
- Previously, first segment failure dropped all remaining segments

## Tests Added
- `splitMessage`: surrogate pair hard cut test
- `StreamRelay`: segment failure continuation test
- `GroupContext`: message persistence, loadMessagesFromDb restoration, loadAllFromDb full restore

## Verification
- `npx tsc --noEmit` — zero errors
- `npx vitest run` — 188/188 tests pass (9 test files)

## Files Changed
- `src/stream-relay.ts` — Q21 + Q23
- `src/group-context.ts` — Q15 + Q16
- `src/index.ts` — Q16 + Q22
- `src/__tests__/stream-relay.test.ts` — Q21 + Q23 tests
- `src/__tests__/group-context.test.ts` — Q15 + Q16 tests