### PR TITLE
fix(P2): ws listener cleanup, heartbeat during refresh, dependency risk docs (Q30+Q33+Q35)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -166,6 +166,20 @@ The WuKongIM protocol mandates specific cryptographic choices that cc-channel-oc
 
 These are protocol-level constraints, not implementation choices. Changing them requires WuKongIM server-side changes.
 
+### Known Dependency Risks
+
+Three cryptographic dependencies have low maintenance activity:
+
+| Package | Version | Last Published | Risk | Replacement Path |
+|---------|---------|---------------|------|------------------|
+| `crypto-js` | 4.2.0 | 2023-10-24 | CVE-2023-46233 (PBKDF2, not used here). No releases in 2+ years. | Node.js built-in `crypto.createCipheriv` / `crypto.createDecipheriv` for AES-128-CBC. Drop-in replacement, ~20 lines. |
+| `md5-typescript` | 1.0.5 | 2018-03-03 | No known CVEs. Unmaintained (8+ years). | Node.js built-in `crypto.createHash('md5')`. One-line replacement. |
+| `curve25519-js` | 0.0.4 | 2019-08-02 | No known CVEs. Unmaintained (7+ years). Pure JS implementation. | `@noble/curves` (actively maintained, audited). Requires API adaptation. |
+
+**Current assessment:** Production runtime risk is **low** — these libraries perform simple, well-understood operations (AES-CBC, MD5 hash, X25519 DH). No known exploitable vulnerabilities affect our usage patterns. The risk is supply chain (abandoned packages receiving no security patches) rather than functional.
+
+**Replacement plan:** Tracked as tech debt. Replace when (a) a CVE affects our usage, (b) we diverge from upstream `openclaw-channel-octo` anyway, or (c) a dependency audit policy requires actively maintained packages.
+
 ## Persistence
 
 All persistent state lives in a single SQLite database (`data/cc-octo.db`):

--- a/src/gateway.ts
+++ b/src/gateway.ts
@@ -201,6 +201,9 @@ export class OctoGateway {
     try {
       console.log('Attempting token refresh...');
 
+      // Q33: Stop heartbeat during refresh to avoid empty pings
+      this.stopHeartbeat();
+
       if (this.socket) {
         await this.socket.disconnectAndWait();
         this.socket = null;
@@ -219,6 +222,7 @@ export class OctoGateway {
 
       this.socket = this.createSocket(reg.ws_url, reg.robot_id, reg.im_token);
       this.socket.connect();
+      this.startHeartbeat(); // Q33: Restart API heartbeat after successful refresh
     } catch (err) {
       console.error('Token refresh failed:', String(err));
     } finally {

--- a/src/octo/socket.ts
+++ b/src/octo/socket.ts
@@ -282,7 +282,7 @@ export class WKSocket extends EventEmitter {
     this.stopReconnectTimer();
     this.clearStableTimer();
     if (this.ws) {
-      try { this.ws.close(); } catch { /* ignore */ }
+      try { this.ws.removeAllListeners(); this.ws.close(); } catch { /* ignore */ }
       this.ws = null;
     }
   }
@@ -307,6 +307,7 @@ export class WKSocket extends EventEmitter {
       const done = () => {
         if (resolved) return;
         resolved = true;
+        oldWs.removeAllListeners();
         resolve();
       };
       oldWs.on("close", done);


### PR DESCRIPTION
## Changes

### Q30: WS listener cleanup on disconnect (socket.ts)

`disconnect()` and `disconnectAndWait()` now call `ws.removeAllListeners()` before `ws.close()`. Previously, event listeners (open/message/close/error) remained on old WS instances until GC. Stale guards prevented message processing (security was fine), but listeners accumulated in reconnect loops — a memory leak.

### Q33: Heartbeat timer during token refresh (gateway.ts)

`attemptTokenRefresh()` now calls `stopHeartbeat()` at the start and `startHeartbeat()` after successful reconnect. Previously the API heartbeat timer continued firing during refresh, sending requests that would fail and increment `heartbeatFailCount`, potentially triggering a second overlapping refresh cycle.

### Q35: Known Dependency Risks documentation (ARCHITECTURE.md)

New section documenting maintenance status and replacement paths for three cryptographic dependencies:

| Package | Last Published | Risk |
|---------|---------------|------|
| `crypto-js@4.2.0` | 2023-10-24 | CVE-2023-46233 (PBKDF2, not used here). 2+ years unmaintained. |
| `md5-typescript@1.0.5` | 2018-03-03 | 8+ years unmaintained. |
| `curve25519-js@0.0.4` | 2019-08-02 | 7+ years unmaintained. |

Assessment: production risk is low (simple operations, no exploitable CVEs for our usage). Risk is supply chain. Replacement paths documented.

### Verification

- `tsc --noEmit`: ✅ clean
- `vitest run`: 237 tests pass
- Scope: 3 files, +20/-1 lines