### PR TITLE
fix: restore heartbeat on token refresh failure (Q33 catch path)

### DIFF
--- a/src/gateway.ts
+++ b/src/gateway.ts
@@ -230,6 +230,7 @@ export class OctoGateway {
       this.startHeartbeat(); // Q33: Restart API heartbeat after successful refresh
     } catch (err) {
       console.error('Token refresh failed:', String(err));
+      this.startHeartbeat(); // Q33: Restore heartbeat on failure for self-healing
     } finally {
       this.isRefreshing = false;
     }


### PR DESCRIPTION
Follow-up fix for PR#23 Q33: `attemptTokenRefresh()` calls `stopHeartbeat()` at the start, but the catch block did not restart it. If `registerBot` throws, the gateway permanently loses self-healing. Now both success and failure paths call `startHeartbeat()`.

1 file, +1 line.