### PR TITLE
feat(G3,G8,G12,G13): reply context + read receipt + mention-free + @botname strip

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Three-level priority: **environment variables** > **config.json** > **defaults**
 | `context.maxContextChars` | `CC_OCTO_CONTEXT_MAX_CHARS` | `6000` | Max characters of group context injected into prompts |
 | `context.historyLimit` | `CC_OCTO_CONTEXT_HISTORY_LIMIT` | `40` | Max messages in session history window |
 | `botBlocklist` | `CC_OCTO_BOT_BLOCKLIST` | `[]` | Comma-separated bot UIDs to ignore in DMs (prevents bot loops) |
+| `mentionFreeGroups` | `CC_OCTO_MENTION_FREE_GROUPS` | `[]` | Comma-separated group channel IDs where the bot responds to every text message without requiring an `@bot` mention (G12). |
 
 ## Security Model
 

--- a/config.example.json
+++ b/config.example.json
@@ -21,5 +21,8 @@
     "historyLimit": 40
   },
 
-  "botBlocklist": []
+  "botBlocklist": [],
+
+  "_comment_mention_free": "G12: group_ids listed here process every text message without requiring an @bot mention. Use group channel IDs as strings. Env override: CC_OCTO_MENTION_FREE_GROUPS (csv).",
+  "mentionFreeGroups": []
 }

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -26,6 +26,7 @@ const CC_VARS = [
   'CC_OCTO_SDK_MAX_TURNS', 'CC_OCTO_SDK_SYSTEM_PROMPT', 'CC_OCTO_SDK_SETTING_SOURCES',
   'CC_OCTO_RATE_LIMIT_MAX_PER_MINUTE', 'CC_OCTO_CONTEXT_MAX_CHARS',
   'CC_OCTO_CONTEXT_HISTORY_LIMIT', 'CC_OCTO_BOT_BLOCKLIST',
+  'CC_OCTO_MENTION_FREE_GROUPS', 'CC_OCTO_MAX_RESPONSE_CHARS',
 ];
 
 function setup() {
@@ -250,6 +251,12 @@ describe('CC_OCTO_* env override coverage', () => {
     const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
     process.env.CC_OCTO_BOT_BLOCKLIST = 'bot-a, bot-b, bot-c';
     expect(loadConfig(path).botBlocklist).toEqual(['bot-a', 'bot-b', 'bot-c']);
+  });
+
+  it('CC_OCTO_MENTION_FREE_GROUPS (csv) overrides config (G12)', () => {
+    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
+    process.env.CC_OCTO_MENTION_FREE_GROUPS = 'group-1, group-2,group-3';
+    expect(loadConfig(path).mentionFreeGroups).toEqual(['group-1', 'group-2', 'group-3']);
   });
 });
 

--- a/src/__tests__/e2e.test.ts
+++ b/src/__tests__/e2e.test.ts
@@ -23,7 +23,7 @@ vi.mock('../octo/api.js', () => ({
   }),
   generateClientMsgNo: vi.fn().mockReturnValue('client-msg-001'),
   fetchUserInfo: vi.fn().mockResolvedValue(null),
-}));;
+}));
 
 vi.mock('../agent-bridge.js', async (importOriginal) => {
   const original = await importOriginal<typeof import('../agent-bridge.js')>();
@@ -164,15 +164,24 @@ async function simulateMessage(
 
     const userContent = msg.payload.content ?? '';
 
-    // G3: Extract quoted/replied message content for LLM context
+    // G3: Extract quoted/replied message content for LLM context (truncated to 4KB).
     let quotePrefix = '';
     const replyData = msg.payload?.reply;
     if (replyData) {
-      const replyPayload = replyData.payload;
-      const replyContent = replyPayload?.content ?? '';
+      const replyPayload = replyData?.payload;
+      const rawReplyContent = replyPayload?.content ?? '';
       const replyFrom = replyData.from_name ?? replyData.from_uid ?? 'unknown';
-      if (replyContent) {
-        quotePrefix = `[Quoted message from ${replyFrom}]: ${replyContent}\n---\n`;
+      if (rawReplyContent) {
+        const QUOTE_MAX_BYTES = 4_096;
+        let truncated = rawReplyContent;
+        if (Buffer.byteLength(rawReplyContent, 'utf-8') > QUOTE_MAX_BYTES) {
+          truncated = rawReplyContent.slice(0, QUOTE_MAX_BYTES);
+          while (Buffer.byteLength(truncated, 'utf-8') > QUOTE_MAX_BYTES) {
+            truncated = truncated.slice(0, -1);
+          }
+          truncated += '…[truncated]';
+        }
+        quotePrefix = `[Quoted message from ${replyFrom}]: ${truncated}\n---\n`;
       }
     }
     const userContentForLLM = quotePrefix + (result.cleanContent ?? userContent);
@@ -547,6 +556,34 @@ describe('E2E smoke tests', () => {
     expect(userMsg).toContain('[Quoted message from Alice]');
     expect(userMsg).toContain('the original code');
     expect(userMsg).toContain('what does this mean');
+  });
+
+  // P1 regression: oversized reply payload is truncated before being prepended
+  // to user content. Without this guard, a small current message could carry
+  // an unbounded payload.reply.payload.content into queryAgent, bypassing the
+  // 32KB content guard in session-router.
+  it('G3 P1: truncates oversized quoted reply to ~4KB', async () => {
+    const hugeReply = 'X'.repeat(50_000);
+    const msg = makeDmMsg('tell me about this', {
+      payload: {
+        type: MessageType.Text,
+        content: 'tell me about this',
+        reply: {
+          from_uid: 'other-user',
+          from_name: 'Alice',
+          payload: { type: MessageType.Text, content: hugeReply },
+        },
+      },
+    });
+    await simulateMessage(msg, config, store, router, groupContext, streamRelay);
+
+    expect(queryAgent).toHaveBeenCalledTimes(1);
+    const userMsg = (queryAgent as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    // Truncation marker present.
+    expect(userMsg).toContain('[truncated]');
+    // Total prompt size is bounded (4KB cap + small framing overhead).
+    expect(userMsg.length).toBeLessThan(5_000);
+    expect(userMsg).toContain('tell me about this');
   });
 
   // --- G8: Read receipt ---

--- a/src/__tests__/e2e.test.ts
+++ b/src/__tests__/e2e.test.ts
@@ -10,6 +10,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 vi.mock('../octo/api.js', () => ({
   sendMessage: vi.fn().mockResolvedValue(undefined),
   sendTyping: vi.fn().mockResolvedValue(undefined),
+  sendReadReceipt: vi.fn().mockResolvedValue(undefined),
   getGroupMembers: vi.fn().mockResolvedValue([]),
   sendHeartbeat: vi.fn().mockResolvedValue(undefined),
   registerBot: vi.fn().mockResolvedValue({
@@ -22,7 +23,7 @@ vi.mock('../octo/api.js', () => ({
   }),
   generateClientMsgNo: vi.fn().mockReturnValue('client-msg-001'),
   fetchUserInfo: vi.fn().mockResolvedValue(null),
-}));
+}));;
 
 vi.mock('../agent-bridge.js', async (importOriginal) => {
   const original = await importOriginal<typeof import('../agent-bridge.js')>();
@@ -45,6 +46,7 @@ import { createAdapter, type DbAdapter } from '../db-adapter.js';
 import { queryAgent } from '../agent-bridge.js';
 import {
   sendMessage,
+  sendReadReceipt,
 } from '../octo/api.js';
 import { ChannelType, MessageType } from '../octo/types.js';
 import type { BotMessage } from '../octo/types.js';
@@ -161,10 +163,24 @@ async function simulateMessage(
     }
 
     const userContent = msg.payload.content ?? '';
+
+    // G3: Extract quoted/replied message content for LLM context
+    let quotePrefix = '';
+    const replyData = msg.payload?.reply;
+    if (replyData) {
+      const replyPayload = replyData.payload;
+      const replyContent = replyPayload?.content ?? '';
+      const replyFrom = replyData.from_name ?? replyData.from_uid ?? 'unknown';
+      if (replyContent) {
+        quotePrefix = `[Quoted message from ${replyFrom}]: ${replyContent}\n---\n`;
+      }
+    }
+    const userContentForLLM = quotePrefix + (result.cleanContent ?? userContent);
+
     const historyPrefix = store.buildSegmentedHistoryPrefix(sessionKey, config.context.historyLimit);
     store.appendUser(sessionKey, userContent, msg.message_seq);
 
-    const rawChunks = queryAgent(userContent, historyPrefix, contextStr, config);
+    const rawChunks = queryAgent(userContentForLLM, historyPrefix, contextStr, config);
 
     const collected: string[] = [];
     async function* teeChunks(): AsyncIterable<string> {
@@ -180,7 +196,19 @@ async function simulateMessage(
       teeChunks(),
       config.apiUrl,
       config.botToken,
+      config.maxResponseChars,
     );
+
+    // G8: Send read receipt after processing (fire-and-forget)
+    if (msg.message_id && msg.channel_id && msg.channel_type !== undefined) {
+      sendReadReceipt({
+        apiUrl: config.apiUrl,
+        botToken: config.botToken,
+        channelId: msg.channel_id,
+        channelType: msg.channel_type,
+        messageIds: [msg.message_id],
+      }).catch((err) => console.error(`readReceipt failed: ${String(err)}`));
+    }
 
     const fullResponse = collected.join('');
     if (fullResponse) {
@@ -496,5 +524,46 @@ describe('E2E smoke tests', () => {
     expect(segHistory).toContain('first answer');
     expect(segHistory).toContain('[new messages]');
     expect(segHistory).toContain('follow-up question');
+  });
+
+  // --- G3: Reply quote context ---
+
+  it('G3: quoted message context is prepended to user message for LLM', async () => {
+    const msg = makeDmMsg('what does this mean', {
+      payload: {
+        type: MessageType.Text,
+        content: 'what does this mean',
+        reply: {
+          from_uid: 'other-user',
+          from_name: 'Alice',
+          payload: { type: MessageType.Text, content: 'the original code' },
+        },
+      },
+    });
+    await simulateMessage(msg, config, store, router, groupContext, streamRelay);
+
+    expect(queryAgent).toHaveBeenCalledTimes(1);
+    const userMsg = (queryAgent as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(userMsg).toContain('[Quoted message from Alice]');
+    expect(userMsg).toContain('the original code');
+    expect(userMsg).toContain('what does this mean');
+  });
+
+  // --- G8: Read receipt ---
+
+  it('G8: read receipt is sent after processing', async () => {
+    vi.clearAllMocks();
+    mockQueryYield('response');
+    const msg = makeDmMsg('test read receipt', { message_id: 'msg-123' });
+    await simulateMessage(msg, config, store, router, groupContext, streamRelay);
+
+    // Allow microtasks to flush (fire-and-forget)
+    await Promise.resolve();
+
+    expect(sendReadReceipt).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messageIds: ['msg-123'],
+      }),
+    );
   });
 });

--- a/src/__tests__/g3-g8-g12-g13.test.ts
+++ b/src/__tests__/g3-g8-g12-g13.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Mock API
+vi.mock('../octo/api.js', () => ({
+  sendMessage: vi.fn().mockResolvedValue(undefined),
+  sendReadReceipt: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { SessionRouter } from '../session-router.js';
+import { ChannelType, MessageType } from '../octo/types.js';
+import type { Config } from '../config.js';
+
+const BOT_ID = 'bot-001';
+
+function makeConfig(overrides?: Partial<Config>): Config {
+  return {
+    botToken: 'test-token',
+    apiUrl: 'https://test.example.com',
+    cwd: '/tmp',
+    dataDir: '/tmp/data',
+    sdk: { allowedTools: [], permissionMode: 'bypassPermissions', settingSources: ['user'] },
+    rateLimit: { maxPerMinute: 100 },
+    context: { maxContextChars: 6000, historyLimit: 40 },
+    maxResponseChars: 524288,
+    ...overrides,
+  };
+}
+
+// --- G13: @botname stripping ---
+describe('G13: @botname stripping', () => {
+  it('strips leading @botname from group message via entities', async () => {
+    const router = new SessionRouter(makeConfig(), BOT_ID);
+    let cleanContent: string | undefined;
+
+    await router.routeAndHandle({
+      message_id: '1', message_seq: 1, from_uid: 'user-1',
+      channel_id: 'g1', channel_type: ChannelType.Group,
+      timestamp: Date.now(),
+      payload: {
+        type: MessageType.Text,
+        content: '@MyBot help me with this code',
+        mention: {
+          uids: [BOT_ID],
+          entities: [{ uid: BOT_ID, offset: 0, length: 6 }],
+        },
+      },
+    }, async (result) => {
+      cleanContent = result.cleanContent;
+    });
+
+    expect(cleanContent).toBe('help me with this code');
+  });
+
+  it('strips leading @botname via regex fallback', async () => {
+    const router = new SessionRouter(makeConfig(), BOT_ID);
+    let cleanContent: string | undefined;
+
+    await router.routeAndHandle({
+      message_id: '1', message_seq: 1, from_uid: 'user-1',
+      channel_id: 'g1', channel_type: ChannelType.Group,
+      timestamp: Date.now(),
+      payload: {
+        type: MessageType.Text,
+        content: '@bot review this',
+        mention: { uids: [BOT_ID] },
+      },
+    }, async (result) => {
+      cleanContent = result.cleanContent;
+    });
+
+    expect(cleanContent).toBe('review this');
+  });
+
+  it('does not strip @botname in DM', async () => {
+    const router = new SessionRouter(makeConfig(), BOT_ID);
+    let cleanContent: string | undefined;
+
+    await router.routeAndHandle({
+      message_id: '1', message_seq: 1, from_uid: 'user-1',
+      channel_id: 'user-1', channel_type: ChannelType.DM,
+      timestamp: Date.now(),
+      payload: { type: MessageType.Text, content: '@someone hello' },
+    }, async (result) => {
+      cleanContent = result.cleanContent;
+    });
+
+    // DM: no stripping
+    expect(cleanContent).toBe('@someone hello');
+  });
+
+  it('preserves content when stripping would empty it', async () => {
+    const router = new SessionRouter(makeConfig(), BOT_ID);
+    let cleanContent: string | undefined;
+
+    await router.routeAndHandle({
+      message_id: '1', message_seq: 1, from_uid: 'user-1',
+      channel_id: 'g1', channel_type: ChannelType.Group,
+      timestamp: Date.now(),
+      payload: {
+        type: MessageType.Text,
+        content: '@bot',
+        mention: { uids: [BOT_ID] },
+      },
+    }, async (result) => {
+      cleanContent = result.cleanContent;
+    });
+
+    expect(cleanContent).toBe('@bot');
+  });
+});
+
+// --- G12: Mention-free mode ---
+describe('G12: Mention-free groups', () => {
+  it('processes group message without @mention when group is mention-free', async () => {
+    const router = new SessionRouter(
+      makeConfig({ mentionFreeGroups: ['free-group-1'] }),
+      BOT_ID,
+    );
+    let processed = false;
+
+    await router.routeAndHandle({
+      message_id: '1', message_seq: 1, from_uid: 'user-1',
+      channel_id: 'free-group-1', channel_type: ChannelType.Group,
+      timestamp: Date.now(),
+      payload: { type: MessageType.Text, content: 'hello without @' },
+    }, async () => {
+      processed = true;
+    });
+
+    expect(processed).toBe(true);
+  });
+
+  it('still requires @mention in non-mention-free groups', async () => {
+    const router = new SessionRouter(
+      makeConfig({ mentionFreeGroups: ['free-group-1'] }),
+      BOT_ID,
+    );
+    let processed = false;
+
+    await router.routeAndHandle({
+      message_id: '1', message_seq: 1, from_uid: 'user-1',
+      channel_id: 'normal-group', channel_type: ChannelType.Group,
+      timestamp: Date.now(),
+      payload: { type: MessageType.Text, content: 'hello without @' },
+    }, async () => {
+      processed = true;
+    });
+
+    expect(processed).toBe(false);
+  });
+
+  it('still filters system events in mention-free groups', async () => {
+    const router = new SessionRouter(
+      makeConfig({ mentionFreeGroups: ['free-group-1'] }),
+      BOT_ID,
+    );
+    let processed = false;
+
+    await router.routeAndHandle({
+      message_id: '1', message_seq: 1, from_uid: 'user-1',
+      channel_id: 'free-group-1', channel_type: ChannelType.Group,
+      timestamp: Date.now(),
+      payload: {
+        type: MessageType.Text,
+        content: '',
+        event: { type: 'member_join' },
+      },
+    }, async () => {
+      processed = true;
+    });
+
+    expect(processed).toBe(false);
+  });
+});
+
+// --- G8: Read receipt ---
+describe('G8: sendReadReceipt API', () => {
+  it('sendReadReceipt is exported from api.ts', async () => {
+    const { sendReadReceipt } = await import('../octo/api.js');
+    expect(typeof sendReadReceipt).toBe('function');
+  });
+});
+
+// --- G3: Reply quote context ---
+describe('G3: Reply quote context', () => {
+  // This is mostly an integration test via e2e, but we can verify the types support it
+  it('BotMessage supports reply payload', () => {
+    const msg = {
+      message_id: '1', message_seq: 1, from_uid: 'u1',
+      channel_type: ChannelType.DM, timestamp: 0,
+      payload: {
+        type: MessageType.Text,
+        content: 'test',
+        reply: {
+          from_uid: 'u2',
+          from_name: 'Alice',
+          payload: { type: MessageType.Text, content: 'original message' },
+        },
+      },
+    };
+    expect(msg.payload.reply?.payload?.content).toBe('original message');
+    expect(msg.payload.reply?.from_name).toBe('Alice');
+  });
+});

--- a/src/__tests__/g3-g8-g12-g13.test.ts
+++ b/src/__tests__/g3-g8-g12-g13.test.ts
@@ -107,6 +107,67 @@ describe('G13: @botname stripping', () => {
 
     expect(cleanContent).toBe('@bot');
   });
+
+  // P1 regression: regex fallback must NOT strip non-bot @mention.
+  // Failure mode (before fix): in a mention-free group, a message addressed
+  // to a teammate like "@alice please check" would be stripped to
+  // "please check", losing the addressee context.
+  it('does not strip leading @mention when bot is not mentioned (G12 mention-free)', async () => {
+    const router = new SessionRouter(
+      makeConfig({ mentionFreeGroups: ['free-group-1'] }),
+      BOT_ID,
+    );
+    let cleanContent: string | undefined;
+
+    await router.routeAndHandle({
+      message_id: '1', message_seq: 1, from_uid: 'user-1',
+      channel_id: 'free-group-1', channel_type: ChannelType.Group,
+      timestamp: Date.now(),
+      payload: {
+        type: MessageType.Text,
+        content: '@alice please check this',
+        mention: { uids: ['alice-uid'] }, // alice mentioned, NOT bot
+      },
+    }, async (result) => {
+      cleanContent = result.cleanContent;
+    });
+
+    // The @alice mention is addressed to a teammate — must be preserved.
+    expect(cleanContent).toBe('@alice please check this');
+  });
+
+  // P1 regression: entity-based path only strips when uid matches bot at offset 0.
+  it('does not strip when bot mention is not at offset 0', async () => {
+    const router = new SessionRouter(makeConfig(), BOT_ID);
+    let cleanContent: string | undefined;
+
+    await router.routeAndHandle({
+      message_id: '1', message_seq: 1, from_uid: 'user-1',
+      channel_id: 'g1', channel_type: ChannelType.Group,
+      timestamp: Date.now(),
+      payload: {
+        type: MessageType.Text,
+        content: '@alice @bot help',
+        mention: {
+          uids: ['alice-uid', BOT_ID],
+          entities: [
+            { uid: 'alice-uid', offset: 0, length: 6 },
+            { uid: BOT_ID, offset: 7, length: 4 },
+          ],
+        },
+      },
+    }, async (result) => {
+      cleanContent = result.cleanContent;
+    });
+
+    // Bot not at offset 0 — regex fallback runs because bot IS mentioned,
+    // but it strips the leading @alice. This is an accepted limitation of
+    // regex fallback when entities don't help; the important invariant is
+    // that we DO NOT strip when the bot wasn't mentioned at all (covered above).
+    // Here, since the bot IS mentioned, regex strips @alice — not ideal but
+    // safe in the sense that the user knew they were @ing the bot.
+    expect(cleanContent).toBe('@bot help');
+  });
 });
 
 // --- G12: Mention-free mode ---
@@ -200,5 +261,36 @@ describe('G3: Reply quote context', () => {
     };
     expect(msg.payload.reply?.payload?.content).toBe('original message');
     expect(msg.payload.reply?.from_name).toBe('Alice');
+  });
+
+  // P1 regression: oversized reply payload is truncated, not propagated.
+  // We replicate the truncation logic inline because the production path
+  // lives in index.ts handleMessage; the assertion is that the prefix never
+  // exceeds ~4.1KB regardless of how big payload.reply.payload.content is.
+  it('truncates oversized quoted reply content (P1 size guard)', () => {
+    const QUOTE_MAX_BYTES = 4_096;
+    const huge = 'A'.repeat(50_000); // 50KB — way over single-message limit
+    let truncated = huge;
+    if (Buffer.byteLength(huge, 'utf-8') > QUOTE_MAX_BYTES) {
+      truncated = huge.slice(0, QUOTE_MAX_BYTES);
+      while (Buffer.byteLength(truncated, 'utf-8') > QUOTE_MAX_BYTES) {
+        truncated = truncated.slice(0, -1);
+      }
+      truncated += '…[truncated]';
+    }
+    expect(Buffer.byteLength(truncated, 'utf-8')).toBeLessThanOrEqual(QUOTE_MAX_BYTES + 64);
+    expect(truncated.endsWith('[truncated]')).toBe(true);
+  });
+
+  it('preserves short reply content without truncation', () => {
+    const QUOTE_MAX_BYTES = 4_096;
+    const short = 'short original message';
+    let truncated = short;
+    if (Buffer.byteLength(short, 'utf-8') > QUOTE_MAX_BYTES) {
+      truncated = short.slice(0, QUOTE_MAX_BYTES);
+      truncated += '…[truncated]';
+    }
+    expect(truncated).toBe(short);
+    expect(truncated.endsWith('[truncated]')).toBe(false);
   });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -33,6 +33,8 @@ export interface Config {
    * the `_bot` heuristic. Use this to whitelist trusted bots.
    */
   allowedBotUids?: string[];
+  /** Group IDs where the bot responds without being @mentioned (G12). */
+  mentionFreeGroups?: string[];
 }
 
 type PartialConfig = {
@@ -46,6 +48,7 @@ type PartialConfig = {
   maxResponseChars?: number;
   botBlocklist?: string[];
   allowedBotUids?: string[];
+  mentionFreeGroups?: string[];
 };
 
 function defaults(): Config {
@@ -126,6 +129,7 @@ function mergeConfig(base: Config, override: PartialConfig): Config {
     maxResponseChars: override.maxResponseChars ?? base.maxResponseChars,
     botBlocklist: override.botBlocklist ?? base.botBlocklist,
     allowedBotUids: override.allowedBotUids ?? base.allowedBotUids,
+    mentionFreeGroups: override.mentionFreeGroups ?? base.mentionFreeGroups,
   };
 }
 
@@ -205,6 +209,10 @@ function applyEnv(cfg: Config): Config {
 
   if (env.CC_OCTO_ALLOWED_BOT_UIDS) {
     next.allowedBotUids = parseCsv(env.CC_OCTO_ALLOWED_BOT_UIDS);
+  }
+
+  if (env.CC_OCTO_MENTION_FREE_GROUPS) {
+    next.mentionFreeGroups = parseCsv(env.CC_OCTO_MENTION_FREE_GROUPS);
   }
 
   if (env.CC_OCTO_MAX_RESPONSE_CHARS) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ import { SessionRouter } from './session-router.js';
 import { GroupContext } from './group-context.js';
 import { queryAgent } from './agent-bridge.js';
 import { StreamRelay } from './stream-relay.js';
-import { sendMessage } from './octo/api.js';
+import { sendMessage, sendReadReceipt } from './octo/api.js';
 import { ChannelType, MessageType } from './octo/types.js';
 import type { BotMessage } from './octo/types.js';
 import { join } from 'node:path';
@@ -135,12 +135,26 @@ async function handleMessage(
 
       // --- Build history prefix BEFORE appending current message (G10: segmented) ---
       const userContent = msg.payload.content ?? '';
+
+      // G3: Extract quoted/replied message content for LLM context
+      let quotePrefix = '';
+      const replyData = msg.payload?.reply;
+      if (replyData) {
+        const replyPayload = replyData.payload;
+        const replyContent = replyPayload?.content ?? '';
+        const replyFrom = replyData.from_name ?? replyData.from_uid ?? 'unknown';
+        if (replyContent) {
+          quotePrefix = `[Quoted message from ${replyFrom}]: ${replyContent}\n---\n`;
+        }
+      }
+      const userContentForLLM = quotePrefix + (result.cleanContent ?? userContent);
+
       const historyPrefix = store.buildSegmentedHistoryPrefix(sessionKey, config.context.historyLimit);
       store.appendUser(sessionKey, userContent, msg.message_seq);
 
       // --- Query agent with structural role separation (Q3 fix) ---
-      // userContent → user role (prompt), history + context → system role (systemPrompt)
-      const rawChunks = queryAgent(userContent, historyPrefix, contextStr, config);
+      // userContentForLLM → user role (prompt), history + context → system role (systemPrompt)
+      const rawChunks = queryAgent(userContentForLLM, historyPrefix, contextStr, config);
 
       // Tee the generator: collect full text while streaming to Octo
       const collected: string[] = [];
@@ -153,6 +167,17 @@ async function handleMessage(
 
       // --- Stream output to Octo ---
       await streamRelay.deliver(channelId, channelType, teeChunks(), config.apiUrl, config.botToken, config.maxResponseChars);
+
+      // G8: Send read receipt after processing (fire-and-forget)
+      if (msg.message_id && msg.channel_id && msg.channel_type !== undefined) {
+        sendReadReceipt({
+          apiUrl: config.apiUrl,
+          botToken: config.botToken,
+          channelId: msg.channel_id,
+          channelType: msg.channel_type,
+          messageIds: [msg.message_id],
+        }).catch((err) => console.error(`[cc-channel-octo] readReceipt failed: ${String(err)}`));
+      }
 
       // --- Store assistant response in history ---
       const fullResponse = collected.join('');

--- a/src/index.ts
+++ b/src/index.ts
@@ -136,17 +136,38 @@ async function handleMessage(
       // --- Build history prefix BEFORE appending current message (G10: segmented) ---
       const userContent = msg.payload.content ?? '';
 
-      // G3: Extract quoted/replied message content for LLM context
+      // G3: Extract quoted/replied message content for LLM context.
+      //
+      // The quote payload comes from a previously-sent message (bounded by the
+      // server's own size limits), but to honor cc-channel-octo's 32KB user
+      // content gate without amplification we truncate the quoted body to a
+      // small budget. The quoted content is supplementary context, not a
+      // primary input, so a 4KB cap preserves usefulness without bypassing
+      // the size guarantee documented in session-router.ts.
       let quotePrefix = '';
       const replyData = msg.payload?.reply;
       if (replyData) {
-        const replyPayload = replyData.payload;
-        const replyContent = replyPayload?.content ?? '';
+        const replyPayload = replyData?.payload;
+        const rawReplyContent = replyPayload?.content ?? '';
         const replyFrom = replyData.from_name ?? replyData.from_uid ?? 'unknown';
-        if (replyContent) {
-          quotePrefix = `[Quoted message from ${replyFrom}]: ${replyContent}\n---\n`;
+        if (rawReplyContent) {
+          const QUOTE_MAX_BYTES = 4_096;
+          let truncated = rawReplyContent;
+          if (Buffer.byteLength(rawReplyContent, 'utf-8') > QUOTE_MAX_BYTES) {
+            // Byte-safe truncate: take a generous char slice then trim by bytes.
+            // 4096 bytes can hold ~1365 CJK chars; slice 1366 to be safe and shrink.
+            truncated = rawReplyContent.slice(0, QUOTE_MAX_BYTES);
+            while (Buffer.byteLength(truncated, 'utf-8') > QUOTE_MAX_BYTES) {
+              truncated = truncated.slice(0, -1);
+            }
+            truncated += '…[truncated]';
+          }
+          quotePrefix = `[Quoted message from ${replyFrom}]: ${truncated}\n---\n`;
         }
       }
+      // Note: quotePrefix is added to LLM input only — store.appendUser below
+      // persists the raw user content without the quote prefix to avoid prefix
+      // duplication on conversation replay.
       const userContentForLLM = quotePrefix + (result.cleanContent ?? userContent);
 
       const historyPrefix = store.buildSegmentedHistoryPrefix(sessionKey, config.context.historyLimit);

--- a/src/octo/api.ts
+++ b/src/octo/api.ts
@@ -205,6 +205,23 @@ async function getJson<T>(
   return parseOctoJson<T>(text);
 }
 
+// ─── Read Receipt ──────────────────────────────────────────────────────────
+
+export async function sendReadReceipt(params: {
+  apiUrl: string;
+  botToken: string;
+  channelId: string;
+  channelType: ChannelType;
+  messageIds: string[];
+  signal?: AbortSignal;
+}): Promise<void> {
+  await postJson(params.apiUrl, params.botToken, '/v1/bot/readReceipt', {
+    channel_id: params.channelId,
+    channel_type: params.channelType,
+    message_ids: params.messageIds,
+  }, params.signal);
+}
+
 // ─── Group Members ──────────────────────────────────────────────────────────
 
 export interface GroupMember {

--- a/src/session-router.ts
+++ b/src/session-router.ts
@@ -3,7 +3,7 @@
  */
 
 import type { Config } from './config.js';
-import type { BotMessage } from './octo/types.js';
+import type { BotMessage, MentionEntity } from './octo/types.js';
 import { ChannelType, MessageType } from './octo/types.js';
 import { sendMessage } from './octo/api.js';
 
@@ -11,6 +11,8 @@ export interface RouteResult {
   sessionKey: string;
   shouldProcess: boolean;
   message: BotMessage;
+  /** User content with leading @botname stripped (for LLM input). */
+  cleanContent?: string;
 }
 
 interface TokenBucket {
@@ -209,9 +211,13 @@ export class SessionRouter {
     // @-mentioned. The mention gate below already enforces this, but bots in
     // the blocklist (above) get hard-dropped without even checking mentions.
 
-    // Group mention gate.
+    // Group mention gate — skip unless mentioned OR in mention-free group (G12).
     if (this.isGroupLike(msg.channel_type) && !this.isMentioned(msg)) {
-      return null;
+      // G12: Check if this group is in the mention-free list
+      const isMentionFree = this.config.mentionFreeGroups?.includes(msg.channel_id ?? '') ?? false;
+      if (!isMentionFree) {
+        return null;
+      }
     }
 
     // Skip system events (group join/leave, etc.) — no user-facing reply needed.
@@ -244,7 +250,28 @@ export class SessionRouter {
       return { sessionKey: key, shouldProcess: false, message: msg };
     }
 
-    return { sessionKey: key, shouldProcess: true, message: msg };
+    // G13: Strip leading @botname from group messages for cleaner LLM input.
+    let cleanContent = content;
+    if (this.isGroupLike(msg.channel_type)) {
+      // Try entities-based removal first (precise offset/length)
+      const mention = msg.payload.mention;
+      if (mention?.entities && Array.isArray(mention.entities)) {
+        const botEntity = mention.entities.find(
+          (e: MentionEntity) => e.uid === this.robotId && e.offset === 0,
+        );
+        if (botEntity && typeof botEntity.length === 'number') {
+          cleanContent = content.substring(botEntity.length).trimStart();
+        }
+      }
+      // Fallback: regex strip leading @word
+      if (cleanContent === content) {
+        cleanContent = content.replace(/^@\S+\s*/, '').trim();
+      }
+      // If stripping emptied the content, keep original
+      if (!cleanContent) cleanContent = content;
+    }
+
+    return { sessionKey: key, shouldProcess: true, message: msg, cleanContent };
   }
 
   /**

--- a/src/session-router.ts
+++ b/src/session-router.ts
@@ -251,10 +251,18 @@ export class SessionRouter {
     }
 
     // G13: Strip leading @botname from group messages for cleaner LLM input.
+    //
+    // Only strip when we have positive evidence the leading @token IS the bot.
+    // The regex fallback used to strip *any* leading @word, which corrupts
+    // messages like "@alice please check" (especially in G12 mention-free
+    // groups, where the bot wasn't even @'d and would still lose the @alice
+    // context). We now only strip when:
+    //   1. entities precisely identify the bot at offset 0, OR
+    //   2. the bot is mentioned AND the leading @token resolves to its robotId.
     let cleanContent = content;
     if (this.isGroupLike(msg.channel_type)) {
-      // Try entities-based removal first (precise offset/length)
       const mention = msg.payload.mention;
+      // Path 1: entities-based removal (precise offset/length).
       if (mention?.entities && Array.isArray(mention.entities)) {
         const botEntity = mention.entities.find(
           (e: MentionEntity) => e.uid === this.robotId && e.offset === 0,
@@ -263,11 +271,13 @@ export class SessionRouter {
           cleanContent = content.substring(botEntity.length).trimStart();
         }
       }
-      // Fallback: regex strip leading @word
-      if (cleanContent === content) {
-        cleanContent = content.replace(/^@\S+\s*/, '').trim();
+      // Path 2: regex fallback — only when the bot was explicitly @mentioned.
+      // In mention-free groups (G12) where the bot wasn't @'d, do NOT touch
+      // the message — a leading @ is addressed to someone else.
+      if (cleanContent === content && this.isMentioned(msg)) {
+        cleanContent = content.replace(/^@\S+\s*/, '').trimStart();
       }
-      // If stripping emptied the content, keep original
+      // If stripping emptied the content, keep original.
       if (!cleanContent) cleanContent = content;
     }
 


### PR DESCRIPTION
## Summary

Implements 4 feature GAPs in a single commit.

### G3: Reply/quoted message context
- In `handleMessage`, extract `msg.payload.reply` and prepend a `[Quoted message from <name>]: <content>` prefix to the user content sent to the LLM.
- Original `userContent` is still stored in history unchanged.

### G8: Read receipt
- Added `sendReadReceipt` to `src/octo/api.ts` (POST `/v1/bot/readReceipt`).
- In `handleMessage`, after `streamRelay.deliver()` completes, fire-and-forget a read receipt for the processed message.

### G12: Mention-free mode
- Added `mentionFreeGroups?: string[]` to `Config` interface, `PartialConfig`, `mergeConfig`, and `applyEnv` (env var: `CC_OCTO_MENTION_FREE_GROUPS`).
- In `SessionRouter.processMessage`, the group mention gate now allows through messages from groups listed in `mentionFreeGroups` even without an @mention. System events, rate limits, and non-text checks still apply.

### G13: Strip @botname from group messages
- Added `cleanContent?: string` to `RouteResult`.
- In `processMessage`, after all checks pass, strip the leading @botname from group messages using entities-based removal (precise offset/length) with regex fallback. Empty result falls back to original content.
- In `handleMessage`, use `result.cleanContent ?? userContent` as the LLM input.

## Tests
- New `src/__tests__/g3-g8-g12-g13.test.ts` with 9 unit tests covering all 4 features.
- Updated `src/__tests__/e2e.test.ts`: added `sendReadReceipt` to mock, updated `simulateMessage` to mirror `index.ts` (G3/G8/G13), added G3 quote context test and G8 read receipt test.

## Verification
- `npx tsc --noEmit`: zero errors
- `npx eslint src/`: no new warnings (one pre-existing any in q13-q14-q17.test.ts)
- `npx vitest run`: 277/277 tests pass across 18 test files