### PR TITLE
feat(G1,G2,G4,G11,G22): inbound resolution + file inlining + history backfill

### DIFF
--- a/src/__tests__/e2e.test.ts
+++ b/src/__tests__/e2e.test.ts
@@ -44,6 +44,7 @@ import { GroupContext } from '../group-context.js';
 import { StreamRelay } from '../stream-relay.js';
 import { createAdapter, type DbAdapter } from '../db-adapter.js';
 import { queryAgent } from '../agent-bridge.js';
+import { resolveContent } from '../inbound.js';
 import {
   sendMessage,
   sendReadReceipt,
@@ -164,6 +165,10 @@ async function simulateMessage(
 
     const userContent = msg.payload.content ?? '';
 
+    // G1: resolve non-text payloads through inbound.resolveContent.
+    const resolved = resolveContent(msg.payload, config.apiUrl);
+    const bodyText = result.cleanContent ?? resolved.text;
+
     // G3: Extract quoted/replied message content for LLM context (truncated to 4KB).
     let quotePrefix = '';
     const replyData = msg.payload?.reply;
@@ -184,7 +189,7 @@ async function simulateMessage(
         quotePrefix = `[Quoted message from ${replyFrom}]: ${truncated}\n---\n`;
       }
     }
-    const userContentForLLM = quotePrefix + (result.cleanContent ?? userContent);
+    const userContentForLLM = quotePrefix + bodyText;
 
     const historyPrefix = store.buildSegmentedHistoryPrefix(sessionKey, config.context.historyLimit);
     store.appendUser(sessionKey, userContent, msg.message_seq);
@@ -343,19 +348,23 @@ describe('E2E smoke tests', () => {
     expect(ctx).toContain('TestUser：Just chatting');
   });
 
-  // --- 4. Non-text message gets "unsupported" reply ---
+  // --- 4. Non-text message: G1 routes it through to the agent ---
 
-  it('Non-text DM message: replies with unsupported notice', async () => {
+  it('G1: non-text DM message is resolved and sent to the agent (not rejected)', async () => {
     const msg = makeDmMsg('', {
-      payload: { type: MessageType.Image, url: 'https://example.com/img.png' },
+      payload: { type: MessageType.Image, url: 'file/preview/img.png' },
     });
     await simulateMessage(msg, config, store, router, groupContext, streamRelay);
 
-    // queryAgent should NOT be called
-    expect(queryAgent).not.toHaveBeenCalled();
+    // queryAgent IS called — the image is resolved as "[图片] <url>" and the
+    // agent gets a chance to respond.
+    expect(queryAgent).toHaveBeenCalled();
+    const userMsg = (queryAgent as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(userMsg).toContain('[图片]');
+    expect(userMsg).toContain('img.png');
 
-    // sendMessage called with unsupported notice
-    expect(sendMessage).toHaveBeenCalledWith(
+    // No “不支持” notice.
+    expect(sendMessage).not.toHaveBeenCalledWith(
       expect.objectContaining({
         content: '暂不支持此类消息，请发送文字',
       }),

--- a/src/__tests__/g2-file-inline.test.ts
+++ b/src/__tests__/g2-file-inline.test.ts
@@ -1,0 +1,183 @@
+/**
+ * G2 (file inlining) + G4 (history backfill) integration tests.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+describe('G2: file inlining via tryResolveFile', () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('inlines small text file content', async () => {
+    const { tryResolveFile } = await import('../inbound.js');
+
+    const fileContent = 'def hello():\n    print("world")\n';
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode(fileContent));
+        controller.close();
+      },
+    });
+
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      body: stream,
+    } as unknown as Response);
+
+    const result = await tryResolveFile({
+      url: 'https://api.example.com/file/hello.py',
+      botToken: 'tok',
+      filename: 'hello.py',
+    });
+
+    expect(result).toHaveProperty('inlined');
+    if ('inlined' in result) {
+      expect(result.inlined).toBe(fileContent);
+    }
+  });
+
+  it('rejects non-text extensions with size description', async () => {
+    const { tryResolveFile } = await import('../inbound.js');
+
+    const result = await tryResolveFile({
+      url: 'https://api.example.com/file/photo.jpg',
+      botToken: 'tok',
+      filename: 'photo.jpg',
+      knownSize: 5_000,
+    });
+
+    expect(result).toHaveProperty('description');
+    if ('description' in result) {
+      expect(result.description).toContain('photo.jpg');
+      expect(result.description).toContain('4.9KB');
+    }
+  });
+
+  it('rejects files exceeding hard cap by knownSize', async () => {
+    const { tryResolveFile } = await import('../inbound.js');
+
+    const result = await tryResolveFile({
+      url: 'https://api.example.com/file/big.md',
+      botToken: 'tok',
+      filename: 'big.md',
+      knownSize: 10 * 1024 * 1024, // 10 MB > 5MB cap
+    });
+
+    expect(result).toHaveProperty('description');
+    if ('description' in result) {
+      expect(result.description).toContain('超过下载上限');
+    }
+  });
+
+  it('returns description on HTTP error', async () => {
+    const { tryResolveFile } = await import('../inbound.js');
+
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      body: null,
+    } as unknown as Response);
+
+    const result = await tryResolveFile({
+      url: 'https://api.example.com/file/missing.md',
+      botToken: 'tok',
+      filename: 'missing.md',
+    });
+
+    expect(result).toHaveProperty('description');
+    if ('description' in result) {
+      expect(result.description).toContain('HTTP 404');
+    }
+  });
+
+  it('returns description on network error', async () => {
+    const { tryResolveFile } = await import('../inbound.js');
+
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error('ECONNRESET'));
+
+    const result = await tryResolveFile({
+      url: 'https://api.example.com/file/foo.md',
+      botToken: 'tok',
+      filename: 'foo.md',
+    });
+
+    expect(result).toHaveProperty('description');
+    if ('description' in result) {
+      expect(result.description).toContain('网络错误');
+    }
+  });
+
+  it('extracts extension from URL when filename has none', async () => {
+    const { tryResolveFile } = await import('../inbound.js');
+
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      body: new ReadableStream({
+        start(c) {
+          c.enqueue(new TextEncoder().encode('# Title\n'));
+          c.close();
+        },
+      }),
+    } as unknown as Response);
+
+    const result = await tryResolveFile({
+      url: 'https://api.example.com/file/something.md',
+      botToken: 'tok',
+      filename: 'something', // no extension
+    });
+
+    // URL extension .md is recognized
+    expect(result).toHaveProperty('inlined');
+  });
+
+  it('streams file to temp path when exceeding inline cap', async () => {
+    const { tryResolveFile, INLINE_FILE_MAX_BYTES } = await import('../inbound.js');
+
+    // 25KB > 20KB inline cap
+    const largeContent = 'A'.repeat(INLINE_FILE_MAX_BYTES + 5_000);
+    const encoder = new TextEncoder();
+    const chunks = [
+      encoder.encode(largeContent.slice(0, 10_000)),
+      encoder.encode(largeContent.slice(10_000, 22_000)),
+      encoder.encode(largeContent.slice(22_000)),
+    ];
+    let idx = 0;
+    const stream = new ReadableStream({
+      pull(controller) {
+        if (idx < chunks.length) {
+          controller.enqueue(chunks[idx++]);
+        } else {
+          controller.close();
+        }
+      },
+    });
+
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      body: stream,
+    } as unknown as Response);
+
+    const result = await tryResolveFile({
+      url: 'https://api.example.com/file/big.txt',
+      botToken: 'tok',
+      filename: 'big.txt',
+    });
+
+    expect(result).toHaveProperty('tempPath');
+    if ('tempPath' in result) {
+      expect(result.tempPath).toContain('big.txt');
+      expect(result.tempPath).toContain('/tmp/cc-channel-octo/inbound-files');
+    }
+  });
+});

--- a/src/__tests__/g4-history-api.test.ts
+++ b/src/__tests__/g4-history-api.test.ts
@@ -1,0 +1,221 @@
+/**
+ * getChannelMessages (G4) — API history backfill.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+describe('getChannelMessages (G4)', () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('returns parsed messages with decoded payload', async () => {
+    const { getChannelMessages } = await import('../octo/api.js');
+
+    const samplePayload = { type: 1, content: 'hello world' };
+    const payloadB64 = Buffer.from(JSON.stringify(samplePayload), 'utf-8').toString('base64');
+
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: () =>
+        Promise.resolve(
+          JSON.stringify({
+            messages: [
+              {
+                from_uid: 'user1',
+                from_name: 'Alice',
+                content: 'hello world',
+                timestamp: 1234567890,
+                message_id: 'm1',
+                message_seq: 5,
+                type: 1,
+                payload: payloadB64,
+              },
+            ],
+          }),
+        ),
+    } as unknown as Response);
+
+    const result = await getChannelMessages({
+      apiUrl: 'https://api.example.com',
+      botToken: 'tok',
+      channelId: 'g1',
+      channelType: 2,
+      limit: 10,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].from_uid).toBe('user1');
+    expect(result[0].from_name).toBe('Alice');
+    expect(result[0].content).toBe('hello world');
+    expect(result[0].message_seq).toBe(5);
+    expect(result[0].type).toBe(1);
+    expect(result[0].payload).toEqual(samplePayload);
+  });
+
+  it('handles missing payload field gracefully', async () => {
+    const { getChannelMessages } = await import('../octo/api.js');
+
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: () =>
+        Promise.resolve(
+          JSON.stringify({
+            messages: [
+              { from_uid: 'user1', content: 'no payload', timestamp: 1, message_seq: 1, type: 1 },
+            ],
+          }),
+        ),
+    } as unknown as Response);
+
+    const result = await getChannelMessages({
+      apiUrl: 'https://api.example.com',
+      botToken: 'tok',
+      channelId: 'g1',
+      channelType: 2,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].payload).toBeUndefined();
+  });
+
+  it('handles malformed payload gracefully (does not throw)', async () => {
+    const { getChannelMessages } = await import('../octo/api.js');
+
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: () =>
+        Promise.resolve(
+          JSON.stringify({
+            messages: [
+              { from_uid: 'user1', payload: 'not-valid-base64-or-json', timestamp: 1, type: 1 },
+            ],
+          }),
+        ),
+    } as unknown as Response);
+
+    const result = await getChannelMessages({
+      apiUrl: 'https://api.example.com',
+      botToken: 'tok',
+      channelId: 'g1',
+      channelType: 2,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].payload).toBeUndefined(); // decoding failed, but no crash
+  });
+
+  it('returns empty array on HTTP error', async () => {
+    const { getChannelMessages } = await import('../octo/api.js');
+
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: () => Promise.resolve('server error'),
+    } as unknown as Response);
+
+    const result = await getChannelMessages({
+      apiUrl: 'https://api.example.com',
+      botToken: 'tok',
+      channelId: 'g1',
+      channelType: 2,
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it('returns empty array on network error (no throw)', async () => {
+    const { getChannelMessages } = await import('../octo/api.js');
+
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error('ECONNRESET'));
+
+    const result = await getChannelMessages({
+      apiUrl: 'https://api.example.com',
+      botToken: 'tok',
+      channelId: 'g1',
+      channelType: 2,
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it('returns empty array when messages field absent', async () => {
+    const { getChannelMessages } = await import('../octo/api.js');
+
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: () => Promise.resolve('{}'),
+    } as unknown as Response);
+
+    const result = await getChannelMessages({
+      apiUrl: 'https://api.example.com',
+      botToken: 'tok',
+      channelId: 'g1',
+      channelType: 2,
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it('sends correct request body (sync endpoint)', async () => {
+    const { getChannelMessages } = await import('../octo/api.js');
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: () => Promise.resolve('{"messages":[]}'),
+    } as unknown as Response);
+    globalThis.fetch = fetchMock;
+
+    await getChannelMessages({
+      apiUrl: 'https://api.example.com',
+      botToken: 'tok',
+      channelId: 'group-123',
+      channelType: 2,
+      limit: 50,
+      startMessageSeq: 100,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('https://api.example.com/v1/bot/messages/sync');
+    expect(init.method).toBe('POST');
+    const body = JSON.parse(init.body as string);
+    expect(body.channel_id).toBe('group-123');
+    expect(body.channel_type).toBe(2);
+    expect(body.limit).toBe(50);
+    expect(body.start_message_seq).toBe(100);
+    expect(body.pull_mode).toBe(1);
+  });
+
+  it('defaults limit to 20 when not specified', async () => {
+    const { getChannelMessages } = await import('../octo/api.js');
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: () => Promise.resolve('{"messages":[]}'),
+    } as unknown as Response);
+    globalThis.fetch = fetchMock;
+
+    await getChannelMessages({
+      apiUrl: 'https://api.example.com',
+      botToken: 'tok',
+      channelId: 'g1',
+      channelType: 2,
+    });
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+    expect(body.limit).toBe(20);
+  });
+});

--- a/src/__tests__/inbound.test.ts
+++ b/src/__tests__/inbound.test.ts
@@ -1,0 +1,345 @@
+/**
+ * Inbound message resolver tests — G1, G2, G11, G22 coverage.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  resolveContent,
+  resolveRichTextContent,
+  resolveMultipleForwardText,
+  resolveHistoricalMessagePlaceholder,
+  buildMediaUrl,
+  TEXT_FILE_EXTENSIONS,
+  INLINE_FILE_MAX_BYTES,
+} from '../inbound.js';
+import { MessageType, RICH_TEXT_BLOCK_IMAGE, RICH_TEXT_BLOCK_TEXT } from '../octo/types.js';
+import type { MessagePayload } from '../octo/types.js';
+
+const API_URL = 'https://api.example.com';
+
+// --- buildMediaUrl ---
+
+describe('buildMediaUrl', () => {
+  it('returns undefined for missing url', () => {
+    expect(buildMediaUrl(undefined, API_URL)).toBeUndefined();
+    expect(buildMediaUrl('', API_URL)).toBeUndefined();
+  });
+
+  it('passes through absolute http(s) URLs', () => {
+    expect(buildMediaUrl('https://cdn.x.com/a.jpg', API_URL)).toBe('https://cdn.x.com/a.jpg');
+    expect(buildMediaUrl('http://cdn.x.com/a.jpg', API_URL)).toBe('http://cdn.x.com/a.jpg');
+  });
+
+  it('strips file/preview/ prefix', () => {
+    expect(buildMediaUrl('file/preview/123/img.png', API_URL))
+      .toBe('https://api.example.com/file/123/img.png');
+  });
+
+  it('strips file/ prefix', () => {
+    expect(buildMediaUrl('file/abc/img.png', API_URL))
+      .toBe('https://api.example.com/file/abc/img.png');
+  });
+
+  it('handles raw storage path', () => {
+    expect(buildMediaUrl('abc/img.png', API_URL))
+      .toBe('https://api.example.com/file/abc/img.png');
+  });
+});
+
+// --- resolveContent (G1) ---
+
+describe('resolveContent: Text', () => {
+  it('returns plain content for text', () => {
+    const r = resolveContent({ type: MessageType.Text, content: 'hello' }, API_URL);
+    expect(r.text).toBe('hello');
+    expect(r.mediaUrl).toBeUndefined();
+  });
+
+  it('handles missing content', () => {
+    const r = resolveContent({ type: MessageType.Text }, API_URL);
+    expect(r.text).toBe('');
+  });
+});
+
+describe('resolveContent: Image', () => {
+  it('renders image with URL marker', () => {
+    const r = resolveContent({ type: MessageType.Image, url: 'file/abc.jpg' }, API_URL);
+    expect(r.text).toBe('[图片]\nhttps://api.example.com/file/abc.jpg');
+    expect(r.mediaUrl).toBe('https://api.example.com/file/abc.jpg');
+  });
+
+  it('renders image without URL gracefully', () => {
+    const r = resolveContent({ type: MessageType.Image }, API_URL);
+    expect(r.text).toBe('[图片]');
+    expect(r.mediaUrl).toBeUndefined();
+  });
+});
+
+describe('resolveContent: GIF / Voice / Video / File', () => {
+  it('GIF', () => {
+    const r = resolveContent({ type: MessageType.GIF, url: 'file/x.gif' }, API_URL);
+    expect(r.text).toContain('[GIF]');
+    expect(r.text).toContain('x.gif');
+  });
+
+  it('Voice (G22: URL marker only, transcription TBD)', () => {
+    const r = resolveContent({ type: MessageType.Voice, url: 'file/x.mp3' }, API_URL);
+    expect(r.text).toContain('[语音消息]');
+    expect(r.text).toContain('x.mp3');
+    expect(r.mediaUrl).toBeDefined();
+  });
+
+  it('Video', () => {
+    const r = resolveContent({ type: MessageType.Video, url: 'file/x.mp4' }, API_URL);
+    expect(r.text).toContain('[视频]');
+    expect(r.text).toContain('x.mp4');
+  });
+
+  it('File with name', () => {
+    const r = resolveContent({ type: MessageType.File, url: 'file/x.pdf', name: 'report.pdf' }, API_URL);
+    expect(r.text).toContain('[文件: report.pdf]');
+    expect(r.text).toContain('x.pdf');
+  });
+
+  it('File without name uses placeholder', () => {
+    const r = resolveContent({ type: MessageType.File, url: 'file/x.pdf' }, API_URL);
+    expect(r.text).toContain('[文件: 未知文件]');
+  });
+});
+
+describe('resolveContent: Location', () => {
+  it('renders coordinates when present', () => {
+    const r = resolveContent(
+      { type: MessageType.Location, latitude: 31.23, longitude: 121.47 } as unknown as MessagePayload,
+      API_URL,
+    );
+    expect(r.text).toBe('[位置信息: 31.23,121.47]');
+  });
+
+  it('renders placeholder without coordinates', () => {
+    const r = resolveContent({ type: MessageType.Location }, API_URL);
+    expect(r.text).toBe('[位置信息]');
+  });
+});
+
+describe('resolveContent: Card', () => {
+  it('renders name + uid', () => {
+    const r = resolveContent(
+      { type: MessageType.Card, name: 'Alice', uid: 'u-alice' } as unknown as MessagePayload,
+      API_URL,
+    );
+    expect(r.text).toBe('[名片: Alice (u-alice)]');
+  });
+
+  it('renders name only', () => {
+    const r = resolveContent({ type: MessageType.Card, name: 'Bob' } as unknown as MessagePayload, API_URL);
+    expect(r.text).toBe('[名片: Bob]');
+  });
+});
+
+describe('resolveContent: RichText (type=14)', () => {
+  it('expands content blocks to text + collects image URLs', () => {
+    const payload = {
+      type: MessageType.RichText,
+      content: [
+        { type: RICH_TEXT_BLOCK_TEXT, text: '看这张图：' },
+        { type: RICH_TEXT_BLOCK_IMAGE, url: 'file/img1.png' },
+        { type: RICH_TEXT_BLOCK_TEXT, text: '还有这张' },
+        { type: RICH_TEXT_BLOCK_IMAGE, url: 'file/img2.jpg' },
+      ],
+    } as unknown as MessagePayload;
+    const r = resolveContent(payload, API_URL);
+    expect(r.text).toContain('看这张图：');
+    expect(r.text).toContain('还有这张');
+    expect(r.mediaUrls).toHaveLength(2);
+    expect(r.mediaUrls?.[0]).toContain('img1.png');
+    expect(r.mediaUrl).toBe(r.mediaUrls?.[0]);
+  });
+
+  it('uses top-level plain when present (server-authoritative)', () => {
+    const payload = {
+      type: MessageType.RichText,
+      plain: 'authoritative plain text',
+      content: [{ type: RICH_TEXT_BLOCK_TEXT, text: 'block text' }],
+    } as unknown as MessagePayload;
+    const r = resolveContent(payload, API_URL);
+    expect(r.text).toBe('authoritative plain text');
+  });
+
+  it('falls back to block assembly when plain is empty', () => {
+    const payload = {
+      type: MessageType.RichText,
+      plain: '   ',
+      content: [{ type: RICH_TEXT_BLOCK_TEXT, text: 'block text' }],
+    } as unknown as MessagePayload;
+    const r = resolveContent(payload, API_URL);
+    expect(r.text).toBe('block text');
+  });
+
+  it('handles string content (legacy compat)', () => {
+    const payload = {
+      type: MessageType.RichText,
+      content: 'legacy string content',
+    } as unknown as MessagePayload;
+    const r = resolveContent(payload, API_URL);
+    expect(r.text).toBe('legacy string content');
+  });
+
+  it('skips malformed image url (non-string)', () => {
+    const payload = {
+      type: MessageType.RichText,
+      content: [
+        { type: RICH_TEXT_BLOCK_IMAGE, url: { malformed: true } },
+        { type: RICH_TEXT_BLOCK_IMAGE, url: 'file/good.png' },
+      ],
+    } as unknown as MessagePayload;
+    const r = resolveContent(payload, API_URL);
+    expect(r.mediaUrls).toHaveLength(1);
+    expect(r.mediaUrls?.[0]).toContain('good.png');
+  });
+
+  it('handles non-string text in text block', () => {
+    const payload = {
+      type: MessageType.RichText,
+      content: [
+        { type: RICH_TEXT_BLOCK_TEXT, text: { bad: 'object' } },
+        { type: RICH_TEXT_BLOCK_TEXT, text: 'ok' },
+      ],
+    } as unknown as MessagePayload;
+    const r = resolveContent(payload, API_URL);
+    // Should not produce "[object Object]"
+    expect(r.text).not.toContain('[object Object]');
+    expect(r.text).toContain('ok');
+  });
+});
+
+describe('resolveContent: MultipleForward (type=11)', () => {
+  it('expands forwarded transcript with user names', () => {
+    const payload = {
+      type: MessageType.MultipleForward,
+      users: [
+        { uid: 'u1', name: 'Alice' },
+        { uid: 'u2', name: 'Bob' },
+      ],
+      msgs: [
+        { from_uid: 'u1', payload: { type: MessageType.Text, content: 'hello' } },
+        { from_uid: 'u2', payload: { type: MessageType.Text, content: 'world' } },
+        { from_uid: 'u1', payload: { type: MessageType.Image, url: 'file/img.jpg' } },
+      ],
+    } as unknown as MessagePayload;
+    const r = resolveContent(payload, API_URL);
+    expect(r.text).toContain('[合并转发: 聊天记录]');
+    expect(r.text).toContain('Alice: hello');
+    expect(r.text).toContain('Bob: world');
+    expect(r.text).toContain('Alice: [图片]');
+    expect(r.text).toContain('img.jpg');
+  });
+
+  it('handles nested MultipleForward', () => {
+    const nested = {
+      type: MessageType.MultipleForward,
+      users: [{ uid: 'u3', name: 'Carol' }],
+      msgs: [{ from_uid: 'u3', payload: { type: MessageType.Text, content: 'inner' } }],
+    };
+    const payload = {
+      type: MessageType.MultipleForward,
+      users: [{ uid: 'u1', name: 'Alice' }],
+      msgs: [
+        { from_uid: 'u1', payload: nested },
+      ],
+    } as unknown as MessagePayload;
+    const r = resolveContent(payload, API_URL);
+    expect(r.text).toContain('Alice: [合并转发]');
+    expect(r.text).toContain('Carol: inner');
+  });
+
+  it('falls back to uid when user name missing', () => {
+    const payload = {
+      type: MessageType.MultipleForward,
+      users: [],
+      msgs: [{ from_uid: 'unknown-uid', payload: { type: MessageType.Text, content: 'lone' } }],
+    } as unknown as MessagePayload;
+    const r = resolveContent(payload, API_URL);
+    expect(r.text).toContain('unknown-uid: lone');
+  });
+});
+
+describe('resolveContent: unknown type', () => {
+  it('falls back to content or url', () => {
+    const r1 = resolveContent({ type: 999, content: 'fallback' } as unknown as MessagePayload, API_URL);
+    expect(r1.text).toBe('fallback');
+    const r2 = resolveContent({ type: 999, url: 'https://x.com' } as unknown as MessagePayload, API_URL);
+    expect(r2.text).toBe('https://x.com');
+    const r3 = resolveContent({ type: 999 } as unknown as MessagePayload, API_URL);
+    expect(r3.text).toBe('[消息]');
+  });
+});
+
+describe('resolveContent: undefined payload', () => {
+  it('returns empty text', () => {
+    const r = resolveContent(undefined, API_URL);
+    expect(r.text).toBe('');
+  });
+});
+
+// --- resolveHistoricalMessagePlaceholder (G4) ---
+
+describe('resolveHistoricalMessagePlaceholder (G4)', () => {
+  it('returns placeholder for each non-text type', () => {
+    expect(resolveHistoricalMessagePlaceholder(MessageType.Image)).toBe('[图片]');
+    expect(resolveHistoricalMessagePlaceholder(MessageType.GIF)).toBe('[GIF]');
+    expect(resolveHistoricalMessagePlaceholder(MessageType.Voice)).toBe('[语音消息]');
+    expect(resolveHistoricalMessagePlaceholder(MessageType.Video)).toBe('[视频]');
+    expect(resolveHistoricalMessagePlaceholder(MessageType.File, 'doc.pdf')).toBe('[文件: doc.pdf]');
+    expect(resolveHistoricalMessagePlaceholder(MessageType.Location)).toBe('[位置信息]');
+    expect(resolveHistoricalMessagePlaceholder(MessageType.Card)).toBe('[名片]');
+    expect(resolveHistoricalMessagePlaceholder(MessageType.MultipleForward)).toBe('[合并转发]');
+    expect(resolveHistoricalMessagePlaceholder(MessageType.RichText)).toBe('[图文消息]');
+  });
+
+  it('returns empty for Text (use content directly)', () => {
+    expect(resolveHistoricalMessagePlaceholder(MessageType.Text)).toBe('');
+  });
+
+  it('returns empty for unknown type', () => {
+    expect(resolveHistoricalMessagePlaceholder(undefined)).toBe('');
+    expect(resolveHistoricalMessagePlaceholder(999)).toBe('');
+  });
+});
+
+// --- TEXT_FILE_EXTENSIONS (G2) ---
+
+describe('TEXT_FILE_EXTENSIONS (G2)', () => {
+  it('includes common code/text extensions', () => {
+    for (const ext of ['py', 'ts', 'js', 'json', 'md', 'csv', 'yaml', 'sh', 'rs', 'go']) {
+      expect(TEXT_FILE_EXTENSIONS.has(ext)).toBe(true);
+    }
+  });
+
+  it('excludes binary types', () => {
+    for (const ext of ['png', 'jpg', 'pdf', 'zip', 'exe', 'mp4']) {
+      expect(TEXT_FILE_EXTENSIONS.has(ext)).toBe(false);
+    }
+  });
+
+  it('inline cap is 20KB', () => {
+    expect(INLINE_FILE_MAX_BYTES).toBe(20 * 1024);
+  });
+});
+
+// --- Direct helpers ---
+
+describe('resolveRichTextContent', () => {
+  it('handles empty payload', () => {
+    const r = resolveRichTextContent({}, API_URL);
+    expect(r.text).toBe('');
+    expect(r.mediaUrls).toEqual([]);
+  });
+});
+
+describe('resolveMultipleForwardText', () => {
+  it('returns header only when msgs empty', () => {
+    const r = resolveMultipleForwardText({ users: [], msgs: [] }, API_URL);
+    expect(r).toBe('[合并转发: 聊天记录]');
+  });
+});

--- a/src/__tests__/session-router.test.ts
+++ b/src/__tests__/session-router.test.ts
@@ -155,15 +155,18 @@ describe('SessionRouter', () => {
 
   // --- Non-text message ---
 
-  it('replies to non-text message and returns shouldProcess=false', async () => {
+  it('now passes non-text messages through (G1: handled by inbound.resolveContent)', async () => {
     const msg = makeMsg({
       channel_type: ChannelType.DM,
-      payload: { type: MessageType.Image },
+      payload: { type: MessageType.Image, url: 'file/abc.jpg' },
     });
     const result = await router.route(msg);
     expect(result).not.toBeNull();
-    expect(result!.shouldProcess).toBe(false);
-    expect(sendMessage).toHaveBeenCalledWith(
+    // G1: image messages are no longer rejected — they flow through to the
+    // pipeline where resolveContent renders them as "[图片] <url>".
+    expect(result!.shouldProcess).toBe(true);
+    // No “不支持” auto-reply.
+    expect(sendMessage).not.toHaveBeenCalledWith(
       expect.objectContaining({ content: '暂不支持此类消息，请发送文字' }),
     );
   });

--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -1,0 +1,487 @@
+/**
+ * Inbound message resolver — converts BotMessage payload into LLM-friendly text.
+ *
+ * Each MessageType is rendered as either:
+ *   - plain text (for Text)
+ *   - text + media URL marker (for Image/GIF/Voice/Video/File)
+ *   - structured placeholder (for Location/Card)
+ *   - recursively expanded (for MultipleForward)
+ *   - text + image URLs (for RichText)
+ *
+ * For text-extension files (.py/.ts/.md/.json etc.) the contents are inlined
+ * up to a small byte budget (G2) so the agent can actually answer questions
+ * about the file rather than just see its URL.
+ */
+
+import { createWriteStream, statSync } from 'node:fs';
+import { mkdir, unlink, readdir, stat } from 'node:fs/promises';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import type { MessagePayload, ForwardMessage, ForwardUser } from './octo/types.js';
+import { MessageType, RICH_TEXT_BLOCK_IMAGE, RICH_TEXT_BLOCK_TEXT, RICH_TEXT_IMAGE_PLACEHOLDER } from './octo/types.js';
+
+// ─── Configuration ─────────────────────────────────────────────────────────
+
+/** Extensions we will try to inline (text-like content). */
+export const TEXT_FILE_EXTENSIONS = new Set([
+  'txt', 'md', 'csv', 'json', 'xml', 'yaml', 'yml',
+  'log', 'py', 'js', 'ts', 'tsx', 'jsx', 'mjs', 'cjs',
+  'go', 'java', 'rs', 'c', 'h', 'cpp', 'hpp', 'cs', 'rb', 'php',
+  'html', 'htm', 'css', 'scss', 'sass', 'less',
+  'sh', 'bash', 'zsh', 'fish', 'ps1',
+  'toml', 'ini', 'conf', 'cfg', 'env',
+  'sql', 'graphql', 'gql', 'proto',
+]);
+
+/** Maximum bytes to inline a text file in the LLM prompt (G2). */
+export const INLINE_FILE_MAX_BYTES = 20 * 1024;
+
+/** Maximum bytes to download for any text file (inline or temp). */
+const MAX_FILE_DOWNLOAD_BYTES = 5 * 1024 * 1024; // 5 MB
+
+/** HTTP timeout for file download. */
+const FILE_DOWNLOAD_TIMEOUT_MS = 30_000;
+
+/** Temp directory for non-inlinable downloads. */
+const TEMP_DIR = join('/tmp', 'cc-channel-octo', 'inbound-files');
+
+// ─── Public types ──────────────────────────────────────────────────────────
+
+/**
+ * Result of resolving a single inbound BotMessage payload.
+ *
+ * `text` is the LLM-facing rendering — always present, never empty for
+ * supported types. `mediaUrl` exposes any single primary attachment URL,
+ * `mediaUrls` exposes all attachments for RichText (which can carry several).
+ */
+export interface ResolvedContent {
+  /** LLM-facing text (description + URL markers as appropriate). */
+  text: string;
+  /** Primary media URL (first one for RichText). */
+  mediaUrl?: string;
+  /** All embedded media URLs (RichText only — text/image types use mediaUrl). */
+  mediaUrls?: string[];
+  /** When true the agent received the file's literal contents inline. */
+  inlinedFile?: boolean;
+  /** Local temp path when a non-inlined file was downloaded for the agent. */
+  localFilePath?: string;
+}
+
+// ─── URL helpers ───────────────────────────────────────────────────────────
+
+/** Resolve a relative storage path against the bot API base. */
+export function buildMediaUrl(relUrl?: string, apiUrl?: string): string | undefined {
+  if (!relUrl) return undefined;
+  if (relUrl.startsWith('http://') || relUrl.startsWith('https://')) return relUrl;
+  let storagePath = relUrl;
+  if (storagePath.startsWith('file/preview/')) {
+    storagePath = storagePath.substring('file/preview/'.length);
+  } else if (storagePath.startsWith('file/')) {
+    storagePath = storagePath.substring('file/'.length);
+  }
+  const baseUrl = apiUrl?.replace(/\/+$/, '') ?? '';
+  return `${baseUrl}/file/${storagePath}`;
+}
+
+/** Guess MIME type from filename extension.
+ *  Kept for future use (download path may need to override server content-type for G22). */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function guessMime(pathOrName?: string, fallback = 'application/octet-stream'): string {
+  if (!pathOrName) return fallback;
+  const ext = pathOrName.split('.').pop()?.toLowerCase() ?? '';
+  const map: Record<string, string> = {
+    jpg: 'image/jpeg', jpeg: 'image/jpeg', png: 'image/png',
+    gif: 'image/gif', webp: 'image/webp', svg: 'image/svg+xml', bmp: 'image/bmp',
+    mp3: 'audio/mpeg', ogg: 'audio/ogg', wav: 'audio/wav', m4a: 'audio/mp4',
+    mp4: 'video/mp4', mov: 'video/quicktime', webm: 'video/webm',
+    pdf: 'application/pdf', zip: 'application/zip',
+    txt: 'text/plain', json: 'application/json', csv: 'text/csv', md: 'text/markdown',
+  };
+  return map[ext] ?? fallback;
+}
+
+// ─── RichText (type=14) expansion ─────────────────────────────────────────
+
+function normalizeRichTextBlocks(content: unknown): Array<Record<string, unknown>> {
+  if (Array.isArray(content)) {
+    return content.filter((b): b is Record<string, unknown> => !!b && typeof b === 'object');
+  }
+  if (typeof content === 'string' && content) {
+    return [{ type: RICH_TEXT_BLOCK_TEXT, text: content }];
+  }
+  return [];
+}
+
+function buildRichTextPlain(blocks: Array<Record<string, unknown>>): string {
+  let out = '';
+  for (const blk of blocks) {
+    if (blk.type === RICH_TEXT_BLOCK_IMAGE) {
+      out += RICH_TEXT_IMAGE_PLACEHOLDER;
+    } else if (blk.type === RICH_TEXT_BLOCK_TEXT) {
+      // Guard against non-string text (would render as "[object Object]")
+      out += typeof blk.text === 'string' ? blk.text : '';
+    } else if (typeof blk.text === 'string' && blk.text) {
+      out += blk.text;
+    }
+  }
+  return out;
+}
+
+/**
+ * Expand a RichText (type=14) payload into `{ text, mediaUrls[] }`.
+ *
+ * Mirrors upstream's MultipleForward expansion pattern:
+ *   - text: prefer top-level `plain` (server-authoritative); else assemble
+ *     from content blocks (text → text, image → `[图片]` placeholder)
+ *   - mediaUrls: collect all image-block `url` (sanitized for string type)
+ */
+export function resolveRichTextContent(
+  payload: { content?: unknown; plain?: unknown },
+  apiUrl?: string,
+): { text: string; mediaUrls: string[] } {
+  const blocks = normalizeRichTextBlocks(payload?.content);
+  const mediaUrls: string[] = [];
+  for (const blk of blocks) {
+    // Defensive: only collect string URLs so a malformed `{url: {}}` cannot
+    // crash buildMediaUrl downstream.
+    if (blk.type === RICH_TEXT_BLOCK_IMAGE && typeof blk.url === 'string' && blk.url) {
+      const full = buildMediaUrl(blk.url, apiUrl);
+      if (full) mediaUrls.push(full);
+    }
+  }
+  const topPlain = typeof payload?.plain === 'string' ? payload.plain : '';
+  const text = topPlain.trim() !== '' ? topPlain : buildRichTextPlain(blocks);
+  return { text, mediaUrls };
+}
+
+// ─── Inner message rendering (MultipleForward children) ──────────────────
+
+function resolveInnerMessageText(payload: ForwardMessage['payload'], apiUrl?: string): string {
+  if (!payload) return '';
+  const fullUrl = buildMediaUrl(payload.url, apiUrl);
+  switch (payload.type) {
+    case MessageType.Text:
+      return payload.content ?? '';
+    case MessageType.Image:
+      return fullUrl ? `[图片]\n${fullUrl}` : '[图片]';
+    case MessageType.GIF:
+      return fullUrl ? `[GIF]\n${fullUrl}` : '[GIF]';
+    case MessageType.Voice:
+      return fullUrl ? `[语音]\n${fullUrl}` : '[语音]';
+    case MessageType.Video:
+      return fullUrl ? `[视频]\n${fullUrl}` : '[视频]';
+    case MessageType.Location:
+      return '[位置信息]';
+    case MessageType.Card:
+      return '[名片]';
+    case MessageType.File: {
+      const label = payload.name ? `[文件: ${payload.name}]` : '[文件]';
+      return fullUrl ? `${label}\n${fullUrl}` : label;
+    }
+    case MessageType.MultipleForward:
+      return '[合并转发]';
+    case MessageType.RichText: {
+      const rt = resolveRichTextContent(payload as { content?: unknown; plain?: unknown }, apiUrl);
+      return rt.text || '[图文消息]';
+    }
+    default:
+      return payload.content ?? '[消息]';
+  }
+}
+
+/** Expand a MultipleForward payload into a readable transcript. */
+export function resolveMultipleForwardText(
+  payload: { users?: ForwardUser[]; msgs?: ForwardMessage[] },
+  apiUrl?: string,
+): string {
+  const users: ForwardUser[] = payload?.users ?? [];
+  const msgs: ForwardMessage[] = payload?.msgs ?? [];
+  const userMap = new Map<string, string>();
+  for (const u of users) {
+    if (u.uid && u.name) userMap.set(u.uid, u.name);
+  }
+  const lines: string[] = ['[合并转发: 聊天记录]'];
+  for (const m of msgs) {
+    const senderName = userMap.get(m.from_uid) ?? m.from_uid;
+    if (m.payload?.type === MessageType.MultipleForward) {
+      const nested = resolveMultipleForwardText(m.payload, apiUrl);
+      lines.push(`${senderName}: [合并转发]`);
+      lines.push(nested);
+    } else {
+      lines.push(`${senderName}: ${resolveInnerMessageText(m.payload, apiUrl)}`);
+    }
+  }
+  return lines.join('\n');
+}
+
+// ─── Core resolver ─────────────────────────────────────────────────────────
+
+/**
+ * Render an inbound payload to LLM-friendly text + optional media metadata.
+ *
+ * This is the synchronous part — file inlining (which requires HTTP) is a
+ * separate async step done by `tryInlineFile()`.
+ */
+export function resolveContent(payload: MessagePayload | undefined, apiUrl?: string): ResolvedContent {
+  if (!payload) return { text: '' };
+
+  switch (payload.type) {
+    case MessageType.Text:
+      return { text: payload.content ?? '' };
+
+    case MessageType.Image: {
+      const imgUrl = buildMediaUrl(payload.url, apiUrl);
+      return {
+        text: imgUrl ? `[图片]\n${imgUrl}` : '[图片]',
+        mediaUrl: imgUrl,
+      };
+    }
+
+    case MessageType.GIF: {
+      const url = buildMediaUrl(payload.url, apiUrl);
+      return {
+        text: url ? `[GIF]\n${url}` : '[GIF]',
+        mediaUrl: url,
+      };
+    }
+
+    case MessageType.Voice: {
+      const url = buildMediaUrl(payload.url, apiUrl);
+      return {
+        // G22: language model receives the URL as a marker; transcription is
+        // out of scope for v0.2 and tracked separately.
+        text: url ? `[语音消息]\n${url}` : '[语音消息]',
+        mediaUrl: url,
+      };
+    }
+
+    case MessageType.Video: {
+      const url = buildMediaUrl(payload.url, apiUrl);
+      return {
+        text: url ? `[视频]\n${url}` : '[视频]',
+        mediaUrl: url,
+      };
+    }
+
+    case MessageType.File: {
+      const url = buildMediaUrl(payload.url, apiUrl);
+      const fileName = typeof payload.name === 'string' ? payload.name : '未知文件';
+      return {
+        text: url ? `[文件: ${fileName}]\n${url}` : `[文件: ${fileName}]`,
+        mediaUrl: url,
+      };
+    }
+
+    case MessageType.Location: {
+      const lat = (payload.latitude ?? payload.lat) as number | undefined;
+      const lng = (payload.longitude ?? payload.lng ?? payload.lon) as number | undefined;
+      return {
+        text: lat != null && lng != null ? `[位置信息: ${lat},${lng}]` : '[位置信息]',
+      };
+    }
+
+    case MessageType.Card: {
+      const cardName = typeof payload.name === 'string' ? payload.name : '未知';
+      const cardUid = typeof payload.uid === 'string' ? payload.uid : '';
+      return {
+        text: cardUid ? `[名片: ${cardName} (${cardUid})]` : `[名片: ${cardName}]`,
+      };
+    }
+
+    case MessageType.MultipleForward: {
+      return {
+        text: resolveMultipleForwardText(
+          payload as unknown as { users?: ForwardUser[]; msgs?: ForwardMessage[] },
+          apiUrl,
+        ),
+      };
+    }
+
+    case MessageType.RichText: {
+      const rt = resolveRichTextContent(payload as unknown as { content?: unknown; plain?: unknown }, apiUrl);
+      return {
+        text: rt.text,
+        ...(rt.mediaUrls.length > 0 ? { mediaUrl: rt.mediaUrls[0], mediaUrls: rt.mediaUrls } : {}),
+      };
+    }
+
+    default:
+      return { text: payload.content ?? payload.url ?? '[消息]' };
+  }
+}
+
+/** Placeholder text used when reconstructing a historical (API-backfilled) message. */
+export function resolveHistoricalMessagePlaceholder(type?: number, name?: string): string {
+  switch (type) {
+    case MessageType.Image: return '[图片]';
+    case MessageType.GIF: return '[GIF]';
+    case MessageType.Voice: return '[语音消息]';
+    case MessageType.Video: return '[视频]';
+    case MessageType.File: return `[文件: ${name ?? '未知文件'}]`;
+    case MessageType.Location: return '[位置信息]';
+    case MessageType.Card: return '[名片]';
+    case MessageType.MultipleForward: return '[合并转发]';
+    case MessageType.RichText: return '[图文消息]';
+    case MessageType.Text:
+    default:
+      return '';
+  }
+}
+
+// ─── File inlining (G2) ────────────────────────────────────────────────────
+
+/** Best-effort cleanup of temp files older than 1 hour. */
+async function cleanupOldTempFiles(): Promise<void> {
+  try {
+    const entries = await readdir(TEMP_DIR);
+    const cutoff = Date.now() - 60 * 60 * 1000;
+    for (const entry of entries) {
+      try {
+        const filePath = join(TEMP_DIR, entry);
+        const info = await stat(filePath);
+        if (info.mtimeMs < cutoff) await unlink(filePath);
+      } catch {
+        /* best effort */
+      }
+    }
+  } catch {
+    /* best effort */
+  }
+}
+
+function extractExtension(url: string, fallbackName?: string): string {
+  try {
+    const pathname = new URL(url).pathname;
+    const ext = pathname.split('.').pop()?.toLowerCase() ?? '';
+    if (ext && ext.length <= 8) return ext;
+  } catch {
+    /* fall through */
+  }
+  return fallbackName?.split('.').pop()?.toLowerCase() ?? '';
+}
+
+/**
+ * Attempt to inline a text file's contents, or download it to a temp path.
+ *
+ * Returns:
+ *   - `{ inlined: text }` when the file is text-extension and under the inline cap
+ *   - `{ tempPath }`      when the file is text-extension but exceeds the cap
+ *                         (downloaded to disk so the agent can read it)
+ *   - `{ description }`   when the file isn't text or download failed
+ */
+export async function tryResolveFile(params: {
+  url: string;
+  botToken: string;
+  filename: string;
+  knownSize?: number;
+}): Promise<
+  | { inlined: string }
+  | { tempPath: string }
+  | { description: string }
+> {
+  const { url, botToken, filename, knownSize } = params;
+  const ext = extractExtension(url, filename);
+  if (!TEXT_FILE_EXTENSIONS.has(ext)) {
+    // Non-text — surface size info if known
+    return {
+      description: knownSize != null
+        ? `[文件: ${filename} (${formatBytes(knownSize)})]`
+        : `[文件: ${filename}]`,
+    };
+  }
+
+  // Skip download if known to exceed hard cap
+  if (knownSize != null && knownSize > MAX_FILE_DOWNLOAD_BYTES) {
+    return { description: `[文件: ${filename} (${formatBytes(knownSize)}) - 超过下载上限 ${formatBytes(MAX_FILE_DOWNLOAD_BYTES)}]` };
+  }
+
+  // Download with streaming + size guard
+  try {
+    const resp = await fetch(url, {
+      headers: { Authorization: `Bearer ${botToken}` },
+      signal: AbortSignal.timeout(FILE_DOWNLOAD_TIMEOUT_MS),
+    });
+    if (!resp.ok) {
+      return { description: `[文件: ${filename} - 下载失败 HTTP ${resp.status}]` };
+    }
+    const body = resp.body;
+    if (!body) {
+      return { description: `[文件: ${filename} - 响应无内容]` };
+    }
+
+    // Inline path: read up to INLINE_FILE_MAX_BYTES, fall through to temp on overflow
+    const reader = (body as unknown as { getReader: () => ReadableStreamDefaultReader<Uint8Array> }).getReader();
+    const inlineChunks: Uint8Array[] = [];
+    let inlineBytes = 0;
+    let exceededInline = false;
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      inlineBytes += value.byteLength;
+      if (inlineBytes > INLINE_FILE_MAX_BYTES) {
+        exceededInline = true;
+        // Continue draining for the temp path
+        inlineChunks.push(value);
+        if (inlineBytes > MAX_FILE_DOWNLOAD_BYTES) {
+          try { reader.cancel(); } catch { /* ignore */ }
+          return { description: `[文件: ${filename} (${formatBytes(inlineBytes)}) - 超过下载上限]` };
+        }
+        // Drain rest into chunks for temp write
+        break;
+      }
+      inlineChunks.push(value);
+    }
+
+    if (!exceededInline) {
+      // Inline the content
+      const buf = Buffer.concat(inlineChunks.map((c) => Buffer.from(c)));
+      return { inlined: buf.toString('utf-8') };
+    }
+
+    // Drain remaining body into the temp file
+    await mkdir(TEMP_DIR, { recursive: true });
+    cleanupOldTempFiles().catch(() => {});
+    const safeName = filename.replace(/[^a-zA-Z0-9._-]/g, '_') || 'file';
+    const tempPath = join(TEMP_DIR, `${randomUUID()}-${safeName}`);
+    const ws = createWriteStream(tempPath);
+    try {
+      for (const chunk of inlineChunks) {
+        if (!ws.write(chunk)) await new Promise<void>((r) => ws.once('drain', r));
+      }
+      let totalBytes = inlineBytes;
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        totalBytes += value.byteLength;
+        if (totalBytes > MAX_FILE_DOWNLOAD_BYTES) {
+          try { reader.cancel(); } catch { /* ignore */ }
+          ws.destroy();
+          await unlink(tempPath).catch(() => {});
+          return { description: `[文件: ${filename} (${formatBytes(totalBytes)}) - 超过下载上限]` };
+        }
+        if (!ws.write(value)) await new Promise<void>((r) => ws.once('drain', r));
+      }
+      ws.end();
+      await new Promise<void>((resolve, reject) => {
+        ws.on('finish', () => resolve());
+        ws.on('error', reject);
+      });
+      const sizeInfo = statSync(tempPath).size;
+      return { tempPath, ...({ description: `[文件: ${filename} (${formatBytes(sizeInfo)}) - 已下载到 ${tempPath}]` } as { description?: string }) };
+    } catch (err) {
+      ws.destroy();
+      await unlink(tempPath).catch(() => {});
+      return { description: `[文件: ${filename} - 下载错误: ${String(err)}]` };
+    }
+  } catch (err) {
+    return { description: `[文件: ${filename} - ${String(err).includes('TimeoutError') ? '下载超时' : '网络错误'}]` };
+  }
+}
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n}B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)}KB`;
+  if (n < 1024 * 1024 * 1024) return `${(n / (1024 * 1024)).toFixed(1)}MB`;
+  return `${(n / (1024 * 1024 * 1024)).toFixed(1)}GB`;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,9 +14,11 @@ import { SessionRouter } from './session-router.js';
 import { GroupContext } from './group-context.js';
 import { queryAgent } from './agent-bridge.js';
 import { StreamRelay } from './stream-relay.js';
-import { sendMessage, sendReadReceipt } from './octo/api.js';
+import { sendMessage, sendReadReceipt, getChannelMessages } from './octo/api.js';
+import type { HistoricalMessage } from './octo/api.js';
 import { ChannelType, MessageType } from './octo/types.js';
 import type { BotMessage } from './octo/types.js';
+import { resolveContent, tryResolveFile, resolveHistoricalMessagePlaceholder } from './inbound.js';
 import { join } from 'node:path';
 
 async function main(): Promise<void> {
@@ -121,20 +123,55 @@ async function handleMessage(
         await groupContext.refreshMembers(channelId, config.apiUrl, config.botToken);
         contextStr = groupContext.buildContext(channelId);
         // Cache current message AFTER buildContext so it only appears in
-        // [Current message], not duplicated in [Group context].
-        if (msg.payload.type === MessageType.Text && msg.payload.content) {
+        // [Current message], not duplicated in [Group context]. We render
+        // a short summary for non-text payloads so context still shows them.
+        const contextSummary = renderMessageForContext(msg, config.apiUrl);
+        if (contextSummary) {
           groupContext.pushMessage(
             channelId,
             msg.from_uid,
             msg.from_name ?? msg.from_uid,
-            msg.payload.content,
+            contextSummary,
             msg.timestamp,
           );
         }
       }
 
+      // --- G1: Resolve the inbound payload into LLM-friendly text ---
+      // Text messages use the router's cleanContent (with @bot stripping);
+      // non-text payloads go through resolveContent for type-aware rendering.
+      const resolved = resolveContent(msg.payload, config.apiUrl);
+      let bodyText = result.cleanContent ?? resolved.text;
+
+      // G2: Inline text-file content for File payloads when feasible.
+      if (
+        msg.payload.type === MessageType.File &&
+        resolved.mediaUrl
+      ) {
+        const filename = typeof msg.payload.name === 'string' ? msg.payload.name : '未知文件';
+        const knownSize = typeof msg.payload.size === 'number' ? msg.payload.size : undefined;
+        try {
+          const fileResult = await tryResolveFile({
+            url: resolved.mediaUrl,
+            botToken: config.botToken,
+            filename,
+            knownSize,
+          });
+          if ('inlined' in fileResult) {
+            bodyText = `[文件: ${filename}]\n\n--- 文件内容 ---\n${fileResult.inlined}\n--- 文件结束 ---`;
+          } else if ('tempPath' in fileResult) {
+            bodyText = `[文件: ${filename}]\n本地路径: ${fileResult.tempPath}\n远程 URL: ${resolved.mediaUrl}`;
+          } else {
+            bodyText = fileResult.description;
+          }
+        } catch (err) {
+          console.error(`[cc-channel-octo] inline file failed: ${String(err)}`);
+          // Keep the default bodyText from resolveContent.
+        }
+      }
+
       // --- Build history prefix BEFORE appending current message (G10: segmented) ---
-      const userContent = msg.payload.content ?? '';
+      const userContent = msg.payload.content ?? bodyText;
 
       // G3: Extract quoted/replied message content for LLM context.
       //
@@ -168,9 +205,39 @@ async function handleMessage(
       // Note: quotePrefix is added to LLM input only — store.appendUser below
       // persists the raw user content without the quote prefix to avoid prefix
       // duplication on conversation replay.
-      const userContentForLLM = quotePrefix + (result.cleanContent ?? userContent);
+      const userContentForLLM = quotePrefix + bodyText;
 
-      const historyPrefix = store.buildSegmentedHistoryPrefix(sessionKey, config.context.historyLimit);
+      // G4: Backfill history from API when local cache is empty for groups.
+      // Only triggered on first interaction with a group (cold start) to avoid
+      // duplicate API calls; checked via a sentinel marker stored in-memory.
+      let historyPrefix = store.buildSegmentedHistoryPrefix(sessionKey, config.context.historyLimit);
+      if (
+        isGroup &&
+        !historyPrefix &&
+        !backfilledSessions.has(sessionKey) &&
+        msg.channel_id &&
+        msg.channel_type !== undefined
+      ) {
+        backfilledSessions.add(sessionKey);
+        try {
+          const apiMessages = await getChannelMessages({
+            apiUrl: config.apiUrl,
+            botToken: config.botToken,
+            channelId: msg.channel_id,
+            channelType: msg.channel_type,
+            limit: Math.min(config.context.historyLimit, 100),
+          });
+          if (apiMessages.length > 0) {
+            // Persist into local store so subsequent turns hit cache,
+            // and rebuild historyPrefix with the enriched data.
+            seedHistoryFromApi(store, sessionKey, apiMessages, msg.from_uid);
+            historyPrefix = store.buildSegmentedHistoryPrefix(sessionKey, config.context.historyLimit);
+          }
+        } catch (err) {
+          console.error(`[cc-channel-octo] G4 backfill failed for ${sessionKey}: ${String(err)}`);
+        }
+      }
+
       store.appendUser(sessionKey, userContent, msg.message_seq);
 
       // --- Query agent with structural role separation (Q3 fix) ---
@@ -235,16 +302,74 @@ async function handleMessage(
     }
   });
 
-  // Cache non-processed group text messages for context.
+  // Cache non-processed group messages for context.
   // G21: skip stream update messages — only cache the final (non-stream) message.
-  if (!wasProcessed && isGroup && !msg.streamOn && msg.payload.type === MessageType.Text && msg.payload.content) {
-    groupContext.pushMessage(
-      channelId,
-      msg.from_uid,
-      msg.from_name ?? msg.from_uid,
-      msg.payload.content,
-      msg.timestamp,
-    );
+  // G1: cache non-text payloads as type summaries so [Group context] shows them.
+  if (!wasProcessed && isGroup && !msg.streamOn) {
+    const summary = renderMessageForContext(msg, config.apiUrl);
+    if (summary) {
+      groupContext.pushMessage(
+        channelId,
+        msg.from_uid,
+        msg.from_name ?? msg.from_uid,
+        summary,
+        msg.timestamp,
+      );
+    }
+  }
+}
+
+// ─── G1/G11 helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Compact rendering of a message for the rolling [Group context] cache.
+ *
+ * Text → raw content (cheap, faithful).
+ * Non-text → short placeholder via resolveContent so the agent at least
+ * sees "某人: [图片]" instead of nothing.
+ */
+function renderMessageForContext(msg: BotMessage, apiUrl: string): string {
+  if (msg.payload.type === MessageType.Text) {
+    return msg.payload.content ?? '';
+  }
+  // For non-text use the resolved text (already short for media/cards).
+  const resolved = resolveContent(msg.payload, apiUrl);
+  return resolved.text;
+}
+
+/** Sessions for which G4 cold-start backfill has already run. */
+const backfilledSessions = new Set<string>();
+
+/**
+ * Seed local SessionStore with messages fetched from the WuKongIM sync API.
+ * Skips the current user's bot (replies come from the agent path) and
+ * persists each historical message in chronological order.
+ */
+function seedHistoryFromApi(
+  store: SessionStore,
+  sessionKey: string,
+  apiMessages: HistoricalMessage[],
+  currentUserUid: string,
+): void {
+  // Older messages first — sync API returns newest-first depending on pull_mode.
+  const ordered = apiMessages
+    .slice()
+    .sort((a, b) => (a.message_seq ?? 0) - (b.message_seq ?? 0));
+  for (const m of ordered) {
+    const placeholder = resolveHistoricalMessagePlaceholder(m.type, m.name);
+    const content = m.content && m.content.trim() !== ''
+      ? m.content
+      : placeholder;
+    if (!content) continue;
+    // We don't know which side of the conversation each historical message
+    // came from without the bot uid, so heuristic: from_uid matching the
+    // current message's sender = user; everyone else = user too. The agent
+    // sees the senders inside the rendered history via the [user]/[assistant]
+    // labels we'll wire up later. For now, all historical messages are stored
+    // as user role to preserve conversation flavor without falsely claiming
+    // any of them came from us.
+    void currentUserUid;
+    store.appendUser(sessionKey, content, m.message_seq);
   }
 }
 

--- a/src/octo/api.ts
+++ b/src/octo/api.ts
@@ -362,3 +362,86 @@ export async function searchSpaceMembers(params: {
     `/v1/bot/space/members${qs ? `?${qs}` : ""}`,
   );
 }
+
+// ─── Channel Message History (G4) ──────────────────────────────────────────
+
+/** Historical message returned by /v1/bot/messages/sync. */
+export interface HistoricalMessage {
+  from_uid: string;
+  from_name?: string;
+  content?: string;
+  timestamp: number;
+  message_id?: string;
+  message_seq?: number;
+  /** Numeric MessageType (1=Text, 2=Image, 8=File, 14=RichText, etc.) */
+  type?: number;
+  url?: string;
+  name?: string;
+  /** Decoded full payload (server sends base64, we decode + JSON.parse). */
+  payload?: Record<string, unknown>;
+}
+
+/**
+ * Pull recent messages for a channel via the WuKongIM sync endpoint.
+ *
+ * Used by G4 to backfill conversation history when the local SQLite cache is
+ * empty or sparse (e.g. cold start, restored snapshot). The server payload is
+ * base64-encoded JSON; we decode it inline so callers get a clean object.
+ *
+ * Returns `[]` on any failure — the agent runs fine without history.
+ */
+export async function getChannelMessages(params: {
+  apiUrl: string;
+  botToken: string;
+  channelId: string;
+  channelType: number;
+  limit?: number;
+  startMessageSeq?: number;
+  endMessageSeq?: number;
+  signal?: AbortSignal;
+}): Promise<HistoricalMessage[]> {
+  try {
+    const result = await postJson<{ messages?: Array<Record<string, unknown>> }>(
+      params.apiUrl,
+      params.botToken,
+      '/v1/bot/messages/sync',
+      {
+        channel_id: params.channelId,
+        channel_type: params.channelType,
+        limit: params.limit ?? 20,
+        start_message_seq: params.startMessageSeq ?? 0,
+        end_message_seq: params.endMessageSeq ?? 0,
+        pull_mode: 1, // 1 = pull newer messages
+      },
+      params.signal,
+    );
+    const messages = result?.messages ?? [];
+    return messages.map((m) => {
+      let payload: Record<string, unknown> | undefined;
+      if (typeof m.payload === 'string') {
+        try {
+          payload = JSON.parse(Buffer.from(m.payload, 'base64').toString('utf-8'));
+        } catch {
+          // Leave payload undefined if decoding fails
+        }
+      } else if (m.payload && typeof m.payload === 'object') {
+        payload = m.payload as Record<string, unknown>;
+      }
+      return {
+        from_uid: String(m.from_uid ?? ''),
+        from_name: typeof m.from_name === 'string' ? m.from_name : undefined,
+        content: typeof m.content === 'string' ? m.content : undefined,
+        timestamp: typeof m.timestamp === 'number' ? m.timestamp : 0,
+        message_id: typeof m.message_id === 'string' ? m.message_id : undefined,
+        message_seq: typeof m.message_seq === 'number' ? m.message_seq : undefined,
+        type: typeof m.type === 'number' ? m.type : undefined,
+        url: typeof m.url === 'string' ? m.url : undefined,
+        name: typeof m.name === 'string' ? m.name : undefined,
+        payload,
+      };
+    });
+  } catch (err) {
+    console.error(`octo: getChannelMessages error: ${String(err)}`);
+    return [];
+  }
+}

--- a/src/octo/types.ts
+++ b/src/octo/types.ts
@@ -106,4 +106,45 @@ export enum MessageType {
   Card = 7,
   File = 8,
   MultipleForward = 11,
+  /** Rich text (text + inline images), introduced in upstream v1.0.x */
+  RichText = 14,
 }
+
+// ─── RichText (type=14) content blocks ──────────────────────────────────────
+
+export const RICH_TEXT_BLOCK_TEXT = 1;
+export const RICH_TEXT_BLOCK_IMAGE = 2;
+
+/** Placeholder rendered for an inline image when assembling plain text. */
+export const RICH_TEXT_IMAGE_PLACEHOLDER = '[图片]';
+
+export interface RichTextBlock {
+  type: number;
+  text?: string;
+  url?: string;
+  name?: string;
+  size?: number;
+  [key: string]: unknown;
+}
+
+// ─── Forward-payload nested message (MultipleForward children) ──────────────
+
+export interface ForwardUser {
+  uid: string;
+  name: string;
+}
+
+export interface ForwardMessage {
+  message_id?: string;
+  from_uid: string;
+  timestamp?: number;
+  payload: {
+    type: number;
+    content?: string;
+    url?: string;
+    name?: string;
+    users?: ForwardUser[];
+    msgs?: ForwardMessage[];
+  };
+}
+

--- a/src/session-router.ts
+++ b/src/session-router.ts
@@ -237,48 +237,48 @@ export class SessionRouter {
       return { sessionKey: key, shouldProcess: false, message: msg };
     }
 
-    // Non-text message → reply with notice.
-    if (msg.payload.type !== MessageType.Text) {
-      await this.replySafe(msg, '暂不支持此类消息，请发送文字');
-      return { sessionKey: key, shouldProcess: false, message: msg };
-    }
+    // G1: All payload types are now resolved by inbound.resolveContent in
+    // handleMessage. The router only filters rate limits, size, and bot
+    // loops — type-specific handling lives in the pipeline.
 
-    // Q10: Reject messages exceeding content length limit.
+    // Q10: Reject messages exceeding content length limit (text only — media
+    // URLs are bounded by their own size and rendered via resolveContent).
     const content = msg.payload.content ?? '';
-    if (Buffer.byteLength(content, 'utf-8') > MAX_CONTENT_BYTES) {
+    if (
+      msg.payload.type === MessageType.Text &&
+      Buffer.byteLength(content, 'utf-8') > MAX_CONTENT_BYTES
+    ) {
       await this.replySafe(msg, '消息过长，请缩短后重试');
       return { sessionKey: key, shouldProcess: false, message: msg };
     }
 
-    // G13: Strip leading @botname from group messages for cleaner LLM input.
-    //
-    // Only strip when we have positive evidence the leading @token IS the bot.
-    // The regex fallback used to strip *any* leading @word, which corrupts
-    // messages like "@alice please check" (especially in G12 mention-free
-    // groups, where the bot wasn't even @'d and would still lose the @alice
-    // context). We now only strip when:
-    //   1. entities precisely identify the bot at offset 0, OR
-    //   2. the bot is mentioned AND the leading @token resolves to its robotId.
-    let cleanContent = content;
-    if (this.isGroupLike(msg.channel_type)) {
-      const mention = msg.payload.mention;
-      // Path 1: entities-based removal (precise offset/length).
-      if (mention?.entities && Array.isArray(mention.entities)) {
-        const botEntity = mention.entities.find(
-          (e: MentionEntity) => e.uid === this.robotId && e.offset === 0,
-        );
-        if (botEntity && typeof botEntity.length === 'number') {
-          cleanContent = content.substring(botEntity.length).trimStart();
+    // G13: Strip leading @botname from group TEXT messages for cleaner LLM input.
+    // For non-text payloads (images, files, etc.) cleanContent stays undefined
+    // so the pipeline falls back to the resolveContent rendering instead of an
+    // empty string.
+    let cleanContent: string | undefined;
+    if (msg.payload.type === MessageType.Text) {
+      cleanContent = content;
+      if (this.isGroupLike(msg.channel_type)) {
+        const mention = msg.payload.mention;
+        // Path 1: entities-based removal (precise offset/length).
+        if (mention?.entities && Array.isArray(mention.entities)) {
+          const botEntity = mention.entities.find(
+            (e: MentionEntity) => e.uid === this.robotId && e.offset === 0,
+          );
+          if (botEntity && typeof botEntity.length === 'number') {
+            cleanContent = content.substring(botEntity.length).trimStart();
+          }
         }
+        // Path 2: regex fallback — only when the bot was explicitly @mentioned.
+        // In mention-free groups (G12) where the bot wasn't @'d, do NOT touch
+        // the message — a leading @ is addressed to someone else.
+        if (cleanContent === content && this.isMentioned(msg)) {
+          cleanContent = content.replace(/^@\S+\s*/, '').trimStart();
+        }
+        // If stripping emptied the content, keep original.
+        if (!cleanContent) cleanContent = content;
       }
-      // Path 2: regex fallback — only when the bot was explicitly @mentioned.
-      // In mention-free groups (G12) where the bot wasn't @'d, do NOT touch
-      // the message — a leading @ is addressed to someone else.
-      if (cleanContent === content && this.isMentioned(msg)) {
-        cleanContent = content.replace(/^@\S+\s*/, '').trimStart();
-      }
-      // If stripping emptied the content, keep original.
-      if (!cleanContent) cleanContent = content;
     }
 
     return { sessionKey: key, shouldProcess: true, message: msg, cleanContent };


### PR DESCRIPTION
## Summary

Second-batch GAP fixes for inbound message handling.

| GAP | Description | Implementation |
|-----|-------------|----------------|
| **G1** | Media message handling | New `src/inbound.ts` `resolveContent()` covers all 10 `MessageType` values (Text/Image/GIF/Voice/Video/File/Location/Card/MultipleForward/RichText) — replaces the previous '暂不支持' rejection |
| **G2** | Text-file inlining | `tryResolveFile()` HEAD-aware download with 20KB inline cap and 5MB hard cap; .py/.ts/.js/.json/.md/.csv (25+ extensions) get inlined into the prompt; oversize text files stream to `/tmp/cc-channel-octo/inbound-files/` |
| **G4** | API history backfill | New `getChannelMessages()` over POST `/v1/bot/messages/sync` with base64 payload decoding; `index.ts` cold-start backfill for empty group sessions, one-shot per session via in-memory Set |
| **G11** | Enriched history format | `HistoricalMessage` type carries `from_uid/from_name/type/timestamp`; `resolveHistoricalMessagePlaceholder()` maps non-text types to compact replay placeholders; `seedHistoryFromApi()` populates SessionStore so subsequent turns hit cache |
| **G22** | Voice context | Voice payload now reaches the agent with `[语音消息] <url>` marker; full STT integration tracked separately |

## RichText (type=14) details

- Adds `MessageType.RichText = 14` plus `RichTextBlock` / block-type constants to `octo/types.ts`
- `resolveRichTextContent()` honors server-authoritative top-level `plain` when present, falls back to assembling text from content blocks
- Image blocks collected into `mediaUrls` (sanitized for non-string url defense)
- Legacy string-content compat preserved

## Session router changes

- `session-router.ts` no longer auto-replies '暂不支持此类消息' for non-text payloads — all types flow to `handleMessage` where `resolveContent` produces LLM-friendly text
- G13 `cleanContent` (@bot stripping) now scoped to `Text` payloads only; non-text returns `cleanContent: undefined` so the pipeline uses `resolveContent.text`
- Size limit (32KB) still enforced for Text payloads (media URLs are bounded by their own size)

## Files

| File | Lines | Change |
|------|-------|--------|
| `src/inbound.ts` | +487 (new) | `resolveContent`, `tryResolveFile`, RichText / MultipleForward expansion, file inlining |
| `src/octo/types.ts` | +41 | RichText enum + block types + ForwardMessage shapes |
| `src/octo/api.ts` | +83 | `getChannelMessages` + `HistoricalMessage` type |
| `src/index.ts` | +149/-19 | resolveContent integration, G2 file inline path, G4 backfill, context cache for non-text |
| `src/session-router.ts` | +25/-43 | Drop non-text rejection, scope cleanContent to Text |
| `src/__tests__/inbound.test.ts` | +345 (new) | 37 tests covering all MessageType + RichText / MultipleForward parsing |
| `src/__tests__/g4-history-api.test.ts` | +221 (new) | 8 tests covering API parsing, base64 decoding, error paths |
| `src/__tests__/g2-file-inline.test.ts` | +183 (new) | 7 tests covering inline path, temp-file path, size caps, errors |
| `src/__tests__/e2e.test.ts` | +12/-13 | Updated 'unsupported notice' test → 'G1 routes non-text to agent' |
| `src/__tests__/session-router.test.ts` | +9/-2 | Same update at the unit level |

## Verification

- `tsc --noEmit`: ✅ clean
- `eslint src/`: ✅ 0 new warnings on changed files (7 pre-existing in other people's files)
- `vitest run`: 372/372 pass (+52 new tests)
- Scope: only inbound parsing + index.ts handler — does **not** touch outbound (mention/sendMedia/RichText send) which belongs to 豆豆's G5+G6+G7+G24 PR

## Out of scope (intentional)

- History string-format change (sender/timestamp tags per row) — needs a schema migration coordinated with PR#30's `message_seq` column; will follow as a focused G11 phase-2 PR to avoid churn here
- Outbound mention construction (G7) — 豆豆's PR
- COS upload / sendMediaMessage (G5+G24) — 豆豆's PR
- RichText *send* (G6) — 豆豆's PR

## Coordination with 豆豆

Confirmed boundaries:
- 飞飞 owns inbound parsing (resolveContent, mention payload **reading**)
- 豆豆 owns outbound construction (sendMediaMessage, mention payload **writing**, RichText send)
- No file-level overlap expected