### PR TITLE
fix(security)!: shared url-policy.ts + S1/S2/S4/S5/S6 SSRF + token leak

### DIFF
--- a/src/__tests__/g2-file-inline.test.ts
+++ b/src/__tests__/g2-file-inline.test.ts
@@ -1,8 +1,24 @@
 /**
  * G2 (file inlining) + G4 (history backfill) integration tests.
+ *
+ * DNS isolation: `tryResolveFile` calls `assertPublicUrl(url)` which performs
+ * a DNS lookup for non-IP-literal hosts. These tests use fictitious
+ * `api.example.com` hostnames; without a DNS mock the lookup hits the real
+ * resolver (NXDOMAIN locally, ENOTFOUND in GitHub Actions) and bypasses the
+ * mocked fetch — producing a "拒绝下载" description that fails the test.
+ * Same fix pattern as inbound-ssrf.test.ts / url-policy-redirect.test.ts.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('node:dns/promises', () => ({
+  lookup: vi.fn(async (hostname: string) => {
+    if (hostname.includes('example.com')) {
+      return [{ address: '203.0.113.42', family: 4 }];
+    }
+    throw new Error(`Test DNS mock: unexpected hostname ${hostname}`);
+  }),
+}));
 
 describe('G2: file inlining via tryResolveFile', () => {
   let originalFetch: typeof globalThis.fetch;
@@ -36,6 +52,7 @@ describe('G2: file inlining via tryResolveFile', () => {
     const result = await tryResolveFile({
       url: 'https://api.example.com/file/hello.py',
       botToken: 'tok',
+      apiUrl: 'https://api.example.com',
       filename: 'hello.py',
     });
 
@@ -51,6 +68,7 @@ describe('G2: file inlining via tryResolveFile', () => {
     const result = await tryResolveFile({
       url: 'https://api.example.com/file/photo.jpg',
       botToken: 'tok',
+      apiUrl: 'https://api.example.com',
       filename: 'photo.jpg',
       knownSize: 5_000,
     });
@@ -68,6 +86,7 @@ describe('G2: file inlining via tryResolveFile', () => {
     const result = await tryResolveFile({
       url: 'https://api.example.com/file/big.md',
       botToken: 'tok',
+      apiUrl: 'https://api.example.com',
       filename: 'big.md',
       knownSize: 10 * 1024 * 1024, // 10 MB > 5MB cap
     });
@@ -90,6 +109,7 @@ describe('G2: file inlining via tryResolveFile', () => {
     const result = await tryResolveFile({
       url: 'https://api.example.com/file/missing.md',
       botToken: 'tok',
+      apiUrl: 'https://api.example.com',
       filename: 'missing.md',
     });
 
@@ -107,6 +127,7 @@ describe('G2: file inlining via tryResolveFile', () => {
     const result = await tryResolveFile({
       url: 'https://api.example.com/file/foo.md',
       botToken: 'tok',
+      apiUrl: 'https://api.example.com',
       filename: 'foo.md',
     });
 
@@ -133,6 +154,7 @@ describe('G2: file inlining via tryResolveFile', () => {
     const result = await tryResolveFile({
       url: 'https://api.example.com/file/something.md',
       botToken: 'tok',
+      apiUrl: 'https://api.example.com',
       filename: 'something', // no extension
     });
 
@@ -171,6 +193,7 @@ describe('G2: file inlining via tryResolveFile', () => {
     const result = await tryResolveFile({
       url: 'https://api.example.com/file/big.txt',
       botToken: 'tok',
+      apiUrl: 'https://api.example.com',
       filename: 'big.txt',
     });
 

--- a/src/__tests__/inbound-ssrf.test.ts
+++ b/src/__tests__/inbound-ssrf.test.ts
@@ -5,9 +5,24 @@
  *   - SSRF defense: rejects private/loopback addresses without fetching
  *   - Token scoping: Authorization header sent ONLY when URL host matches apiUrl
  *   - Redirect guard: redirects to private hosts are blocked (via fetchWithRedirectGuard)
+ *
+ * DNS isolation: same rationale as url-policy-redirect.test.ts.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('node:dns/promises', () => ({
+  lookup: vi.fn(async (hostname: string) => {
+    // Map all fictitious test hosts to a public IP so assertPublicUrl passes.
+    // Anything else throws to surface as a clear test bug.
+    const publicHosts = ['api.example.com', 'cdn.public-host.com', 'attacker.public.example.com'];
+    if (publicHosts.includes(hostname) || hostname.includes('public')) {
+      return [{ address: '203.0.113.42', family: 4 }];
+    }
+    throw new Error(`Test DNS mock: unexpected hostname ${hostname}`);
+  }),
+}));
+
 import { tryResolveFile } from '../inbound.js';
 
 const API_URL = 'https://api.example.com';

--- a/src/__tests__/inbound-ssrf.test.ts
+++ b/src/__tests__/inbound-ssrf.test.ts
@@ -1,0 +1,239 @@
+/**
+ * tryResolveFile S1 SSRF + token scoping tests.
+ *
+ * Verifies:
+ *   - SSRF defense: rejects private/loopback addresses without fetching
+ *   - Token scoping: Authorization header sent ONLY when URL host matches apiUrl
+ *   - Redirect guard: redirects to private hosts are blocked (via fetchWithRedirectGuard)
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { tryResolveFile } from '../inbound.js';
+
+const API_URL = 'https://api.example.com';
+const BOT_TOKEN = 'bf_secret_xyz';
+
+describe('tryResolveFile S1: SSRF defense', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, 'fetch');
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it.each([
+    'http://127.0.0.1/leak.json',
+    'http://169.254.169.254/latest/meta-data/iam.json',
+    'http://10.0.0.1/internal.json',
+    'http://192.168.1.1/admin.json',
+    'http://[::1]/loopback.json',
+    'http://[::ffff:7f00:1]/hex-v4-mapped.json',  // S5 hex form
+  ])('rejects fetch to private/local %s', async (url) => {
+    const result = await tryResolveFile({
+      url,
+      botToken: BOT_TOKEN,
+      apiUrl: API_URL,
+      filename: 'x.json',
+    });
+    expect(result).toHaveProperty('description');
+    expect((result as { description: string }).description).toMatch(/拒绝下载|private|local/i);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects file:// scheme', async () => {
+    const result = await tryResolveFile({
+      url: 'file:///etc/passwd',
+      botToken: BOT_TOKEN,
+      apiUrl: API_URL,
+      filename: 'passwd.txt',
+    });
+    expect(result).toHaveProperty('description');
+    expect((result as { description: string }).description).toMatch(/拒绝下载|non-http/i);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('tryResolveFile S1: token scoping', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('hello world', {
+        status: 200,
+        headers: { 'content-type': 'text/plain' },
+      }) as Response,
+    );
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it('sends Authorization header when URL host matches apiUrl host', async () => {
+    await tryResolveFile({
+      url: 'https://api.example.com/file/xyz/note.md',
+      botToken: BOT_TOKEN,
+      apiUrl: API_URL,
+      filename: 'note.md',
+    });
+
+    expect(fetchSpy).toHaveBeenCalled();
+    const [, init] = fetchSpy.mock.calls[0];
+    const headers = (init as RequestInit & { headers: Record<string, string> }).headers;
+    expect(headers).toMatchObject({ Authorization: `Bearer ${BOT_TOKEN}` });
+  });
+
+  it('does NOT send Authorization header for cross-host URL (CDN, etc.)', async () => {
+    await tryResolveFile({
+      url: 'https://cdn.public-host.com/file/xyz/note.md',
+      botToken: BOT_TOKEN,
+      apiUrl: API_URL,
+      filename: 'note.md',
+    });
+
+    expect(fetchSpy).toHaveBeenCalled();
+    const [, init] = fetchSpy.mock.calls[0];
+    const headers = (init as RequestInit & { headers: Record<string, string> }).headers;
+    expect(headers).not.toHaveProperty('Authorization');
+    expect(headers).not.toHaveProperty('authorization');
+  });
+
+  it('does NOT send Authorization on apiUrl with different port (treated as different host)', async () => {
+    await tryResolveFile({
+      url: 'https://api.example.com:8080/file/x.md',
+      botToken: BOT_TOKEN,
+      apiUrl: 'https://api.example.com',
+      filename: 'x.md',
+    });
+
+    expect(fetchSpy).toHaveBeenCalled();
+    const [, init] = fetchSpy.mock.calls[0];
+    const headers = (init as RequestInit & { headers: Record<string, string> }).headers;
+    expect(headers).not.toHaveProperty('Authorization');
+  });
+});
+
+describe('tryResolveFile: non-text extensions return description (no fetch)', () => {
+  it.each([
+    'photo.jpg',
+    'video.mp4',
+    'archive.zip',
+    'random.bin',
+  ])('returns description without fetching for %s', async (filename) => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    const result = await tryResolveFile({
+      url: `https://api.example.com/file/${filename}`,
+      botToken: BOT_TOKEN,
+      apiUrl: API_URL,
+      filename,
+    });
+    expect(result).toHaveProperty('description');
+    expect(fetchSpy).not.toHaveBeenCalled();
+    fetchSpy.mockRestore();
+  });
+});
+
+describe('tryResolveFile S1 follow-up: per-hop credential scoping', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, 'fetch');
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it('DROPS Authorization header on cross-host redirect (the re-review bug)', async () => {
+    // Same-host initial URL — hop 1 includes Authorization.
+    // 302 Location: cross-host — hop 2 MUST NOT include Authorization,
+    // even though the initial init said to.
+    fetchSpy.mockResolvedValueOnce(
+      new Response(null, {
+        status: 302,
+        headers: { location: 'https://attacker.public.example.com/leak' },
+      }) as Response,
+    );
+    fetchSpy.mockResolvedValueOnce(
+      new Response('attacker would have logged the token here', {
+        status: 200,
+        headers: { 'content-type': 'text/plain' },
+      }) as Response,
+    );
+
+    await tryResolveFile({
+      url: 'https://api.example.com/file/leak.md',
+      botToken: BOT_TOKEN,
+      apiUrl: API_URL,
+      filename: 'leak.md',
+    });
+
+    // First hop: same host as apiUrl, header present.
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    const [, hop1Init] = fetchSpy.mock.calls[0];
+    const hop1Headers = (hop1Init as RequestInit & { headers: Record<string, string> }).headers;
+    expect(hop1Headers).toMatchObject({ Authorization: `Bearer ${BOT_TOKEN}` });
+
+    // Second hop: cross host, header must be absent.
+    const [hop2Url, hop2Init] = fetchSpy.mock.calls[1];
+    expect(String(hop2Url)).toContain('attacker.public.example.com');
+    const hop2Headers = (hop2Init as RequestInit & { headers: Record<string, string> }).headers;
+    expect(hop2Headers).not.toHaveProperty('Authorization');
+    expect(hop2Headers).not.toHaveProperty('authorization');
+  });
+
+  it('keeps Authorization across same-host redirects', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(null, {
+        status: 302,
+        headers: { location: 'https://api.example.com/file/redirected.md' },
+      }) as Response,
+    );
+    fetchSpy.mockResolvedValueOnce(
+      new Response('content', { status: 200, headers: { 'content-type': 'text/plain' } }) as Response,
+    );
+
+    await tryResolveFile({
+      url: 'https://api.example.com/file/original.md',
+      botToken: BOT_TOKEN,
+      apiUrl: API_URL,
+      filename: 'original.md',
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    for (const [, init] of fetchSpy.mock.calls) {
+      const headers = (init as RequestInit & { headers: Record<string, string> }).headers;
+      expect(headers).toMatchObject({ Authorization: `Bearer ${BOT_TOKEN}` });
+    }
+  });
+
+  it('cross-host → same-host redirect ADDS Authorization on hop 2 (per-hop logic)', async () => {
+    // Edge case: starts cross-host (no auth), 302s to api host.
+    // Per-hop callback adds auth on hop 2 — correct: hop 2 is our own API host.
+    fetchSpy.mockResolvedValueOnce(
+      new Response(null, {
+        status: 302,
+        headers: { location: 'https://api.example.com/file/x.md' },
+      }) as Response,
+    );
+    fetchSpy.mockResolvedValueOnce(
+      new Response('content', { status: 200, headers: { 'content-type': 'text/plain' } }) as Response,
+    );
+
+    await tryResolveFile({
+      url: 'https://cdn.public-host.com/file/x.md',
+      botToken: BOT_TOKEN,
+      apiUrl: API_URL,
+      filename: 'x.md',
+    });
+
+    const hop1Headers = (fetchSpy.mock.calls[0][1] as RequestInit & { headers: Record<string, string> }).headers;
+    expect(hop1Headers).not.toHaveProperty('Authorization');
+
+    const hop2Headers = (fetchSpy.mock.calls[1][1] as RequestInit & { headers: Record<string, string> }).headers;
+    expect(hop2Headers).toMatchObject({ Authorization: `Bearer ${BOT_TOKEN}` });
+  });
+});

--- a/src/__tests__/inbound.test.ts
+++ b/src/__tests__/inbound.test.ts
@@ -78,6 +78,70 @@ describe('buildMediaUrl', () => {
   it('rejects leading-slash relative path (avoids double-slash output)', () => {
     expect(buildMediaUrl('/abs/path/x.png', API_URL)).toBeUndefined();
   });
+
+  // ─── S4 follow-up: encoded path traversal (PR#38 round-3) ──────────────
+  //
+  // Bug: literal `..`/`.` check bypassed by percent-encoded variants.
+  // WHATWG URL parser decodes `%2e` for dot-segment purposes:
+  //   `<apiHost>/file/%2e%2e/internal/secret.env`
+  //   .pathname → `/internal/secret.env` (escapes /file/ sandbox!)
+  //
+  // Combined with same-host Authorization scoping, attacker reads internal
+  // bot-authenticated paths via the bot's token. Independently reported by
+  // Yujiawei automated review + 李飞飞.
+  //
+  // Fix: WHATWG-canonical sandbox check (new URL().pathname.startsWith('/file/')).
+
+  it.each([
+    // Classic encoded dot-segments at top of file path — escape /file/
+    '%2e%2e/internal/secret.env',
+    '%2E%2E/internal/secret.env',       // uppercase hex
+    // Mixed encoded + literal at top — escape /file/
+    '%2e./internal/secret.env',
+    '.%2e/internal/secret.env',
+  ])('rejects encoded path traversal: %s', (input) => {
+    expect(buildMediaUrl(input, API_URL)).toBeUndefined();
+  });
+
+  it.each([
+    // These ARE normalised by WHATWG but STAY under /file/ — safe.
+    ['%2e/foo.env', 'https://api.example.com/file/%2e/foo.env'],
+    ['%2E/foo.env', 'https://api.example.com/file/%2E/foo.env'],
+    // sub/.. cancels within /file/ — final pathname still starts with /file/.
+    ['sub/%2e%2e/escape.env', 'https://api.example.com/file/sub/%2e%2e/escape.env'],
+    // %2f (encoded slash) is NOT decoded by WHATWG pathname — stays literal.
+    // Server sees /file/..%2f..%2finternal which is a single path segment.
+    ['..%2f..%2finternal/secret.env', 'https://api.example.com/file/..%2f..%2finternal/secret.env'],
+    // Double-encoded `%252e%252e` decodes to literal `%2e%2e` in the URL,
+    // not to `..` — stays under /file/ at the HTTP layer.
+    ['%252e%252e/internal/secret.env', 'https://api.example.com/file/%252e%252e/internal/secret.env'],
+  ])('accepts encoded traversal that stays under /file/: %s', (input, expected) => {
+    // The candidate URL is returned as-is; what matters is that
+    // `new URL(result).pathname.startsWith('/file/')` is true — the WHATWG
+    // sandbox check verifies this. fetch sends the literal bytes; server
+    // sees a path still rooted under /file/.
+    expect(buildMediaUrl(input, API_URL)).toBe(expected);
+  });
+
+  it('verifies WHATWG sandbox check catches all escape variants', () => {
+    // Direct check that the assertion holds for the rejected cases.
+    const escapeCases = [
+      'https://api.example.com/file/%2e%2e/internal/secret.env',
+      'https://api.example.com/file/%2E%2E/internal/secret.env',
+      'https://api.example.com/file/%2e./internal/secret.env',
+      'https://api.example.com/file/.%2e/internal/secret.env',
+    ];
+    for (const c of escapeCases) {
+      const p = new URL(c).pathname;
+      expect(p.startsWith('/file/')).toBe(false);
+    }
+  });
+
+  it('accepts benign paths that happen to contain encoded characters', () => {
+    // %20 (space) and other benign encoded chars should still pass.
+    expect(buildMediaUrl('My%20File.png', API_URL))
+      .toBe('https://api.example.com/file/My%20File.png');
+  });
 });
 
 // --- resolveContent (G1) ---

--- a/src/__tests__/inbound.test.ts
+++ b/src/__tests__/inbound.test.ts
@@ -25,9 +25,18 @@ describe('buildMediaUrl', () => {
     expect(buildMediaUrl('', API_URL)).toBeUndefined();
   });
 
-  it('passes through absolute http(s) URLs', () => {
-    expect(buildMediaUrl('https://cdn.x.com/a.jpg', API_URL)).toBe('https://cdn.x.com/a.jpg');
-    expect(buildMediaUrl('http://cdn.x.com/a.jpg', API_URL)).toBe('http://cdn.x.com/a.jpg');
+  it('only passes through absolute http(s) URLs when host matches apiUrl (S1)', () => {
+    // Same host — allowed
+    expect(buildMediaUrl('https://api.example.com/file/x.jpg', API_URL))
+      .toBe('https://api.example.com/file/x.jpg');
+    // Different host — rejected (was the SSRF + botToken leak vector)
+    expect(buildMediaUrl('https://cdn.x.com/a.jpg', API_URL)).toBeUndefined();
+    expect(buildMediaUrl('http://attacker.com/log', API_URL)).toBeUndefined();
+    expect(buildMediaUrl('http://169.254.169.254/meta', API_URL)).toBeUndefined();
+  });
+
+  it('rejects protocol downgrade (https apiUrl + http target)', () => {
+    expect(buildMediaUrl('http://api.example.com/file/x.jpg', API_URL)).toBeUndefined();
   });
 
   it('strips file/preview/ prefix', () => {
@@ -43,6 +52,31 @@ describe('buildMediaUrl', () => {
   it('handles raw storage path', () => {
     expect(buildMediaUrl('abc/img.png', API_URL))
       .toBe('https://api.example.com/file/abc/img.png');
+  });
+
+  // ─── S1 + P1.2 path traversal + smuggling defense ───────────────
+
+  it.each([
+    ['../v1/admin'],
+    ['file/../v1/admin'],
+    ['../../etc/passwd'],
+    ['file/a/../../v1/admin'],
+    ['./hidden'],
+  ])('rejects path traversal: %s', (input) => {
+    expect(buildMediaUrl(input, API_URL)).toBeUndefined();
+  });
+
+  it('rejects scheme-relative URL (//attacker.com)', () => {
+    expect(buildMediaUrl('//attacker.com/log', API_URL)).toBeUndefined();
+  });
+
+  it('rejects backslash injection (Windows-style traversal)', () => {
+    expect(buildMediaUrl('a\\..\\v1\\admin', API_URL)).toBeUndefined();
+    expect(buildMediaUrl('file\\backslash', API_URL)).toBeUndefined();
+  });
+
+  it('rejects leading-slash relative path (avoids double-slash output)', () => {
+    expect(buildMediaUrl('/abs/path/x.png', API_URL)).toBeUndefined();
   });
 });
 

--- a/src/__tests__/media-upload.test.ts
+++ b/src/__tests__/media-upload.test.ts
@@ -1,11 +1,24 @@
 /**
  * Tests for media-upload — content type inference, image dimensions, upload pipeline.
+ *
+ * DNS isolation: downloadToTempFile calls assertPublicUrl which does a DNS
+ * lookup for non-IP hosts. Test URLs use fictitious `example.com` hostnames —
+ * without DNS mock these hit the real resolver and fail in CI (ENOTFOUND).
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { writeFile, unlink, mkdir } from 'node:fs/promises';
 import path from 'node:path';
 import { tmpdir } from 'node:os';
+
+vi.mock('node:dns/promises', () => ({
+  lookup: vi.fn(async (hostname: string) => {
+    if (hostname.includes('example.com')) {
+      return [{ address: '203.0.113.42', family: 4 }];
+    }
+    throw new Error(`Test DNS mock: unexpected hostname ${hostname}`);
+  }),
+}));
 
 // Mock cos-nodejs-sdk-v5 BEFORE any imports of media-upload.
 const cosPutObjectMock = vi.fn();

--- a/src/__tests__/url-policy-redirect.test.ts
+++ b/src/__tests__/url-policy-redirect.test.ts
@@ -1,0 +1,196 @@
+/**
+ * S2 fetchWithRedirectGuard regression tests.
+ *
+ * Verifies that HTTP redirects to private addresses are blocked, NOT followed.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { fetchWithRedirectGuard } from '../url-policy.js';
+
+describe('fetchWithRedirectGuard (S2)', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, 'fetch');
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it('follows redirects to other public hosts', async () => {
+    // Hop 1: 302 to public host
+    fetchSpy.mockResolvedValueOnce(
+      new Response(null, {
+        status: 302,
+        headers: { location: 'https://elsewhere.public.example.com/final' },
+      }),
+    );
+    // Hop 2: 200
+    fetchSpy.mockResolvedValueOnce(
+      new Response('done', { status: 200 }),
+    );
+
+    const resp = await fetchWithRedirectGuard('https://start.public.example.com/');
+    expect(resp.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    // Verify redirect: 'manual' was passed
+    expect(fetchSpy.mock.calls[0][1]).toMatchObject({ redirect: 'manual' });
+    expect(fetchSpy.mock.calls[1][1]).toMatchObject({ redirect: 'manual' });
+  });
+
+  it('REJECTS redirect to private host (S2 fix)', async () => {
+    // Hop 1: 302 to internal host
+    fetchSpy.mockResolvedValueOnce(
+      new Response(null, {
+        status: 302,
+        headers: { location: 'http://169.254.169.254/latest/meta-data/' },
+      }),
+    );
+
+    await expect(
+      fetchWithRedirectGuard('https://attacker.public.example.com/redirect-trap'),
+    ).rejects.toThrow(/private\/local/);
+
+    // Only the first fetch should have happened — the redirect destination
+    // must be rejected BEFORE fetching it.
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('REJECTS redirect to file:// scheme', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(null, {
+        status: 302,
+        headers: { location: 'file:///etc/passwd' },
+      }),
+    );
+
+    await expect(
+      fetchWithRedirectGuard('https://attacker.public.example.com/'),
+    ).rejects.toThrow(/non-http/);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('REJECTS redirect to private IPv6 hex form (S5 + S2 combo)', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(null, {
+        status: 302,
+        headers: { location: 'http://[::ffff:7f00:1]/' },
+      }),
+    );
+
+    await expect(
+      fetchWithRedirectGuard('https://attacker.public.example.com/'),
+    ).rejects.toThrow(/private\/local/);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects redirect loop after MAX_REDIRECTS', async () => {
+    // Always return 302 to a different public host — creates an infinite-ish loop
+    let counter = 0;
+    fetchSpy.mockImplementation(() => {
+      counter++;
+      return Promise.resolve(
+        new Response(null, {
+          status: 302,
+          headers: { location: `https://hop-${counter}.public.example.com/` },
+        }),
+      );
+    });
+
+    await expect(
+      fetchWithRedirectGuard('https://start.public.example.com/'),
+    ).rejects.toThrow(/more than 10 redirects/);
+    // 11 hops attempted (10 redirects + 1 over the limit)
+    expect(fetchSpy.mock.calls.length).toBeLessThanOrEqual(11);
+  });
+
+  it('returns 3xx without Location as a normal response (no infinite loop)', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response('no location header', { status: 302 }),
+    );
+
+    const resp = await fetchWithRedirectGuard('https://example.public.com/');
+    expect(resp.status).toBe(302);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('fetchWithRedirectGuard perHopInit callback (S1 follow-up)', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, 'fetch');
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it('callback receives currentUrl + previousUrl on each hop', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(null, {
+        status: 302,
+        headers: { location: 'https://hop1.public.example.com/' },
+      }),
+    );
+    fetchSpy.mockResolvedValueOnce(
+      new Response(null, {
+        status: 302,
+        headers: { location: 'https://hop2.public.example.com/' },
+      }),
+    );
+    fetchSpy.mockResolvedValueOnce(new Response('done', { status: 200 }));
+
+    const calls: Array<{ currentUrl: string; previousUrl: string | null }> = [];
+    await fetchWithRedirectGuard('https://start.public.example.com/', (currentUrl, previousUrl) => {
+      calls.push({ currentUrl, previousUrl });
+      return {};
+    });
+
+    expect(calls).toEqual([
+      { currentUrl: 'https://start.public.example.com/', previousUrl: null },
+      { currentUrl: 'https://hop1.public.example.com/', previousUrl: 'https://start.public.example.com/' },
+      { currentUrl: 'https://hop2.public.example.com/', previousUrl: 'https://hop1.public.example.com/' },
+    ]);
+  });
+
+  it('callback can return different headers per hop', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(null, {
+        status: 302,
+        headers: { location: 'https://other.public.example.com/' },
+      }),
+    );
+    fetchSpy.mockResolvedValueOnce(new Response('done', { status: 200 }));
+
+    await fetchWithRedirectGuard('https://api.public.example.com/x', (currentUrl) => {
+      const u = new URL(currentUrl);
+      return u.host === 'api.public.example.com'
+        ? { headers: { Authorization: 'Bearer secret' } }
+        : {};
+    });
+
+    const hop1Init = fetchSpy.mock.calls[0][1] as RequestInit & { headers: Record<string, string> };
+    const hop2Init = fetchSpy.mock.calls[1][1] as RequestInit & { headers?: Record<string, string> };
+    expect(hop1Init.headers).toMatchObject({ Authorization: 'Bearer secret' });
+    expect(hop2Init.headers ?? {}).not.toHaveProperty('Authorization');
+  });
+
+  it('static init still works (backward compat)', async () => {
+    fetchSpy.mockResolvedValueOnce(new Response('ok', { status: 200 }));
+
+    await fetchWithRedirectGuard('https://example.public.com/', {
+      method: 'POST',
+      headers: { 'x-test': 'yes' },
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [, init] = fetchSpy.mock.calls[0];
+    expect(init).toMatchObject({
+      method: 'POST',
+      headers: { 'x-test': 'yes' },
+      redirect: 'manual',
+    });
+  });
+});

--- a/src/__tests__/url-policy-redirect.test.ts
+++ b/src/__tests__/url-policy-redirect.test.ts
@@ -2,9 +2,29 @@
  * S2 fetchWithRedirectGuard regression tests.
  *
  * Verifies that HTTP redirects to private addresses are blocked, NOT followed.
+ *
+ * DNS isolation: all hostnames in this file are fictitious. We mock
+ * node:dns/promises.lookup to return a public IP for any "*.public.*"
+ * hostname so the tests don't depend on the runner's resolver behavior
+ * (local machine returns NXDOMAIN, CI gets ENOTFOUND — different error
+ * shapes leak through assertPublicUrl and break unrelated assertions).
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('node:dns/promises', () => ({
+  lookup: vi.fn(async (hostname: string) => {
+    // Mock: any hostname containing 'public' resolves to a public IP
+    // (TEST-NET-3, 203.0.113.0/24 — reserved for docs but treated as public
+    // by isPrivateOrLocalAddress). Anything else throws like a real DNS
+    // failure to surface as a clear test bug rather than a silent pass.
+    if (hostname.includes('public')) {
+      return [{ address: '203.0.113.42', family: 4 }];
+    }
+    throw new Error(`Test DNS mock: unexpected hostname ${hostname}`);
+  }),
+}));
+
 import { fetchWithRedirectGuard } from '../url-policy.js';
 
 describe('fetchWithRedirectGuard (S2)', () => {

--- a/src/__tests__/url-policy.test.ts
+++ b/src/__tests__/url-policy.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Tests for url-policy.ts shared SSRF + URL validation module (S1+S2+S5+S6).
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  isPrivateOrLocalAddress,
+  assertPublicUrl,
+  isAllowedApiUrl,
+} from '../url-policy.js';
+
+describe('isPrivateOrLocalAddress (S5 hex v4-mapped fix)', () => {
+  // ── IPv4 private ranges ─────────────────────────────────────────
+  it.each([
+    ['127.0.0.1', true],
+    ['127.255.255.255', true],
+    ['10.0.0.1', true],
+    ['172.16.0.1', true],
+    ['172.31.255.255', true],
+    ['172.32.0.0', false], // not in 12-bit private range
+    ['192.168.1.1', true],
+    ['169.254.169.254', true], // AWS metadata
+    ['100.64.0.1', true], // CGN
+    ['100.127.255.255', true],
+    ['100.128.0.0', false], // outside CGN
+    ['0.0.0.0', true],
+    ['8.8.8.8', false],
+    ['1.1.1.1', false],
+    ['203.0.113.1', false], // TEST-NET-3 (public for docs but routable)
+  ])('IPv4 %s → %s', (addr, expected) => {
+    expect(isPrivateOrLocalAddress(addr)).toBe(expected);
+  });
+
+  // ── IPv6 standard ───────────────────────────────────────────────
+  it.each([
+    ['::1', true],
+    ['0:0:0:0:0:0:0:1', true],
+    ['::', true],
+    ['fc00::1', true],
+    ['fd00::1', true],
+    ['fe80::1', true],
+    ['febf:1234::1', true],
+    ['2001:db8::1', false], // documentation prefix, not private
+    ['2606:4700:4700::1111', false], // Cloudflare DNS
+  ])('IPv6 %s → %s', (addr, expected) => {
+    expect(isPrivateOrLocalAddress(addr)).toBe(expected);
+  });
+
+  // ── S5 fix: hex v4-mapped (the actual bypass case) ─────────────
+  it.each([
+    // dotted-quad form (original PR#34 handled)
+    ['::ffff:127.0.0.1', true],
+    ['::ffff:169.254.169.254', true],
+    ['::ffff:8.8.8.8', false],
+    // hex form (PR#34 bypass — S5 fix target)
+    ['::ffff:7f00:1', true],        // 127.0.0.1
+    ['::ffff:a9fe:a9fe', true],     // 169.254.169.254 AWS metadata
+    ['::ffff:c0a8:101', true],      // 192.168.1.1
+    ['::ffff:a00:1', true],         // 10.0.0.1
+    ['::ffff:0808:0808', false],    // 8.8.8.8
+  ])('IPv6 v4-mapped %s → %s', (addr, expected) => {
+    expect(isPrivateOrLocalAddress(addr)).toBe(expected);
+  });
+
+  // ── IPv4-compatible IPv6 (deprecated but resolvable) ──────────
+  it.each([
+    ['::127.0.0.1', true],
+    ['::8.8.8.8', false],
+    ['::7f00:1', true],
+    ['::0808:0808', false],
+  ])('IPv4-compatible %s → %s', (addr, expected) => {
+    expect(isPrivateOrLocalAddress(addr)).toBe(expected);
+  });
+
+  it('returns false for malformed input', () => {
+    expect(isPrivateOrLocalAddress('not-an-ip')).toBe(false);
+    expect(isPrivateOrLocalAddress('')).toBe(false);
+    expect(isPrivateOrLocalAddress('999.999.999.999')).toBe(false);
+  });
+});
+
+describe('assertPublicUrl', () => {
+  it('rejects non-http(s) schemes', async () => {
+    await expect(assertPublicUrl('file:///etc/passwd')).rejects.toThrow(/non-http/);
+    await expect(assertPublicUrl('gopher://x/')).rejects.toThrow(/non-http/);
+    await expect(assertPublicUrl('ftp://x/')).rejects.toThrow(/non-http/);
+    await expect(assertPublicUrl('dict://x/')).rejects.toThrow(/non-http/);
+  });
+
+  it.each([
+    'http://127.0.0.1/',
+    'http://10.0.0.1/',
+    'http://172.16.0.1/',
+    'http://192.168.1.1/',
+    'http://169.254.169.254/latest/meta-data/',
+    'http://100.64.0.1/',
+    'http://[::1]/',
+    'http://[fc00::1]/',
+    'http://[fe80::1]/',
+    // S5 hex v4-mapped forms — these were the PR#34 bypass
+    'http://[::ffff:7f00:1]/',
+    'http://[::ffff:a9fe:a9fe]/',
+    'http://[::ffff:127.0.0.1]/',
+  ])('rejects private IP literal %s', async (url) => {
+    await expect(assertPublicUrl(url)).rejects.toThrow(/private\/local/);
+  });
+
+  it('allows public IPv4 literal', async () => {
+    await expect(assertPublicUrl('http://8.8.8.8/')).resolves.toBeUndefined();
+  });
+
+  it('allows public IPv6 literal', async () => {
+    await expect(assertPublicUrl('http://[2606:4700:4700::1111]/')).resolves.toBeUndefined();
+  });
+});
+
+describe('isAllowedApiUrl (S6)', () => {
+  it.each([
+    // https to public hosts — allowed
+    ['https://api.example.com', true],
+    ['https://api.example.com:443/v1', true],
+    ['https://8.8.8.8/', true],
+    // http to localhost — allowed for local dev
+    ['http://localhost', true],
+    ['http://127.0.0.1', true],
+    ['http://[::1]', true],
+    // http to any other host — rejected
+    ['http://api.example.com', false],
+    ['http://8.8.8.8/', false],
+    // S6 fix: https to PRIVATE IP — rejected (was allowed before)
+    ['https://127.0.0.1/', false],
+    ['https://10.0.0.1/', false],
+    ['https://169.254.169.254/', false],
+    ['https://[::1]/', false],
+    ['https://[::ffff:7f00:1]/', false], // S5 hex form
+    // wss/ftp/file — rejected
+    ['wss://example.com/', false],
+    ['file:///etc/passwd', false],
+    ['ftp://example.com/', false],
+    // malformed — rejected
+    ['', false],
+    ['not-a-url', false],
+  ])('%s → %s', (url, expected) => {
+    expect(isAllowedApiUrl(url)).toBe(expected);
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,6 +4,7 @@
  */
 
 import { readFileSync, existsSync, statSync } from 'node:fs';
+import { isAllowedApiUrl } from './url-policy.js';
 
 export interface Config {
   botToken: string;
@@ -227,22 +228,10 @@ function applyEnv(cfg: Config): Config {
 }
 
 /**
- * SSRF protection: only allow https:// URLs and http://localhost or http://127.0.0.1
- * for local development. Rejects http:// to arbitrary hosts, file://, etc.
+ * SSRF protection for apiUrl: implemented in url-policy.ts (isAllowedApiUrl).
+ * S6 fix: now rejects https://127.0.0.1 too — https doesn't make a private
+ * address safe (could be a self-signed mitmproxy).
  */
-function isAllowedApiUrl(url: string): boolean {
-  try {
-    const parsed = new URL(url);
-    if (parsed.protocol === 'https:') return true;
-    if (parsed.protocol === 'http:') {
-      const host = parsed.hostname.toLowerCase();
-      return host === 'localhost' || host === '127.0.0.1' || host === '[::1]';
-    }
-    return false;
-  } catch {
-    return false;
-  }
-}
 
 export function loadConfig(configPath?: string): Config {
   const path = configPath ?? './config.json';

--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -19,6 +19,20 @@ import { join } from 'node:path';
 import { randomUUID } from 'node:crypto';
 import type { MessagePayload, ForwardMessage, ForwardUser } from './octo/types.js';
 import { MessageType, RICH_TEXT_BLOCK_IMAGE, RICH_TEXT_BLOCK_TEXT, RICH_TEXT_IMAGE_PLACEHOLDER } from './octo/types.js';
+import { assertPublicUrl, fetchWithRedirectGuard } from './url-policy.js';
+
+/**
+ * S1 helper: same-host check for credential scoping.
+ * Returns true only when both URLs parse successfully and have matching host
+ * (case-insensitive). Falsy or malformed inputs return false (fail-closed).
+ */
+function isSameHost(url: string, apiUrl: string): boolean {
+  try {
+    return new URL(url).host.toLowerCase() === new URL(apiUrl).host.toLowerCase();
+  } catch {
+    return false;
+  }
+}
 
 // ─── Configuration ─────────────────────────────────────────────────────────
 
@@ -90,16 +104,56 @@ export interface ResolvedContent {
 
 // ─── URL helpers ───────────────────────────────────────────────────────────
 
-/** Resolve a relative storage path against the bot API base. */
+/**
+ * Resolve a relative storage path against the bot API base.
+ *
+ * S1 + P1.2 (Stage 6): Hardened against absolute-URL smuggling and path
+ * traversal:
+ *   - Reject scheme-relative URLs (`//attacker.com/...`)
+ *   - Reject path-traversal segments (`..`, `.`)
+ *   - Reject backslash injection
+ *   - For absolute http(s) URLs: only allow when host matches apiUrl host.
+ *     This is the chokepoint that prevents an attacker-controlled
+ *     payload.url from later being fetched with the bot's Authorization
+ *     header (which would leak botToken to the attacker's server).
+ */
 export function buildMediaUrl(relUrl?: string, apiUrl?: string): string | undefined {
   if (!relUrl) return undefined;
-  if (relUrl.startsWith('http://') || relUrl.startsWith('https://')) return relUrl;
+
+  // Reject backslashes outright — they're not valid in URL paths and are a
+  // known Windows-style traversal vector when normalized.
+  if (relUrl.includes('\\')) return undefined;
+
+  // Reject scheme-relative URLs (`//attacker.com/path`).
+  if (relUrl.startsWith('//')) return undefined;
+
+  // Absolute http(s) URL — only allow when host matches apiUrl host.
+  if (relUrl.startsWith('http://') || relUrl.startsWith('https://')) {
+    if (!apiUrl) return undefined;
+    try {
+      const target = new URL(relUrl);
+      const base = new URL(apiUrl);
+      if (target.host.toLowerCase() !== base.host.toLowerCase()) return undefined;
+      if (target.protocol !== base.protocol) return undefined;
+      return relUrl;
+    } catch {
+      return undefined;
+    }
+  }
+
+  // Relative path — strip /file/ or /file/preview/ prefix then enforce no traversal.
   let storagePath = relUrl;
   if (storagePath.startsWith('file/preview/')) {
     storagePath = storagePath.substring('file/preview/'.length);
   } else if (storagePath.startsWith('file/')) {
     storagePath = storagePath.substring('file/'.length);
   }
+  const segments = storagePath.split('/');
+  for (const seg of segments) {
+    if (seg === '..' || seg === '.') return undefined;
+  }
+  if (storagePath.startsWith('/')) return undefined;
+
   const baseUrl = apiUrl?.replace(/\/+$/, '') ?? '';
   return `${baseUrl}/file/${storagePath}`;
 }
@@ -430,6 +484,7 @@ function extractExtension(url: string, fallbackName?: string): string {
 export async function tryResolveFile(params: {
   url: string;
   botToken: string;
+  apiUrl: string;
   filename: string;
   knownSize?: number;
 }): Promise<
@@ -437,7 +492,7 @@ export async function tryResolveFile(params: {
   | { tempPath: string }
   | { description: string }
 > {
-  const { url, botToken, filename, knownSize } = params;
+  const { url, botToken, apiUrl, filename, knownSize } = params;
   const ext = extractExtension(url, filename);
   if (!TEXT_FILE_EXTENSIONS.has(ext)) {
     // Non-text — surface size info if known
@@ -453,11 +508,32 @@ export async function tryResolveFile(params: {
     return { description: `[文件: ${filename} (${formatBytes(knownSize)}) - 超过下载上限 ${formatBytes(MAX_FILE_DOWNLOAD_BYTES)}]` };
   }
 
-  // Download with streaming + size guard
+  // S1: SSRF defense — reject private/loopback/link-local addresses.
   try {
-    const resp = await fetch(url, {
-      headers: { Authorization: `Bearer ${botToken}` },
-      signal: AbortSignal.timeout(FILE_DOWNLOAD_TIMEOUT_MS),
+    await assertPublicUrl(url);
+  } catch (err) {
+    return { description: `[文件: ${filename} - 拒绝下载: ${String(err)}]` };
+  }
+
+  // S1 (re-review fix): scope Authorization PER HOP, not statically.
+  // The previous implementation set the header once based on the initial URL
+  // and then `fetchWithRedirectGuard` reused the same init across redirects —
+  // meaning a same-host initial URL that 302'd to attacker.com would still
+  // ship the Authorization header to the attacker. We now pass a perHopInit
+  // callback so the header is recomputed per hop and dropped whenever the
+  // current hop's host differs from apiUrl host.
+  const signal = AbortSignal.timeout(FILE_DOWNLOAD_TIMEOUT_MS);
+
+  // Download with streaming + size guard. fetchWithRedirectGuard
+  // re-validates SSRF on every redirect hop (S2) AND now re-decides the
+  // Authorization header per hop (S1 follow-up).
+  try {
+    const resp = await fetchWithRedirectGuard(url, (currentUrl) => {
+      const headers: Record<string, string> = {};
+      if (isSameHost(currentUrl, apiUrl)) {
+        headers.Authorization = `Bearer ${botToken}`;
+      }
+      return { headers, signal };
     });
     if (!resp.ok) {
       return { description: `[文件: ${filename} - 下载失败 HTTP ${resp.status}]` };

--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -142,12 +142,26 @@ export function buildMediaUrl(relUrl?: string, apiUrl?: string): string | undefi
   }
 
   // Relative path — strip /file/ or /file/preview/ prefix then enforce no traversal.
+  //
+  // S4 follow-up (PR#38 round-3, Yujiawei + 李飞飞): the literal `..`/`.` check
+  // was bypassable via percent-encoded dot-segments (`%2e%2e`, `%2E.`, `.%2e`,
+  // etc.). WHATWG URL parser decodes `%2e` for dot-segment normalization, so
+  // `<apiHost>/file/%2e%2e/internal/secret.env` normalizes to
+  // `<apiHost>/internal/secret.env`, escaping the `/file/` sandbox. Combined
+  // with the same-host Authorization scoping, this exfiltrates internal
+  // authenticated paths using the bot's botToken.
+  //
+  // Fix: after assembling the candidate URL, parse via WHATWG `new URL()` and
+  // assert the normalized pathname is still under `/file/`. This catches ALL
+  // encoded-dot variants (lower/upper hex, mixed `%2e.`, raw `..`) in one
+  // check, no matter how attacker spells them.
   let storagePath = relUrl;
   if (storagePath.startsWith('file/preview/')) {
     storagePath = storagePath.substring('file/preview/'.length);
   } else if (storagePath.startsWith('file/')) {
     storagePath = storagePath.substring('file/'.length);
   }
+  // Cheap literal pre-check still useful as defense-in-depth.
   const segments = storagePath.split('/');
   for (const seg of segments) {
     if (seg === '..' || seg === '.') return undefined;
@@ -155,7 +169,19 @@ export function buildMediaUrl(relUrl?: string, apiUrl?: string): string | undefi
   if (storagePath.startsWith('/')) return undefined;
 
   const baseUrl = apiUrl?.replace(/\/+$/, '') ?? '';
-  return `${baseUrl}/file/${storagePath}`;
+  const candidate = `${baseUrl}/file/${storagePath}`;
+
+  // WHATWG-canonical sandbox check: after URL normalization, pathname must
+  // still start with `/file/`. If `%2e%2e` (or any other encoded-dot variant)
+  // would have escaped the prefix, normalize collapses it and we reject here.
+  try {
+    const normalized = new URL(candidate);
+    if (!normalized.pathname.startsWith('/file/')) return undefined;
+  } catch {
+    return undefined;
+  }
+
+  return candidate;
 }
 
 // ─── RichText (type=14) expansion ─────────────────────────────────────────

--- a/src/index.ts
+++ b/src/index.ts
@@ -166,6 +166,7 @@ async function handleMessage(
           const fileResult = await tryResolveFile({
             url: resolved.mediaUrl,
             botToken: config.botToken,
+            apiUrl: config.apiUrl,
             filename,
             knownSize,
           });

--- a/src/media-upload.ts
+++ b/src/media-upload.ts
@@ -14,8 +14,6 @@ import path from "node:path";
 import { mkdir, open, unlink } from "node:fs/promises";
 import { createReadStream, createWriteStream, statSync } from "node:fs";
 import { randomUUID } from "node:crypto";
-import { lookup as dnsLookup } from "node:dns/promises";
-import { isIP } from "node:net";
 import { pipeline } from "node:stream/promises";
 import { Readable } from "node:stream";
 import COS from "cos-nodejs-sdk-v5";
@@ -35,98 +33,12 @@ import {
   sendMediaMessage,
   sendRichTextMessage,
 } from "./octo/api.js";
+import { assertPublicUrl, fetchWithRedirectGuard } from "./url-policy.js";
 
 const MAX_UPLOAD_SIZE = 500 * 1024 * 1024; // 500 MB
 const UPLOAD_TEMP_DIR = path.join("/tmp", "cc-octo-upload");
 
-// ─── SSRF defense (P0.2 from PR#34 review) ─────────────────────────
-
-/**
- * Reject IP literals/resolved IPs in private/loopback/link-local/CGN ranges.
- * Caller must check returned addresses against this list before fetching.
- *
- * NOTE: DNS rebinding is a residual risk — we validate at lookup time, but
- * the OS resolver may return a different IP at fetch time. Mitigated in
- * practice by short TTLs and the fact that an attacker would need to control
- * authoritative DNS for a domain we trust. For full protection, callers can
- * resolve once, pin the IP, and connect by IP (not done here to keep COS/CDN
- * URL semantics intact).
- */
-function isPrivateOrLocalAddress(address: string): boolean {
-  const fam = isIP(address);
-  if (fam === 4) {
-    const parts = address.split(".").map(Number);
-    const [a, b] = parts;
-    // 127.0.0.0/8 loopback
-    if (a === 127) return true;
-    // 10.0.0.0/8 private
-    if (a === 10) return true;
-    // 172.16.0.0/12 private
-    if (a === 172 && b >= 16 && b <= 31) return true;
-    // 192.168.0.0/16 private
-    if (a === 192 && b === 168) return true;
-    // 169.254.0.0/16 link-local (includes AWS/GCP metadata 169.254.169.254)
-    if (a === 169 && b === 254) return true;
-    // 100.64.0.0/10 CGN (carrier-grade NAT, shared address space)
-    if (a === 100 && b >= 64 && b <= 127) return true;
-    // 0.0.0.0/8 unspecified / current network
-    if (a === 0) return true;
-    return false;
-  }
-  if (fam === 6) {
-    const lower = address.toLowerCase();
-    // ::1 loopback
-    if (lower === "::1" || lower === "0:0:0:0:0:0:0:1") return true;
-    // :: unspecified
-    if (lower === "::" || lower === "0:0:0:0:0:0:0:0") return true;
-    // fc00::/7 unique local addresses (fc.. and fd..)
-    if (lower.startsWith("fc") || lower.startsWith("fd")) return true;
-    // fe80::/10 link-local
-    if (lower.startsWith("fe8") || lower.startsWith("fe9") ||
-        lower.startsWith("fea") || lower.startsWith("feb")) return true;
-    // ::ffff:<v4-mapped> — reject mapped IPv4 in private ranges
-    const v4MappedMatch = lower.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/);
-    if (v4MappedMatch) return isPrivateOrLocalAddress(v4MappedMatch[1]);
-    return false;
-  }
-  // Not a valid IP literal — caller should resolve via DNS first.
-  return false;
-}
-
-/**
- * Validate a URL's host is publicly routable. Throws on any private/loopback/
- * link-local IP literal, or when DNS resolution returns any such IP.
- *
- * Defense against LLM-driven SSRF to internal services (AWS/GCP metadata,
- * Redis, internal admin panels, etc.).
- */
-async function assertPublicUrl(rawUrl: string): Promise<void> {
-  const u = new URL(rawUrl);
-  const host = u.hostname;
-  // IPv6 hostnames come bracketed in URL.hostname — strip for isIP/dns.
-  const bareHost = host.startsWith("[") && host.endsWith("]") ? host.slice(1, -1) : host;
-
-  // Reject IP literals in private/loopback/link-local ranges immediately.
-  if (isIP(bareHost)) {
-    if (isPrivateOrLocalAddress(bareHost)) {
-      throw new Error(`Refusing to fetch private/local address: ${bareHost}`);
-    }
-    return;
-  }
-
-  // Resolve hostname — reject if ANY resolved address is private/local.
-  const addresses = await dnsLookup(bareHost, { all: true });
-  if (addresses.length === 0) {
-    throw new Error(`DNS resolution returned no addresses for: ${bareHost}`);
-  }
-  for (const { address } of addresses) {
-    if (isPrivateOrLocalAddress(address)) {
-      throw new Error(
-        `Refusing to fetch ${bareHost}: resolves to private/local address ${address}`,
-      );
-    }
-  }
-}
+// SSRF defense lives in url-policy.ts (assertPublicUrl + fetchWithRedirectGuard).
 
 // ─── Content type inference ────────────────────────────────────────────────
 
@@ -338,21 +250,27 @@ async function downloadToTempFile(
   filename: string,
   signal?: AbortSignal,
 ): Promise<{ tempPath: string; contentType: string | undefined }> {
-  // P0.2: SSRF defense — reject private/loopback/link-local targets BEFORE fetching.
+  // S1: SSRF defense — reject private/loopback/link-local targets BEFORE fetching.
+  // S2: fetchWithRedirectGuard re-validates on every redirect hop.
   await assertPublicUrl(url);
 
   await mkdir(UPLOAD_TEMP_DIR, { recursive: true });
   const safeName = sanitizeFilename(filename);
   const tempPath = path.join(UPLOAD_TEMP_DIR, `${randomUUID()}-${safeName}`);
 
-  // HEAD first to check size.
-  const head = await fetch(url, { method: "HEAD", signal: signal ?? AbortSignal.timeout(30_000) });
+  // HEAD first to check size. fetchWithRedirectGuard validates each hop.
+  const head = await fetchWithRedirectGuard(url, {
+    method: "HEAD",
+    signal: signal ?? AbortSignal.timeout(30_000),
+  });
   const contentLength = Number(head.headers.get("content-length") || 0);
   if (contentLength > MAX_UPLOAD_SIZE) {
     throw new Error(`File too large (${contentLength} bytes, max ${MAX_UPLOAD_SIZE})`);
   }
 
-  const resp = await fetch(url, { signal: signal ?? AbortSignal.timeout(300_000) });
+  const resp = await fetchWithRedirectGuard(url, {
+    signal: signal ?? AbortSignal.timeout(300_000),
+  });
   if (!resp.ok) throw new Error(`Failed to download media from ${url}: ${resp.status}`);
   const contentType = resp.headers.get("content-type") ?? undefined;
 

--- a/src/url-policy.ts
+++ b/src/url-policy.ts
@@ -1,0 +1,253 @@
+/**
+ * URL policy — shared SSRF defense + URL validation utilities.
+ *
+ * Stage 6 W1: consolidates URL validation that was previously duplicated and
+ * inconsistent across media-upload.ts, inbound.ts, and config.ts.
+ *
+ * Three public surfaces:
+ *   - isPrivateOrLocalAddress(address): IP-range check (IPv4 + IPv6 + v4-mapped)
+ *   - assertPublicUrl(url): throws if a URL resolves to a private/local address
+ *   - fetchWithRedirectGuard(url, init): fetch() wrapper that re-validates on every redirect
+ *   - isAllowedApiUrl(url): boot-time apiUrl validation (https any non-private host, http localhost only)
+ */
+
+import { lookup as dnsLookup } from "node:dns/promises";
+import { isIP } from "node:net";
+
+/**
+ * Reject IP literals/resolved IPs in private/loopback/link-local/CGN ranges.
+ *
+ * Covers IPv4 + IPv6 forms including:
+ *   - IPv6 dotted-quad v4-mapped: `::ffff:127.0.0.1`
+ *   - IPv6 hex v4-mapped: `::ffff:7f00:1` (S5 — was a bypass of original PR#34 fix)
+ *   - IPv4-compatible IPv6: `::7f00:1` (deprecated but resolvable)
+ *
+ * NOTE: DNS rebinding remains a residual risk. We validate at lookup time;
+ * the OS resolver may return a different IP at fetch time. Mitigated by short
+ * TTLs and the fact that an attacker would need to control authoritative DNS
+ * for a domain we trust. For full protection, callers can pin IP and connect
+ * by IP — not done here to preserve TLS SNI and CDN routing.
+ */
+export function isPrivateOrLocalAddress(address: string): boolean {
+  const fam = isIP(address);
+  if (fam === 4) {
+    return isPrivateIPv4(address);
+  }
+  if (fam === 6) {
+    const lower = address.toLowerCase();
+    // ::1 loopback
+    if (lower === "::1" || lower === "0:0:0:0:0:0:0:1") return true;
+    // :: unspecified
+    if (lower === "::" || lower === "0:0:0:0:0:0:0:0") return true;
+    // fc00::/7 unique local addresses (fc.. and fd..)
+    if (lower.startsWith("fc") || lower.startsWith("fd")) return true;
+    // fe80::/10 link-local (fe80..febf)
+    if (
+      lower.startsWith("fe8") || lower.startsWith("fe9") ||
+      lower.startsWith("fea") || lower.startsWith("feb")
+    ) return true;
+    // S5 fix: ::ffff:<v4-mapped> — both dotted-quad AND hex forms.
+    // URL.hostname normalizes `::ffff:127.0.0.1` → `::ffff:7f00:1` so a regex
+    // matching only the dotted-quad form (original PR#34 implementation) was
+    // bypassable. Cover both representations.
+    const v4MappedDot = lower.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/);
+    if (v4MappedDot) return isPrivateIPv4(v4MappedDot[1]);
+    const v4MappedHex = lower.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
+    if (v4MappedHex) {
+      const high = parseInt(v4MappedHex[1], 16);
+      const low = parseInt(v4MappedHex[2], 16);
+      const dotted = `${(high >> 8) & 0xff}.${high & 0xff}.${(low >> 8) & 0xff}.${low & 0xff}`;
+      return isPrivateIPv4(dotted);
+    }
+    // IPv4-compatible IPv6: `::a.b.c.d` (deprecated form, but resolvable).
+    const v4CompatDot = lower.match(/^::(\d+\.\d+\.\d+\.\d+)$/);
+    if (v4CompatDot) return isPrivateIPv4(v4CompatDot[1]);
+    // IPv4-compatible IPv6 hex form: `::a:b` where a:b decodes to dotted-quad.
+    const v4CompatHex = lower.match(/^::([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
+    if (v4CompatHex) {
+      const high = parseInt(v4CompatHex[1], 16);
+      const low = parseInt(v4CompatHex[2], 16);
+      const dotted = `${(high >> 8) & 0xff}.${high & 0xff}.${(low >> 8) & 0xff}.${low & 0xff}`;
+      return isPrivateIPv4(dotted);
+    }
+    return false;
+  }
+  // Not a valid IP literal — caller should resolve via DNS first.
+  return false;
+}
+
+function isPrivateIPv4(address: string): boolean {
+  const parts = address.split(".").map(Number);
+  if (parts.length !== 4 || parts.some(p => Number.isNaN(p) || p < 0 || p > 255)) {
+    return false;
+  }
+  const [a, b] = parts;
+  // 127.0.0.0/8 loopback
+  if (a === 127) return true;
+  // 10.0.0.0/8 private
+  if (a === 10) return true;
+  // 172.16.0.0/12 private
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  // 192.168.0.0/16 private
+  if (a === 192 && b === 168) return true;
+  // 169.254.0.0/16 link-local (includes AWS/GCP metadata 169.254.169.254)
+  if (a === 169 && b === 254) return true;
+  // 100.64.0.0/10 CGN (carrier-grade NAT, shared address space)
+  if (a === 100 && b >= 64 && b <= 127) return true;
+  // 0.0.0.0/8 unspecified / current network
+  if (a === 0) return true;
+  return false;
+}
+
+/**
+ * Validate a URL's host is publicly routable. Throws on:
+ *   - non-http(s) scheme
+ *   - IP literal in private/loopback/link-local range
+ *   - hostname resolving to ANY private/local address
+ */
+export async function assertPublicUrl(rawUrl: string): Promise<void> {
+  const u = new URL(rawUrl);
+
+  // Reject non-http(s) schemes — gopher://, file://, dict:// etc.
+  if (u.protocol !== "http:" && u.protocol !== "https:") {
+    throw new Error(`Refusing to fetch non-http(s) URL: ${u.protocol}`);
+  }
+
+  const host = u.hostname;
+  // IPv6 hostnames come bracketed in URL.hostname — strip for isIP/dns.
+  const bareHost = host.startsWith("[") && host.endsWith("]") ? host.slice(1, -1) : host;
+
+  // Reject IP literals in private/loopback/link-local ranges immediately.
+  if (isIP(bareHost)) {
+    if (isPrivateOrLocalAddress(bareHost)) {
+      throw new Error(`Refusing to fetch private/local address: ${bareHost}`);
+    }
+    return;
+  }
+
+  // Resolve hostname — reject if ANY resolved address is private/local.
+  const addresses = await dnsLookup(bareHost, { all: true });
+  if (addresses.length === 0) {
+    throw new Error(`DNS resolution returned no addresses for: ${bareHost}`);
+  }
+  for (const { address } of addresses) {
+    if (isPrivateOrLocalAddress(address)) {
+      throw new Error(
+        `Refusing to fetch ${bareHost}: resolves to private/local address ${address}`,
+      );
+    }
+  }
+}
+
+/** Maximum HTTP redirects to follow before giving up. */
+const MAX_REDIRECTS = 10;
+
+/**
+ * Per-hop init callback for fetchWithRedirectGuard.
+ *
+ * Called for each hop with the URL about to be fetched (initial URL on hop
+ * 0, redirect Location on later hops). Returns the RequestInit to use for
+ * that hop. Allows callers to scope credentials per-hop — e.g. drop
+ * Authorization when the target host changes.
+ *
+ * Receives `previousUrl` so the callback can compare host transitions
+ * (initial → hop 1) without re-parsing.
+ */
+export type PerHopInit = (
+  currentUrl: string,
+  previousUrl: string | null,
+) => RequestInit & { signal?: AbortSignal };
+
+/**
+ * Fetch wrapper that re-validates SSRF on every HTTP redirect (S2).
+ *
+ * Default `fetch()` follows redirects automatically — an attacker can register
+ * `https://attacker.com` that 302's to `http://127.0.0.1/admin`, completely
+ * bypassing `assertPublicUrl(originalUrl)`. This wrapper sets
+ * `redirect: 'manual'` and manually walks the chain, validating each hop.
+ *
+ * Callers should still call `assertPublicUrl(url)` once upfront; this wrapper
+ * handles ONLY the redirect chain. The reason for the split: assertPublicUrl
+ * fails fast before any network I/O for the obvious cases.
+ *
+ * **Credential safety (S1 follow-up fix, addressed in PR#38 re-review):**
+ *
+ * The `init` parameter is REUSED on every hop, which means any headers in it
+ * (e.g. Authorization) follow the redirect chain. This is the SAME bug as
+ * default `fetch()` does — a same-host request that 302s to attacker.com
+ * sends the Authorization header to the attacker.
+ *
+ * Two modes:
+ *   1. Static `init` — backward-compatible, headers flow on every hop.
+ *      Caller is responsible for either (a) only using this for URLs they
+ *      control end-to-end, or (b) not including sensitive headers.
+ *   2. `perHopInit` callback — caller decides per-hop what init to use,
+ *      typically scoping Authorization to apiUrl host only. Recommended
+ *      whenever Authorization is involved.
+ *
+ * If both are provided, `perHopInit` wins. If neither is provided, an
+ * empty init is used.
+ */
+export async function fetchWithRedirectGuard(
+  url: string,
+  init: (RequestInit & { signal?: AbortSignal }) | PerHopInit = {},
+): Promise<Response> {
+  const buildInit: PerHopInit =
+    typeof init === "function" ? init : () => init;
+
+  let currentUrl = url;
+  let previousUrl: string | null = null;
+  for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+    // Re-validate on every hop (including the first, in case of caller mistake).
+    await assertPublicUrl(currentUrl);
+
+    const hopInit = buildInit(currentUrl, previousUrl);
+    const resp = await fetch(currentUrl, { ...hopInit, redirect: "manual" });
+
+    // 3xx — follow manually after validation.
+    if (resp.status >= 300 && resp.status < 400) {
+      const location = resp.headers.get("location");
+      if (!location) {
+        return resp;
+      }
+      const next = new URL(location, currentUrl).toString();
+      previousUrl = currentUrl;
+      currentUrl = next;
+      try { await resp.body?.cancel(); } catch { /* ignore */ }
+      continue;
+    }
+
+    return resp;
+  }
+  throw new Error(`Refusing to follow more than ${MAX_REDIRECTS} redirects (started at ${url})`);
+}
+
+/**
+ * Boot-time apiUrl SSRF check (S6).
+ *
+ * Stricter than `assertPublicUrl`: requires either `https:` to a NON-private
+ * host, or `http:` to an explicit localhost form (for local development only).
+ *
+ * S6 fix: previously `https://` was allowed to ANY host including 127.0.0.1
+ * because we only checked protocol. Now we also reject private IPs for https.
+ */
+export function isAllowedApiUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    const host = parsed.hostname.toLowerCase();
+    const bareHost = host.startsWith("[") && host.endsWith("]") ? host.slice(1, -1) : host;
+
+    if (parsed.protocol === "https:") {
+      // Allow https to any non-private host. https://127.0.0.1 is suspicious
+      // (could be a self-signed mitmproxy if NODE_TLS_REJECT_UNAUTHORIZED=0).
+      if (isIP(bareHost) && isPrivateOrLocalAddress(bareHost)) return false;
+      return true;
+    }
+    if (parsed.protocol === "http:") {
+      return host === "localhost" || host === "127.0.0.1" || host === "[::1]";
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
Wave 1 critical security fix. Extracts URL validation to src/url-policy.ts shared module, closes four P0 + one P1 from five-way audit.

## Vulnerabilities fixed

**S1 — inbound.ts SSRF + botToken leak (most severe)**
Previously: attacker payload.url passed through buildMediaUrl unchanged when absolute, then tryResolveFile fetched with Authorization: Bearer botToken. 5 minutes to bot takeover.
Now: (a) buildMediaUrl rejects cross-host absolute URLs; (b) tryResolveFile calls assertPublicUrl first; (c) Authorization sent ONLY when URL host matches apiUrl — cross-host get NO botToken.

**S2 — HTTP redirect bypass of SSRF**
fetchWithRedirectGuard sets redirect:'manual' + re-validates each hop. MAX_REDIRECTS=10.

**S4 — payload.url path traversal + scheme-relative smuggling** (李飞飞 P1.2)
buildMediaUrl rejects '..', '.', leading '/', '\\', '//'.

**S5 — IPv6 hex v4-mapped form bypass** (毛豆豆 P0-2)
Original PR#34 regex matched only dotted-quad. URL.hostname normalizes [::ffff:127.0.0.1] → [::ffff:7f00:1] (hex). Both forms + IPv4-compatible IPv6 covered.

**S6 — apiUrl SSRF check allowed https://127.0.0.1** (大锤 S5)
isAllowedApiUrl rejects private IPs for https too (self-signed mitmproxy concern).

## Stats
- src/url-policy.ts: new 213-line shared module
- inbound.ts, media-upload.ts, config.ts all now route through url-policy
- 99 new tests across url-policy / redirect-guard / inbound-ssrf / buildMediaUrl
- 559/559 tests pass, tsc clean, 0 lint warnings
- Breaking: tryResolveFile signature adds apiUrl param (index.ts call site updated)