### PR TITLE
fix(D1): protocol DoS + correctness — socket tempBuffer cap, base64 cap, system prompt cap, SDK null guard

### DIFF
--- a/src/__tests__/d1-protocol-dos.test.ts
+++ b/src/__tests__/d1-protocol-dos.test.ts
@@ -1,0 +1,222 @@
+/**
+ * D1 (Wave 2) tests:
+ *  - S6 socket.ts tempBuffer OOM guard + variable-length 4-byte cap
+ *  - S7 api.ts getChannelMessages base64 payload size + array length caps
+ *  - P1-3 agent-bridge.ts buildSystemPrompt 100 KiB cap with truncation
+ *  - P1-4 agent-bridge.ts SDK output null-safety guard
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { buildSystemPrompt } from '../agent-bridge.js';
+
+// ─── P1-3: buildSystemPrompt length cap ───────────────────────────────────────
+
+describe('buildSystemPrompt MAX_SYSTEM_PROMPT_CHARS (D1/P1-3)', () => {
+  it('returns assembled prompt unchanged when under cap', () => {
+    const out = buildSystemPrompt('history line', 'group chat', 'custom prompt');
+    expect(out.length).toBeLessThan(2_000);
+    expect(out).toContain('custom prompt');
+    expect(out).toContain('[Group context]\ngroup chat');
+    expect(out).toContain('[Conversation history]\nhistory line');
+  });
+
+  it('caps total length at 100 KiB when history is huge', () => {
+    // 40 turns × 4 KiB each = 160 KiB worth of history.
+    const turns: string[] = [];
+    for (let i = 0; i < 40; i++) {
+      turns.push(`[user]: turn ${i} ${'x'.repeat(4_000)}`);
+    }
+    const huge = turns.join('\n');
+    const out = buildSystemPrompt(huge, '', '');
+    // 100 KiB hard ceiling plus a small slack for headers/labels.
+    expect(out.length).toBeLessThanOrEqual(110 * 1024);
+    expect(out).toContain('[older turns dropped]');
+    // Tail must be preserved (most recent turn = turn 39).
+    expect(out).toContain('turn 39');
+    // Oldest turn should be dropped.
+    expect(out).not.toContain('turn 0 ');
+  });
+
+  it('preserves security prefix and custom prompt verbatim when truncating', () => {
+    const huge = '[user]: ' + 'a'.repeat(120 * 1024);
+    const out = buildSystemPrompt(huge, '', 'OPERATOR_DIRECTIVE_42');
+    // The non-truncatable sections must survive.
+    expect(out).toContain('OPERATOR_DIRECTIVE_42');
+    expect(out).toContain('coding assistant'); // security prefix excerpt
+  });
+
+  it('caps group context separately when total exceeds the budget', () => {
+    // Push total over 100 KiB so the cap kicks in.
+    const giantGroup = 'msg\n'.repeat(8_000);  // ~32 KB — group is big
+    const giantHistory = '[user]: x'.repeat(20_000); // ~200 KB — forces truncation
+    const out = buildSystemPrompt(giantHistory, giantGroup, '');
+    expect(out.length).toBeLessThanOrEqual(110 * 1024);
+    // Group context budget is 20 KiB — should still appear, but drop oldest.
+    expect(out).toContain('[Group context]');
+    expect(out).toContain('[older messages dropped]');
+  });
+
+  it('drops history entirely if security + custom + group already saturate budget', () => {
+    const giantCustom = 'OP_'.repeat(40_000); // 120 KB custom prompt
+    const out = buildSystemPrompt('history line', 'group chat', giantCustom);
+    // Custom prompt is non-truncatable; we still produce a result.
+    expect(out).toContain(giantCustom);
+    expect(out.length).toBeGreaterThan(115 * 1024); // custom dominates
+    // The trailing [Conversation history] section (the appended one, not the
+    // literal mention inside the security prefix) should be truncated to a
+    // tiny tail since budget is exhausted.
+    const lastHistIdx = out.lastIndexOf('[Conversation history]');
+    const histTail = out.substring(lastHistIdx);
+    expect(histTail.length).toBeLessThan(5 * 1024);
+  });
+});
+
+// ─── P1-4: queryAgent SDK output null-safety ─────────────────────────────────
+
+describe('queryAgent assistant.message null-safety (D1/P1-4)', () => {
+  it('does not throw when SDK yields assistant message with undefined content', async () => {
+    vi.resetModules();
+    vi.doMock('@anthropic-ai/claude-agent-sdk', () => ({
+      query: () => ({
+        async *[Symbol.asyncIterator]() {
+          yield { type: 'assistant', message: {} };       // .content missing
+          yield { type: 'assistant', message: { content: undefined } }; // .content undefined
+          yield { type: 'assistant', message: { content: [{ type: 'text', text: 'ok' }] } };
+          yield { type: 'result', subtype: 'success' };
+        },
+        close: vi.fn(),
+      }),
+    }));
+    const { queryAgent } = await import('../agent-bridge.js');
+    const out: string[] = [];
+    for await (const chunk of queryAgent('hi', '', '', {
+      cwd: '/tmp',
+      sdk: {
+        permissionMode: 'bypassPermissions',
+        settingSources: ['user'],
+        allowedTools: [],
+      },
+    } as never)) {
+      out.push(chunk);
+    }
+    expect(out.join('')).toBe('ok');
+  });
+
+  it('does not throw when assistant message lacks message field entirely', async () => {
+    vi.resetModules();
+    vi.doMock('@anthropic-ai/claude-agent-sdk', () => ({
+      query: () => ({
+        async *[Symbol.asyncIterator]() {
+          yield { type: 'assistant' };                    // .message missing entirely
+          yield { type: 'result', subtype: 'success' };
+        },
+        close: vi.fn(),
+      }),
+    }));
+    const { queryAgent } = await import('../agent-bridge.js');
+    const out: string[] = [];
+    for await (const chunk of queryAgent('hi', '', '', {
+      cwd: '/tmp',
+      sdk: {
+        permissionMode: 'bypassPermissions',
+        settingSources: ['user'],
+        allowedTools: [],
+      },
+    } as never)) {
+      out.push(chunk);
+    }
+    expect(out).toEqual([]);
+  });
+});
+
+// ─── S7: getChannelMessages payload + count caps ─────────────────────────────
+
+describe('getChannelMessages defensive caps (D1/S7)', () => {
+  let mockFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    mockFetch = vi.fn();
+    vi.stubGlobal('fetch', mockFetch);
+  });
+
+  it('drops oversized base64 payload instead of decoding to a 75 MB Buffer', async () => {
+    // Construct a server response with one message carrying a > 256 KiB
+    // base64 payload. The pre-fix path would call Buffer.from on it.
+    const oversized = 'A'.repeat(300 * 1024);
+    mockFetch.mockResolvedValue({
+      ok: true,
+      text: () =>
+        Promise.resolve(
+          JSON.stringify({
+            messages: [
+              { from_uid: 'u1', timestamp: 1, payload: oversized },
+            ],
+          }),
+        ),
+    });
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { getChannelMessages } = await import('../octo/api.js');
+    const out = await getChannelMessages({
+      apiUrl: 'https://api',
+      botToken: 't',
+      channelId: 'ch',
+      channelType: 2,
+    });
+    expect(out).toHaveLength(1);
+    expect(out[0].payload).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('dropping oversized payload'),
+    );
+    warnSpy.mockRestore();
+  });
+
+  it('caps returned messages at requested limit even when server returns more', async () => {
+    const items = Array.from({ length: 100 }, (_, i) => ({
+      from_uid: `u${i}`,
+      timestamp: i,
+      content: `m${i}`,
+    }));
+    mockFetch.mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve(JSON.stringify({ messages: items })),
+    });
+
+    const { getChannelMessages } = await import('../octo/api.js');
+    const out = await getChannelMessages({
+      apiUrl: 'https://api',
+      botToken: 't',
+      channelId: 'ch',
+      channelType: 2,
+      limit: 10,
+    });
+    expect(out).toHaveLength(10);
+    expect(out[0].from_uid).toBe('u0');
+    expect(out[9].from_uid).toBe('u9');
+  });
+
+  it('still decodes well-sized payloads successfully', async () => {
+    const json = JSON.stringify({ type: 1, content: 'hello' });
+    const b64 = Buffer.from(json, 'utf-8').toString('base64');
+    mockFetch.mockResolvedValue({
+      ok: true,
+      text: () =>
+        Promise.resolve(
+          JSON.stringify({
+            messages: [{ from_uid: 'u1', timestamp: 1, payload: b64 }],
+          }),
+        ),
+    });
+
+    const { getChannelMessages } = await import('../octo/api.js');
+    const out = await getChannelMessages({
+      apiUrl: 'https://api',
+      botToken: 't',
+      channelId: 'ch',
+      channelType: 2,
+    });
+    expect(out).toHaveLength(1);
+    expect(out[0].payload).toEqual({ type: 1, content: 'hello' });
+  });
+});

--- a/src/__tests__/octo/d1-socket-dos.test.ts
+++ b/src/__tests__/octo/d1-socket-dos.test.ts
@@ -1,0 +1,149 @@
+/**
+ * D1/S6 (齐 P0-1): tempBuffer OOM + variable-length 4-byte cap tests.
+ *
+ * Verifies that a misbehaving server cannot exhaust the bot's memory by
+ * sending partial packets or unending variable-length encoding bytes.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Buffer } from 'buffer';
+
+// ─── Shared WebSocket mock (same shape as wksocket-packet.test.ts) ──────────
+
+interface IMockWS {
+  sent: Uint8Array[];
+  on(event: string, handler: (...args: unknown[]) => void): void;
+  send(data: Uint8Array): void;
+  close(): void;
+  removeAllListeners(): void;
+  emit(event: string, ...args: unknown[]): void;
+}
+
+const wsRef = vi.hoisted(() => ({ current: null as IMockWS | null }));
+const wsCloseSpy = vi.hoisted(() => vi.fn());
+
+vi.mock('ws', () => {
+  class MockWS {
+    binaryType = 'arraybuffer';
+    readyState = 1;
+    sent: Uint8Array[] = [];
+    private _handlers = new Map<string, ((...args: unknown[]) => void)[]>();
+
+    static OPEN = 1;
+
+    constructor() {
+      wsRef.current = this;
+    }
+
+    on(event: string, handler: (...args: unknown[]) => void): void {
+      if (!this._handlers.has(event)) this._handlers.set(event, []);
+      this._handlers.get(event)!.push(handler);
+    }
+
+    send(data: Uint8Array): void {
+      this.sent.push(new Uint8Array(data));
+    }
+
+    close(): void {
+      wsCloseSpy();
+    }
+    removeAllListeners(): void {}
+
+    emit(event: string, ...args: unknown[]): void {
+      for (const h of this._handlers.get(event) ?? []) {
+        h(...args);
+      }
+    }
+  }
+
+  return { default: MockWS };
+});
+
+import { WKSocket } from '../../octo/socket.js';
+
+function makeSocket(): WKSocket {
+  return new WKSocket({
+    wsUrl: 'wss://test.example.com/v1',
+    uid: 'bot_uid',
+    token: 'bot_token',
+    onMessage: vi.fn(),
+    onConnected: vi.fn(),
+    onError: vi.fn(),
+    onDisconnected: vi.fn(),
+  });
+}
+
+describe('WKSocket DoS hardening (D1/S6)', () => {
+  let socket: WKSocket | null = null;
+
+  beforeEach(() => {
+    wsRef.current = null;
+    wsCloseSpy.mockReset();
+  });
+
+  afterEach(() => {
+    socket?.disconnect();
+    socket = null;
+  });
+
+  it('closes connection when tempBuffer exceeds 1 MiB cap (P0-1)', () => {
+    socket = makeSocket();
+    socket.connect();
+    const ws = wsRef.current!;
+    ws.emit('open');
+
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    // Send a chunk of 2 MiB of partial packet data — packetType is REPLY (0x50),
+    // so unpackOne tries to read variable-length, eventually hits the 4-byte
+    // cap and throws OR the size cap kicks in first.
+    const huge = new Uint8Array(2 * 1024 * 1024);
+    // Make it look like a legitimate packet header without ending the length.
+    huge[0] = 0x50;
+    for (let i = 1; i < huge.length; i++) huge[i] = 0x80; // continuation byte forever
+
+    ws.emit('message', Buffer.from(huge));
+
+    // Either the size cap or the varlen cap fired → ws.close should have been
+    // invoked at least once.
+    expect(wsCloseSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+
+  it('rejects malformed variable-length > 4 bytes (P0-1 varlen cap)', () => {
+    socket = makeSocket();
+    socket.connect();
+    const ws = wsRef.current!;
+    ws.emit('open');
+
+    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+
+    // 5 continuation bytes (0x80 with high bit set) → exceeds 4-byte MQTT cap.
+    // Header (0x50) + 0x80 0x80 0x80 0x80 0x80 0x01 ...
+    const malformed = new Uint8Array([
+      0x50, 0x80, 0x80, 0x80, 0x80, 0x80, 0x01,
+    ]);
+    ws.emit('message', Buffer.from(malformed));
+
+    // The decode error handler closes the ws.
+    expect(wsCloseSpy).toHaveBeenCalled();
+    expect(debugSpy).toHaveBeenCalledWith(
+      '[WKSocket] decode error:',
+      expect.objectContaining({
+        message: expect.stringContaining('variable-length encoding exceeded'),
+      }),
+    );
+    debugSpy.mockRestore();
+  });
+
+  it('accepts normal small packets that fit well under the cap', () => {
+    socket = makeSocket();
+    socket.connect();
+    const ws = wsRef.current!;
+    ws.emit('open');
+
+    // PONG is a single byte: 0x80. Should not trigger close.
+    ws.emit('message', Buffer.from([0x80]));
+    expect(wsCloseSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/agent-bridge.ts
+++ b/src/agent-bridge.ts
@@ -125,7 +125,94 @@ export function buildSystemPrompt(
     const sanitized = sanitizeForSystemPrompt(historyPrefix);
     parts.push(`[Conversation history]\n${sanitized}`);
   }
-  return parts.join('\n\n');
+  const assembled = parts.join('\n\n');
+  // D1/P1-3 (齐 P1-3): cap the assembled system prompt to prevent
+  // SDK context_length_exceeded errors. History/groupContext can grow
+  // unbounded with long messages × historyLimit (default 40) × maxContextChars
+  // (default 6000). 100 KiB is comfortably above any realistic legitimate
+  // prompt while staying well under model context limits.
+  if (assembled.length <= MAX_SYSTEM_PROMPT_CHARS) {
+    return assembled;
+  }
+  return truncateSystemPrompt(parts);
+}
+
+/**
+ * Maximum assembled system prompt length in characters.
+ * Beyond this, history is truncated (keeping the most recent entries)
+ * to fit. Security prefix + custom prompt are always preserved.
+ */
+const MAX_SYSTEM_PROMPT_CHARS = 100 * 1024;
+
+/**
+ * Best-effort truncation: keep SECURITY_PROMPT_PREFIX + customPrompt intact,
+ * then preserve the tail of history (most recent) within the remaining budget.
+ * GroupContext is preserved up to a fixed share; the rest of the budget goes
+ * to history.
+ */
+function truncateSystemPrompt(parts: string[]): string {
+  // parts layout (some may be absent): [securityPrefix, customPrompt?,
+  // "[Group context]\n..."?, "[Conversation history]\n..."?]
+  const securityPrefix = parts[0];
+  // Reserved for non-truncated sections.
+  const reservedNonHistory: string[] = [securityPrefix];
+  let used = securityPrefix.length + 2; // +2 for join "\n\n"
+  let groupSection: string | undefined;
+  let historySection: string | undefined;
+  // Pull customPrompt + groupContext into reserved up-front so they can be
+  // budgeted before we drop history lines.
+  for (let i = 1; i < parts.length; i++) {
+    const p = parts[i];
+    if (p.startsWith('[Group context]\n')) {
+      groupSection = p;
+    } else if (p.startsWith('[Conversation history]\n')) {
+      historySection = p;
+    } else {
+      reservedNonHistory.push(p);
+      used += p.length + 2;
+    }
+  }
+  // Group context: keep up to 20 KiB, drop oldest lines if needed.
+  const groupBudget = 20 * 1024;
+  if (groupSection) {
+    if (groupSection.length <= groupBudget) {
+      reservedNonHistory.push(groupSection);
+      used += groupSection.length + 2;
+    } else {
+      const header = '[Group context]\n';
+      const body = groupSection.substring(header.length);
+      const lines = body.split('\n');
+      let kept: string[] = [];
+      let keptLen = 0;
+      for (let i = lines.length - 1; i >= 0; i--) {
+        const candidate = lines[i].length + 1;
+        if (keptLen + candidate > groupBudget) break;
+        kept.unshift(lines[i]);
+        keptLen += candidate;
+      }
+      const truncatedGroup = header + '[older messages dropped]\n' + kept.join('\n');
+      reservedNonHistory.push(truncatedGroup);
+      used += truncatedGroup.length + 2;
+    }
+  }
+  // History: take remaining budget for the tail of the section.
+  if (historySection) {
+    const header = '[Conversation history]\n';
+    const body = historySection.substring(header.length);
+    const remaining = Math.max(1024, MAX_SYSTEM_PROMPT_CHARS - used - header.length - 64);
+    const lines = body.split('\n');
+    let kept: string[] = [];
+    let keptLen = 0;
+    for (let i = lines.length - 1; i >= 0; i--) {
+      const candidate = lines[i].length + 1;
+      if (keptLen + candidate > remaining) break;
+      kept.unshift(lines[i]);
+      keptLen += candidate;
+    }
+    const truncatedHistory = header + '[older turns dropped]\n' + kept.join('\n');
+    reservedNonHistory.push(truncatedHistory);
+  }
+  return reservedNonHistory.join('\n\n');
 }
 
 /**
@@ -197,7 +284,11 @@ export async function* queryAgent(
   try {
     for await (const message of stream) {
       if (message.type === 'assistant') {
-        for (const block of message.message.content) {
+        // D1/P1-4 (齐 P1-4): guard against malformed SDK output — if the
+        // assistant message lacks `.message` or `.message.content`, treat as
+        // empty rather than throwing TypeError into the async generator.
+        const content = message.message?.content ?? [];
+        for (const block of content) {
           if (block.type === 'text' && block.text) {
             yield block.text;
           }

--- a/src/octo/api.ts
+++ b/src/octo/api.ts
@@ -15,6 +15,15 @@ import { randomUUID } from "node:crypto";
 const DEFAULT_TIMEOUT_MS = 30_000;
 
 /**
+ * Maximum base64-encoded payload length accepted from /v1/bot/messages/sync.
+ * D1/S7 (齐 P0-2): a malicious or buggy server could return a single payload
+ * of arbitrary size; Buffer.from(str, 'base64') allocates ~0.75 × input bytes
+ * synchronously. Cap at 256 KiB base64 ≈ 192 KiB decoded — well above any
+ * legitimate IM message payload.
+ */
+const MAX_HISTORICAL_PAYLOAD_BASE64_LEN = 256 * 1024;
+
+/**
  * Generate a client-side idempotency key (UUID) for outbound messages.
  *
  * WuKongIM uses client_msg_no for server-side dedup — identical client_msg_no
@@ -599,13 +608,27 @@ export async function getChannelMessages(params: {
       params.signal,
     );
     const messages = result?.messages ?? [];
-    return messages.map((m) => {
+    // D1/S7 (齐 P0-2): client-side cap on returned message count. The server
+    // could return more than `limit` requested (bug or malice); we map +
+    // decode each item which is O(payload size) per message.
+    const cap = params.limit ?? 20;
+    const limited = messages.length > cap ? messages.slice(0, cap) : messages;
+    return limited.map((m) => {
       let payload: Record<string, unknown> | undefined;
       if (typeof m.payload === 'string') {
-        try {
-          payload = JSON.parse(Buffer.from(m.payload, 'base64').toString('utf-8'));
-        } catch {
-          // Leave payload undefined if decoding fails
+        // D1/S7 (齐 P0-2): cap base64 payload size before decoding. A 100 MB
+        // base64 string would force Buffer.from to allocate ~75 MB synchronously.
+        // 256 KiB decoded ≈ 192 KiB binary, well above any legitimate IM payload.
+        if (m.payload.length > MAX_HISTORICAL_PAYLOAD_BASE64_LEN) {
+          console.warn(
+            `octo: getChannelMessages dropping oversized payload (${m.payload.length} base64 chars > ${MAX_HISTORICAL_PAYLOAD_BASE64_LEN})`,
+          );
+        } else {
+          try {
+            payload = JSON.parse(Buffer.from(m.payload, 'base64').toString('utf-8'));
+          } catch {
+            // Leave payload undefined if decoding fails
+          }
         }
       } else if (m.payload && typeof m.payload === 'object') {
         payload = m.payload as Record<string, unknown>;

--- a/src/octo/socket.ts
+++ b/src/octo/socket.ts
@@ -27,6 +27,21 @@ const enum PacketType {
 
 const PROTO_VERSION = 4;
 
+/**
+ * Maximum bytes allowed in the WebSocket inbound assembly buffer.
+ * D1/S6 (齐 P0-1): a malicious server can send partial packets indefinitely
+ * (e.g. an unending variable-length encoding) and OOM the bot. 1 MiB is
+ * >> any legitimate single packet — if we cross it, close + reconnect.
+ */
+const MAX_TEMP_BUFFER_BYTES = 1 * 1024 * 1024;
+
+/**
+ * Maximum bytes used to encode a single variable-length integer (MQTT spec).
+ * D1/S6: refuse > 4 continuation bytes — anything longer is malformed and
+ * keeps tempBuffer filling forever.
+ */
+const MAX_VARLEN_BYTES = 4;
+
 // ─── Binary Encoder / Decoder ───────────────────────────────────────────────
 
 export class Encoder {
@@ -499,6 +514,20 @@ export class WKSocket extends EventEmitter {
   private handleRawData(data: Uint8Array): void {
     for (let i = 0; i < data.length; i++) this.tempBuffer.push(data[i]);
 
+    // D1/S6 (齐 P0-1): cap tempBuffer at MAX_TEMP_BUFFER_BYTES to prevent
+    // unbounded growth from a malicious/buggy server that sends partial
+    // packets indefinitely (e.g. an unending variable-length encoding).
+    if (this.tempBuffer.length > MAX_TEMP_BUFFER_BYTES) {
+      console.error(
+        `[WKSocket] tempBuffer exceeded ${MAX_TEMP_BUFFER_BYTES} bytes (got ${this.tempBuffer.length}) — dropping and reconnecting`,
+      );
+      this.tempBuffer = [];
+      if (this.ws) {
+        try { this.ws.close(); } catch { /* ignore */ }
+      }
+      return;
+    }
+
     try {
       let lenBefore: number;
       let lenAfter: number;
@@ -545,6 +574,15 @@ export class WKSocket extends EventEmitter {
       if (pos > length - 1) {
         remLengthFull = false;
         break;
+      }
+      // D1/S6 (齐 P0-1): cap at MAX_VARLEN_BYTES per MQTT spec. Without
+      // this, a stream of 0x80 bytes would never terminate and would let
+      // tempBuffer grow until handleRawData kills the connection — raise
+      // earlier and more explicitly here.
+      if (pos - fixedHeaderLength >= MAX_VARLEN_BYTES) {
+        throw new Error(
+          `[WKSocket] variable-length encoding exceeded ${MAX_VARLEN_BYTES} bytes — malformed packet`,
+        );
       }
       const digit = data[pos++];
       remLength += (digit & 127) * multiplier;


### PR DESCRIPTION
## D1 — Wave 2 batch (4 P0/P1 fixes from Phase 6 audit)

Originally proposed five fixes; one (onPacket stale guard) dropped after re-verification — see below.

### S6 (P0-1) — socket.ts tempBuffer OOM
Two-layer defense:
1. `MAX_TEMP_BUFFER_BYTES = 1 MiB` cap in `handleRawData`. If exceeded → drop buffer + close ws (reconnect logic recovers).
2. `MAX_VARLEN_BYTES = 4` inside `unpackOne` — matches MQTT spec. Stream of 0x80 continuation bytes can never exceed 4 bytes legally.

### S7 (P0-2) — getChannelMessages base64 + count caps
1. Per-message payload base64 string capped at 256 KiB (≈ 192 KiB decoded). Oversized payload skipped + warn log.
2. Result array capped at `limit` (default 20) even if server returns more.

### P1-3 — buildSystemPrompt 100 KiB hard cap
`MAX_SYSTEM_PROMPT_CHARS = 100 KiB`. Beyond it: history truncated tail-preserving (most recent kept), group context capped at 20 KiB share (oldest dropped). Security prefix + custom prompt never truncated.

### P1-4 — queryAgent SDK null safety
`message.message?.content ?? []` guards against malformed SDK output.

### Dropped (P1-6 onPacket stale guard)
After rechecking the code, all packet handlers (`onPacket`, `onConnack`, `onRecv`, `onDisconnect`) are synchronous — no awaits between the `ws.on('message')` entry guard and the writes to `this.connected` / `this.aesKey` etc. The existing entry guard is sufficient. My audit concern was theoretical.

### Tests (13 new)
- 10 unit tests in `d1-protocol-dos.test.ts`: buildSystemPrompt under-cap pass-through, history truncation, custom-prompt preservation, group budget, exhausted-budget; queryAgent null content / missing message field; getChannelMessages oversized payload drop / count cap / normal decode
- 3 socket integration tests in `octo/d1-socket-dos.test.ts`: 2 MiB partial-packet flood triggers buffer cap + close, 5-byte varlen triggers cap + close, normal PONG doesn't close

### Verification
- `tsc --noEmit`: clean
- `npm run lint` (eslint --max-warnings 0): clean
- `npx vitest run`: 473/473 (460 baseline + 13 new)
- Pre-commit hook (lint-staged + tsc) ran on commit

### Coordination notes
- **Conflict potential with PR#37 (S3)**: both touch `agent-bridge.ts buildSystemPrompt`. My change is purely additive at the END (cap + helper function). PR#37's edits are inside SECURITY_PROMPT_PREFIX / SECTION_MARKER_RE / buildSystemPrompt body (sanitize groupContext). Should rebase cleanly. If PR#37 lands first I'll rebase D1; if D1 lands first PR#37 rebases.
- C1 (飞飞) blocked on D1's buildSystemPrompt cap so D1 lands first per Wave 2 plan.