### PR TITLE
fix(C1): RichText crash + budgets + G4 payload merge + rejection cache guard

### DIFF
--- a/src/__tests__/c1-rejection-userguard.test.ts
+++ b/src/__tests__/c1-rejection-userguard.test.ts
@@ -1,0 +1,161 @@
+/**
+ * C1 (Stage 6) — RouteResult.rejectionReason + userContent type guard.
+ *
+ * P1.1: index.ts userContent fallback now uses typeof === 'string' guard so
+ *       RichText/File payloads with array/object content don't crash SQLite.
+ * P2.5: SessionRouter attaches rejectionReason on rate-limited/oversized so
+ *       index.ts can suppress group context caching for those messages.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SessionRouter } from '../session-router.js';
+import { ChannelType, MessageType } from '../octo/types.js';
+import type { BotMessage } from '../octo/types.js';
+import type { Config } from '../config.js';
+
+// Mock sendMessage so replySafe doesn't hit the network
+vi.mock('../octo/api.js', async () => {
+  const actual = await vi.importActual<typeof import('../octo/api.js')>('../octo/api.js');
+  return {
+    ...actual,
+    sendMessage: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+const ROBOT_ID = 'bot-xyz';
+const OWNER_UID = 'owner-1';
+
+function makeConfig(overrides: Partial<Config> = {}): Config {
+  return {
+    botToken: 'tok',
+    apiUrl: 'https://test',
+    cwd: '/tmp',
+    dataDir: '/tmp/data',
+    sdk: { allowedTools: [], permissionMode: 'bypassPermissions', settingSources: ['user'] },
+    rateLimit: { maxPerMinute: 5 },
+    context: { maxContextChars: 6000, historyLimit: 40 },
+    maxResponseChars: 524_288,
+    ...overrides,
+  };
+}
+
+function makeMsg(opts: Partial<BotMessage> = {}): BotMessage {
+  return {
+    message_id: '1',
+    message_seq: 1,
+    from_uid: 'user-alice',
+    channel_id: 'dm-1',
+    channel_type: ChannelType.DM,
+    timestamp: Date.now(),
+    payload: { type: MessageType.Text, content: 'hi' },
+    ...opts,
+  };
+}
+
+describe('C1 P2.5: rejectionReason attached to RouteResult', () => {
+  let router: SessionRouter;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    router = new SessionRouter(makeConfig(), ROBOT_ID, OWNER_UID);
+  });
+
+  it('rate-limited message returns rejectionReason="rate_limited"', async () => {
+    const cfg = makeConfig({ rateLimit: { maxPerMinute: 1 } });
+    router = new SessionRouter(cfg, ROBOT_ID, OWNER_UID);
+
+    // First message passes
+    const first = await router.route(makeMsg({ message_id: 'a', message_seq: 1 }));
+    expect(first?.shouldProcess).toBe(true);
+
+    // Second from same user exhausts per-session bucket
+    const second = await router.route(makeMsg({ message_id: 'b', message_seq: 2 }));
+    expect(second?.shouldProcess).toBe(false);
+    expect(second?.rejectionReason).toBe('rate_limited');
+  });
+
+  it('oversized text message returns rejectionReason="oversized"', async () => {
+    const huge = 'A'.repeat(33 * 1024); // 33 KB > 32 KB cap
+    const msg = makeMsg({
+      payload: { type: MessageType.Text, content: huge },
+    });
+    const result = await router.route(msg);
+    expect(result?.shouldProcess).toBe(false);
+    expect(result?.rejectionReason).toBe('oversized');
+  });
+
+  it('legitimate messages have no rejectionReason', async () => {
+    const result = await router.route(makeMsg());
+    expect(result?.shouldProcess).toBe(true);
+    expect(result?.rejectionReason).toBeUndefined();
+  });
+
+  it('routeAndHandle returns the RouteResult including rejectionReason', async () => {
+    const cfg = makeConfig({ rateLimit: { maxPerMinute: 1 } });
+    router = new SessionRouter(cfg, ROBOT_ID, OWNER_UID);
+
+    // Burn the only token
+    await router.routeAndHandle(makeMsg({ message_id: 'a' }), async () => {});
+
+    let handlerCalled = false;
+    const result = await router.routeAndHandle(
+      makeMsg({ message_id: 'b', message_seq: 2 }),
+      async () => { handlerCalled = true; },
+    );
+
+    expect(handlerCalled).toBe(false);
+    expect(result?.shouldProcess).toBe(false);
+    expect(result?.rejectionReason).toBe('rate_limited');
+  });
+});
+
+// ─── P1.1 userContent typeof guard ────────────────────────────────────────
+//
+// The fix lives in index.ts handleMessage. We exercise it at the contract
+// level: simulate the userContent assignment with non-string content and
+// assert the fallback fires.
+
+describe('C1 P1.1: userContent typeof guard prevents RichText/File array crash', () => {
+  function selectUserContent(payloadContent: unknown, historyRecord: string): string {
+    // Mirror the fixed expression in handleMessage:
+    return typeof payloadContent === 'string' ? payloadContent : historyRecord;
+  }
+
+  it('uses historyRecord when payload.content is an array (RichText)', () => {
+    const richTextContent = [
+      { type: 1, text: 'hi' },
+      { type: 2, url: 'file/x.png' },
+    ];
+    const result = selectUserContent(richTextContent, '[RichText placeholder]');
+    expect(result).toBe('[RichText placeholder]');
+    expect(typeof result).toBe('string');
+  });
+
+  it('uses historyRecord when payload.content is an object (defensive)', () => {
+    const objContent = { malicious: true };
+    const result = selectUserContent(objContent, '[fallback]');
+    expect(result).toBe('[fallback]');
+  });
+
+  it('uses historyRecord when payload.content is a number (defensive)', () => {
+    const result = selectUserContent(42, '[fallback]');
+    expect(result).toBe('[fallback]');
+  });
+
+  it('uses payload.content when it is a non-empty string (Text path)', () => {
+    const result = selectUserContent('hello', '[never-used]');
+    expect(result).toBe('hello');
+  });
+
+  it('uses payload.content when it is an empty string (preserves explicit empty)', () => {
+    // Empty string is still a string — pre-fix `?? historyRecord` did NOT fall
+    // back for '', and the new typeof guard preserves that behavior.
+    const result = selectUserContent('', '[never-used]');
+    expect(result).toBe('');
+  });
+
+  it('uses historyRecord when payload.content is null or undefined', () => {
+    expect(selectUserContent(null, '[fb]')).toBe('[fb]');
+    expect(selectUserContent(undefined, '[fb]')).toBe('[fb]');
+  });
+});

--- a/src/__tests__/c1-richtext-budgets.test.ts
+++ b/src/__tests__/c1-richtext-budgets.test.ts
@@ -1,0 +1,299 @@
+/**
+ * C1 (Stage 6) — RichText crash + budgets + G4 backfill + group context suppression.
+ *
+ * Five fixes verified:
+ *   P1.1 userContent typeof guard (RichText/File arrays don't reach SQLite)
+ *   P1.3 MultipleForward depth / msgs / output caps
+ *   P1.4 RichText blocks / mediaUrls / output caps
+ *   P1.5 getChannelMessages decoded payload merged to top level
+ *   P2.5 rate-limited / oversized messages do NOT enter group context
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  resolveRichTextContent,
+  resolveMultipleForwardText,
+  RICH_TEXT_MAX_BLOCKS,
+  RICH_TEXT_MAX_MEDIA_URLS,
+  RICH_TEXT_MAX_OUTPUT_BYTES,
+  MULTIPLE_FORWARD_MAX_DEPTH,
+  MULTIPLE_FORWARD_MAX_MESSAGES,
+  MULTIPLE_FORWARD_MAX_OUTPUT_BYTES,
+} from '../inbound.js';
+import { MessageType, RICH_TEXT_BLOCK_IMAGE, RICH_TEXT_BLOCK_TEXT } from '../octo/types.js';
+
+const API_URL = 'https://api.example.com';
+
+// ─── P1.4 RichText budgets ─────────────────────────────────────────────────
+
+describe('C1 P1.4: RichText input budget', () => {
+  it('caps blocks at RICH_TEXT_MAX_BLOCKS', () => {
+    const blocks = Array.from({ length: RICH_TEXT_MAX_BLOCKS + 100 }, (_, i) => ({
+      type: RICH_TEXT_BLOCK_TEXT,
+      text: `b${i}`,
+    }));
+    const r = resolveRichTextContent({ content: blocks }, API_URL);
+    // text length should equal exactly RICH_TEXT_MAX_BLOCKS blocks worth (~b0..b49)
+    expect(r.text).toContain('b0');
+    expect(r.text).toContain(`b${RICH_TEXT_MAX_BLOCKS - 1}`);
+    expect(r.text).not.toContain(`b${RICH_TEXT_MAX_BLOCKS + 50}`);
+  });
+
+  it('caps mediaUrls at RICH_TEXT_MAX_MEDIA_URLS', () => {
+    const blocks = Array.from({ length: RICH_TEXT_MAX_MEDIA_URLS + 30 }, (_, i) => ({
+      type: RICH_TEXT_BLOCK_IMAGE,
+      url: `file/img${i}.png`,
+    }));
+    const r = resolveRichTextContent({ content: blocks }, API_URL);
+    expect(r.mediaUrls).toHaveLength(RICH_TEXT_MAX_MEDIA_URLS);
+  });
+
+  it('truncates output text at RICH_TEXT_MAX_OUTPUT_BYTES with marker', () => {
+    const huge = 'A'.repeat(RICH_TEXT_MAX_OUTPUT_BYTES + 5_000);
+    const r = resolveRichTextContent(
+      { content: [{ type: RICH_TEXT_BLOCK_TEXT, text: huge }] },
+      API_URL,
+    );
+    expect(Buffer.byteLength(r.text, 'utf-8'))
+      .toBeLessThanOrEqual(RICH_TEXT_MAX_OUTPUT_BYTES + 40); // marker overhead
+    expect(r.text).toContain('[RichText truncated]');
+  });
+
+  it('byte-safe truncation does not split multi-byte CJK chars', () => {
+    // 每个汉字 3 bytes，构造刚好超过限制的串
+    const cjkPerChar = '一'; // 3 bytes
+    const charCount = Math.floor(RICH_TEXT_MAX_OUTPUT_BYTES / 3) + 100;
+    const cjkStr = cjkPerChar.repeat(charCount);
+    const r = resolveRichTextContent(
+      { content: [{ type: RICH_TEXT_BLOCK_TEXT, text: cjkStr }] },
+      API_URL,
+    );
+    // Body without marker should be valid UTF-8 (no half-char)
+    const withoutMarker = r.text.replace('[RichText truncated]', '').trimEnd();
+    // round-trip via Buffer to confirm no replacement chars
+    const roundTripped = Buffer.from(withoutMarker, 'utf-8').toString('utf-8');
+    expect(roundTripped).toBe(withoutMarker);
+    expect(roundTripped).not.toContain('\ufffd');
+  });
+
+  it('benign small RichText passes through unmodified', () => {
+    const r = resolveRichTextContent(
+      {
+        content: [
+          { type: RICH_TEXT_BLOCK_TEXT, text: 'hello ' },
+          { type: RICH_TEXT_BLOCK_IMAGE, url: 'file/x.png' },
+          { type: RICH_TEXT_BLOCK_TEXT, text: ' world' },
+        ],
+      },
+      API_URL,
+    );
+    expect(r.text).toBe('hello [图片] world');
+    expect(r.text).not.toContain('[RichText truncated]');
+    expect(r.mediaUrls).toHaveLength(1);
+  });
+});
+
+// ─── P1.3 MultipleForward budgets ──────────────────────────────────────────
+
+describe('C1 P1.3: MultipleForward depth + msg + output caps', () => {
+  function makeForwardPayload(content: string) {
+    return {
+      type: MessageType.MultipleForward as const,
+      users: [{ uid: 'u', name: 'U' }],
+      msgs: [
+        { from_uid: 'u', payload: { type: MessageType.Text, content } },
+      ],
+    };
+  }
+
+  it('emits truncation marker beyond MULTIPLE_FORWARD_MAX_DEPTH', () => {
+    // Build nesting deeper than the cap
+    let inner: ReturnType<typeof makeForwardPayload> = makeForwardPayload('deepest');
+    for (let i = 0; i < MULTIPLE_FORWARD_MAX_DEPTH + 2; i++) {
+      inner = {
+        type: MessageType.MultipleForward,
+        users: [{ uid: 'u', name: 'U' }],
+        msgs: [{ from_uid: 'u', payload: inner }],
+      };
+    }
+    const out = resolveMultipleForwardText(inner, API_URL);
+    expect(out).toContain('嵌套已截断');
+    // Should NOT recurse so deep that the original "deepest" appears
+    expect(out).not.toContain('deepest');
+  });
+
+  it('caps msgs per level and emits residual count', () => {
+    const tooMany = Array.from({ length: MULTIPLE_FORWARD_MAX_MESSAGES + 17 }, (_, i) => ({
+      from_uid: 'u',
+      payload: { type: MessageType.Text, content: `m${i}` },
+    }));
+    const out = resolveMultipleForwardText({
+      users: [{ uid: 'u', name: 'U' }],
+      msgs: tooMany,
+    }, API_URL);
+    expect(out).toContain('m0');
+    expect(out).toContain(`m${MULTIPLE_FORWARD_MAX_MESSAGES - 1}`);
+    expect(out).not.toContain(`m${MULTIPLE_FORWARD_MAX_MESSAGES + 5}`);
+    expect(out).toContain('还有 17 条消息未展示');
+  });
+
+  it('caps total output bytes', () => {
+    const huge = 'A'.repeat(MULTIPLE_FORWARD_MAX_OUTPUT_BYTES + 2_000);
+    const out = resolveMultipleForwardText({
+      users: [{ uid: 'u', name: 'U' }],
+      msgs: [{ from_uid: 'u', payload: { type: MessageType.Text, content: huge } }],
+    }, API_URL);
+    expect(Buffer.byteLength(out, 'utf-8'))
+      .toBeLessThanOrEqual(MULTIPLE_FORWARD_MAX_OUTPUT_BYTES + 50);
+    expect(out).toContain('输出已截断');
+  });
+
+  it('benign small MultipleForward passes through', () => {
+    const out = resolveMultipleForwardText({
+      users: [{ uid: 'a', name: 'Alice' }, { uid: 'b', name: 'Bob' }],
+      msgs: [
+        { from_uid: 'a', payload: { type: MessageType.Text, content: 'hi' } },
+        { from_uid: 'b', payload: { type: MessageType.Text, content: 'world' } },
+      ],
+    }, API_URL);
+    expect(out).toContain('Alice: hi');
+    expect(out).toContain('Bob: world');
+    expect(out).not.toContain('截断');
+  });
+
+  it('does not stack-overflow on adversarial deep nesting', () => {
+    // 100 levels — without depth cap this would blow the stack on parse
+    let inner: ReturnType<typeof makeForwardPayload> = makeForwardPayload('deep');
+    for (let i = 0; i < 100; i++) {
+      inner = {
+        type: MessageType.MultipleForward,
+        users: [{ uid: 'u', name: 'U' }],
+        msgs: [{ from_uid: 'u', payload: inner }],
+      };
+    }
+    expect(() => resolveMultipleForwardText(inner, API_URL)).not.toThrow();
+  });
+});
+
+// ─── P1.5 G4 backfill base64 payload merge ────────────────────────────────
+
+describe('C1 P1.5: getChannelMessages merges decoded payload to top level', () => {
+  it('extracts Text content from base64 payload when top-level content empty', async () => {
+    const { getChannelMessages } = await import('../octo/api.js');
+
+    const samplePayload = { type: 1, content: 'hello from payload' };
+    const payloadB64 = Buffer.from(JSON.stringify(samplePayload), 'utf-8').toString('base64');
+
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: () =>
+        Promise.resolve(
+          JSON.stringify({
+            messages: [
+              {
+                from_uid: 'u1',
+                // No top-level content — only inside payload
+                timestamp: 1,
+                message_seq: 1,
+                payload: payloadB64,
+              },
+            ],
+          }),
+        ),
+    } as unknown as Response);
+
+    const result = await getChannelMessages({
+      apiUrl: 'https://api.example.com',
+      botToken: 'tok',
+      channelId: 'g1',
+      channelType: 2,
+    });
+
+    expect(result).toHaveLength(1);
+    // BEFORE FIX: content was undefined, G4 backfill silently lost the text.
+    // AFTER FIX: payload.content is merged up.
+    expect(result[0].content).toBe('hello from payload');
+    expect(result[0].type).toBe(1);
+  });
+
+  it('top-level fields take precedence when both present', async () => {
+    const { getChannelMessages } = await import('../octo/api.js');
+
+    const payloadB64 = Buffer.from(JSON.stringify({ type: 8, content: 'inner', name: 'inner.txt' }), 'utf-8').toString('base64');
+
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: () =>
+        Promise.resolve(
+          JSON.stringify({
+            messages: [
+              {
+                from_uid: 'u1',
+                content: 'top-level wins',
+                type: 1, // top-level type Text
+                name: 'top.txt', // top-level name wins
+                timestamp: 1,
+                message_seq: 2,
+                payload: payloadB64,
+              },
+            ],
+          }),
+        ),
+    } as unknown as Response);
+
+    const result = await getChannelMessages({
+      apiUrl: 'https://api.example.com',
+      botToken: 'tok',
+      channelId: 'g1',
+      channelType: 2,
+    });
+
+    expect(result[0].content).toBe('top-level wins');
+    expect(result[0].type).toBe(1);
+    expect(result[0].name).toBe('top.txt');
+  });
+
+  it('extracts File metadata (type + url + name) from payload', async () => {
+    const { getChannelMessages } = await import('../octo/api.js');
+
+    const payloadB64 = Buffer.from(JSON.stringify({
+      type: 8, // File
+      url: 'file/report.csv',
+      name: 'report.csv',
+    }), 'utf-8').toString('base64');
+
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: () =>
+        Promise.resolve(JSON.stringify({
+          messages: [{ from_uid: 'u', timestamp: 1, message_seq: 3, payload: payloadB64 }],
+        })),
+    } as unknown as Response);
+
+    const result = await getChannelMessages({
+      apiUrl: 'https://api.example.com',
+      botToken: 'tok',
+      channelId: 'g1',
+      channelType: 2,
+    });
+
+    expect(result[0].type).toBe(8);
+    expect(result[0].url).toBe('file/report.csv');
+    expect(result[0].name).toBe('report.csv');
+  });
+});
+
+// ─── P2.5 RouteResult.rejectionReason ────────────────────────────────────
+
+describe('C1 P2.5: rate-limited / oversized messages attach rejectionReason', () => {
+  it('SessionRouter exports the rejection reason in RouteResult', async () => {
+    // Type-level smoke test: import + assert the field exists in the type
+    const mod = await import('../session-router.js');
+    expect(typeof mod.SessionRouter).toBe('function');
+    // Detailed behavior is covered by the e2e/session-router suites below
+    // and by the SUPPRESS_GROUP_CACHE wiring in index.ts.
+  });
+});

--- a/src/__tests__/e2e.test.ts
+++ b/src/__tests__/e2e.test.ts
@@ -148,7 +148,7 @@ async function simulateMessage(
     channelType === ChannelType.Group || channelType === ChannelType.CommunityTopic;
 
   let wasProcessed = false;
-  await router.routeAndHandle(msg, async (result) => {
+  const routeResult = await router.routeAndHandle(msg, async (result) => {
     wasProcessed = true;
     const { sessionKey } = result;
 
@@ -258,10 +258,15 @@ async function simulateMessage(
     }
   });
 
+  // C1 / P2.5 mirror: suppress group context cache for actively-rejected msgs
+  const SUPPRESS = new Set(['rate_limited', 'global_rate_limited', 'oversized']);
+  const suppressCache = !!routeResult?.rejectionReason && SUPPRESS.has(routeResult.rejectionReason);
+
   if (
     !wasProcessed &&
     isGroup &&
     !msg.streamOn &&
+    !suppressCache &&
     msg.payload.type === MessageType.Text &&
     msg.payload.content
   ) {
@@ -662,6 +667,98 @@ describe('E2E smoke tests', () => {
     expect(firstLine).not.toMatch(/\][\r\n]/); // no ] right before newline
     // The injected [Conversation history] never lands at a real line start.
     expect(userMsg).not.toMatch(/\n\[Conversation history\]/);
+  });
+
+  // --- C1 / P2.5: rate-limited group message must NOT pollute group context ---
+
+  it('C1 P2.5: rate-limited group message is not cached in group context', async () => {
+    vi.clearAllMocks();
+    // Tight per-session limit so the second message in same session hits the cap.
+    const tightConfig = { ...config, rateLimit: { maxPerMinute: 1 } };
+    const tightRouter = new SessionRouter(tightConfig, BOT_ID);
+    const groupId = 'g-flooder';
+
+    // First message: passes the gate
+    mockQueryYield('first reply');
+    await simulateMessage(
+      {
+        message_id: 'm1', message_seq: 1, from_uid: 'attacker',
+        channel_id: groupId, channel_type: ChannelType.Group,
+        timestamp: Date.now(),
+        payload: {
+          type: MessageType.Text, content: 'first message',
+          mention: { uids: [BOT_ID] },
+        },
+      },
+      tightConfig, store, tightRouter, groupContext, streamRelay,
+    );
+
+    // Second message: SAME group, SAME flooder, mention bot → hits rate limit
+    // BEFORE FIX: this content would still land in [Group context] cache via
+    //             the !wasProcessed branch, letting the flooder inject text
+    //             that the LLM sees on the next legitimate turn.
+    // AFTER FIX:  rejectionReason='rate_limited' suppresses the cache push.
+    await simulateMessage(
+      {
+        message_id: 'm2', message_seq: 2, from_uid: 'attacker',
+        channel_id: groupId, channel_type: ChannelType.Group,
+        timestamp: Date.now() + 1,
+        payload: {
+          type: MessageType.Text,
+          content: 'INJECTED CONTENT VIA RATE LIMIT BYPASS',
+          mention: { uids: [BOT_ID] },
+        },
+      },
+      tightConfig, store, tightRouter, groupContext, streamRelay,
+    );
+
+    const cached = groupContext.buildContext(groupId);
+    expect(cached).toContain('first message');
+    expect(cached).not.toContain('INJECTED CONTENT VIA RATE LIMIT BYPASS');
+  });
+
+  it('C1 P2.5: oversized group text is not cached in group context', async () => {
+    vi.clearAllMocks();
+    const tightRouter = new SessionRouter(config, BOT_ID);
+    const groupId = 'g-oversized';
+    const huge = 'X'.repeat(33 * 1024); // > 32 KB MAX_CONTENT_BYTES
+
+    await simulateMessage(
+      {
+        message_id: 'm1', message_seq: 1, from_uid: 'attacker',
+        channel_id: groupId, channel_type: ChannelType.Group,
+        timestamp: Date.now(),
+        payload: {
+          type: MessageType.Text, content: huge,
+          mention: { uids: [BOT_ID] },
+        },
+      },
+      config, store, tightRouter, groupContext, streamRelay,
+    );
+
+    const cached = groupContext.buildContext(groupId);
+    // Oversized message text is suppressed — the X-flood does not pollute context.
+    expect(cached).not.toContain('XXXXX');
+  });
+
+  it('C1 P2.5: non-mentioned group chatter STILL caches (legitimate context)', async () => {
+    vi.clearAllMocks();
+    const tightRouter = new SessionRouter(config, BOT_ID);
+    const groupId = 'g-chat';
+
+    // Non-mentioned group message — not_mentioned silent-drop; still cache.
+    await simulateMessage(
+      {
+        message_id: 'm1', message_seq: 1, from_uid: 'alice',
+        channel_id: groupId, channel_type: ChannelType.Group,
+        timestamp: Date.now(),
+        payload: { type: MessageType.Text, content: 'casual chat' },
+      },
+      config, store, tightRouter, groupContext, streamRelay,
+    );
+
+    const cached = groupContext.buildContext(groupId);
+    expect(cached).toContain('casual chat');
   });
 
   // --- G8: Read receipt ---

--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -36,6 +36,27 @@ export const TEXT_FILE_EXTENSIONS = new Set([
 /** Maximum bytes to inline a text file in the LLM prompt (G2). */
 export const INLINE_FILE_MAX_BYTES = 20 * 1024;
 
+// ─── RichText / MultipleForward input budgets (C1 / Stage 6) ─────────────────────
+//
+// These caps apply per-payload at parse time. They are independent of — and
+// strictly tighter than — the system-prompt-wide 100 KiB cap in agent-bridge
+// (D1, PR#39). Goal: stop a single malicious payload from spending the
+// entire system-prompt budget or triggering OOM during parsing.
+
+/** Maximum blocks parsed from a RichText payload. */
+export const RICH_TEXT_MAX_BLOCKS = 50;
+/** Maximum image URLs extracted from a RichText payload. */
+export const RICH_TEXT_MAX_MEDIA_URLS = 20;
+/** Maximum bytes of rendered text from a single RichText payload (matches Text gate). */
+export const RICH_TEXT_MAX_OUTPUT_BYTES = 32 * 1024;
+
+/** Maximum recursion depth for MultipleForward expansion. */
+export const MULTIPLE_FORWARD_MAX_DEPTH = 3;
+/** Maximum number of inner messages rendered per MultipleForward level. */
+export const MULTIPLE_FORWARD_MAX_MESSAGES = 50;
+/** Maximum bytes of rendered transcript from a single MultipleForward payload. */
+export const MULTIPLE_FORWARD_MAX_OUTPUT_BYTES = 8 * 1024;
+
 /** Maximum bytes to download for any text file (inline or temp). */
 const MAX_FILE_DOWNLOAD_BYTES = 5 * 1024 * 1024; // 5 MB
 
@@ -87,12 +108,35 @@ export function buildMediaUrl(relUrl?: string, apiUrl?: string): string | undefi
 
 function normalizeRichTextBlocks(content: unknown): Array<Record<string, unknown>> {
   if (Array.isArray(content)) {
-    return content.filter((b): b is Record<string, unknown> => !!b && typeof b === 'object');
+    // C1 / P1.4: cap blocks parsed per payload. A malicious sender could send
+    // 10k blocks of empty text to spend parser CPU + downstream budget.
+    return content
+      .filter((b): b is Record<string, unknown> => !!b && typeof b === 'object')
+      .slice(0, RICH_TEXT_MAX_BLOCKS);
   }
   if (typeof content === 'string' && content) {
     return [{ type: RICH_TEXT_BLOCK_TEXT, text: content }];
   }
   return [];
+}
+
+/**
+ * Truncate a string to at most `maxBytes` UTF-8 bytes, appending a marker.
+ * Shrinks by single chars so multi-byte (CJK / emoji) characters never get
+ * split. Returns `{ text, truncated }` so callers can decide whether to
+ * emit a notice.
+ */
+function truncateByBytes(input: string, maxBytes: number, marker: string): { text: string; truncated: boolean } {
+  if (Buffer.byteLength(input, 'utf-8') <= maxBytes) {
+    return { text: input, truncated: false };
+  }
+  // Generous upfront slice, then trim by bytes (covers ASCII fast path and
+  // CJK without quadratic scan over an unbounded string).
+  let truncated = input.slice(0, maxBytes);
+  while (Buffer.byteLength(truncated, 'utf-8') > maxBytes) {
+    truncated = truncated.slice(0, -1);
+  }
+  return { text: truncated + marker, truncated: true };
 }
 
 function buildRichTextPlain(blocks: Array<Record<string, unknown>>): string {
@@ -117,6 +161,10 @@ function buildRichTextPlain(blocks: Array<Record<string, unknown>>): string {
  *   - text: prefer top-level `plain` (server-authoritative); else assemble
  *     from content blocks (text → text, image → `[图片]` placeholder)
  *   - mediaUrls: collect all image-block `url` (sanitized for string type)
+ *
+ * C1 / P1.4 (Stage 6): output text is truncated to RICH_TEXT_MAX_OUTPUT_BYTES
+ * (32 KiB — matches the Text payload gate in session-router) and mediaUrls is
+ * capped at RICH_TEXT_MAX_MEDIA_URLS to prevent prompt-budget exhaustion.
  */
 export function resolveRichTextContent(
   payload: { content?: unknown; plain?: unknown },
@@ -130,10 +178,12 @@ export function resolveRichTextContent(
     if (blk.type === RICH_TEXT_BLOCK_IMAGE && typeof blk.url === 'string' && blk.url) {
       const full = buildMediaUrl(blk.url, apiUrl);
       if (full) mediaUrls.push(full);
+      if (mediaUrls.length >= RICH_TEXT_MAX_MEDIA_URLS) break;
     }
   }
   const topPlain = typeof payload?.plain === 'string' ? payload.plain : '';
-  const text = topPlain.trim() !== '' ? topPlain : buildRichTextPlain(blocks);
+  const rawText = topPlain.trim() !== '' ? topPlain : buildRichTextPlain(blocks);
+  const { text } = truncateByBytes(rawText, RICH_TEXT_MAX_OUTPUT_BYTES, '\n[RichText truncated]');
   return { text, mediaUrls };
 }
 
@@ -172,13 +222,31 @@ function resolveInnerMessageText(payload: ForwardMessage['payload'], apiUrl?: st
   }
 }
 
-/** Expand a MultipleForward payload into a readable transcript. */
+/**
+ * Expand a MultipleForward payload into a readable transcript.
+ *
+ * C1 / P1.3 (Stage 6): bounded by three caps to prevent DoS via deeply nested
+ * or massive forwarded payloads:
+ *   - depth   ≤ MULTIPLE_FORWARD_MAX_DEPTH (default 3) — stack-safe
+ *   - msgs    ≤ MULTIPLE_FORWARD_MAX_MESSAGES per level — CPU bound
+ *   - output  ≤ MULTIPLE_FORWARD_MAX_OUTPUT_BYTES — prompt budget
+ *
+ * The internal _depth parameter is hop-counted (top-level = 0). Going beyond
+ * the depth cap emits a single placeholder line instead of recursing.
+ */
 export function resolveMultipleForwardText(
   payload: { users?: ForwardUser[]; msgs?: ForwardMessage[] },
   apiUrl?: string,
+  _depth = 0,
 ): string {
+  if (_depth >= MULTIPLE_FORWARD_MAX_DEPTH) {
+    return '[合并转发: 嵌套已截断]';
+  }
   const users: ForwardUser[] = payload?.users ?? [];
-  const msgs: ForwardMessage[] = payload?.msgs ?? [];
+  const rawMsgs: ForwardMessage[] = payload?.msgs ?? [];
+  // Cap inner messages per level to prevent quadratic CPU on adversarial input.
+  const msgs = rawMsgs.slice(0, MULTIPLE_FORWARD_MAX_MESSAGES);
+  const truncatedCount = rawMsgs.length - msgs.length;
   const userMap = new Map<string, string>();
   for (const u of users) {
     if (u.uid && u.name) userMap.set(u.uid, u.name);
@@ -187,14 +255,21 @@ export function resolveMultipleForwardText(
   for (const m of msgs) {
     const senderName = userMap.get(m.from_uid) ?? m.from_uid;
     if (m.payload?.type === MessageType.MultipleForward) {
-      const nested = resolveMultipleForwardText(m.payload, apiUrl);
+      const nested = resolveMultipleForwardText(m.payload, apiUrl, _depth + 1);
       lines.push(`${senderName}: [合并转发]`);
       lines.push(nested);
     } else {
       lines.push(`${senderName}: ${resolveInnerMessageText(m.payload, apiUrl)}`);
     }
   }
-  return lines.join('\n');
+  if (truncatedCount > 0) {
+    lines.push(`[合并转发: 还有 ${truncatedCount} 条消息未展示]`);
+  }
+  const out = lines.join('\n');
+  // Final output budget guard — even with msg/depth caps, a single inner
+  // message text could be large. Truncate once at the top after assembly.
+  const { text } = truncateByBytes(out, MULTIPLE_FORWARD_MAX_OUTPUT_BYTES, '\n[合并转发: 输出已截断]');
+  return text;
 }
 
 // ─── Core resolver ─────────────────────────────────────────────────────────

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,7 +110,7 @@ async function handleMessage(
   // For non-processed messages, routeAndHandle returns without calling handler.
   // We still need to cache group text messages for context.
   let wasProcessed = false;
-  await router.routeAndHandle(msg, async (result) => {
+  const routeResult = await router.routeAndHandle(msg, async (result) => {
     wasProcessed = true;
     const { sessionKey } = result;
 
@@ -183,7 +183,18 @@ async function handleMessage(
       // --- Build history prefix BEFORE appending current message (G10: segmented) ---
       // Use historyRecord (metadata-only for files) instead of bodyText to keep
       // SQLite history compact — inlined file contents stay turn-local.
-      const userContent = msg.payload.content ?? historyRecord;
+      //
+      // P1.1 (Stage 6): RichText payload.content is an Array<RichTextBlock>,
+      // not a string. The previous `?? historyRecord` fallback only fired on
+      // null/undefined, so an array would pass through to store.appendUser()
+      // and SQLite would reject the non-string binding at runtime, crashing
+      // every RichText turn. Same risk for File payloads that ship a content
+      // field instead of using mediaUrl. Defense: only trust payload.content
+      // when it is actually a string; otherwise use the type-safe
+      // historyRecord we already built.
+      const userContent = typeof msg.payload.content === 'string'
+        ? msg.payload.content
+        : historyRecord;
 
       // G3 + S3 (stage 6): Extract quoted/replied message content for LLM context.
       //
@@ -341,7 +352,19 @@ async function handleMessage(
   // Cache non-processed group messages for context.
   // G21: skip stream update messages — only cache the final (non-stream) message.
   // G1: cache non-text payloads as type summaries so [Group context] shows them.
-  if (!wasProcessed && isGroup && !msg.streamOn) {
+  //
+  // C1 / P2.5 (Stage 6): do NOT cache messages that the router actively
+  // rejected (rate-limited, oversized). Without this guard a flooder who
+  // tripped the rate limit could still inject text the LLM would see on the
+  // next legitimate turn — the rate limit reply went out but the content
+  // still landed in [Group context]. Silently-dropped messages (not_mentioned,
+  // system_event, bot loop) still cache because they are legitimate group
+  // chatter the agent should be aware of when next addressed.
+  const SUPPRESS_GROUP_CACHE = new Set(['rate_limited', 'global_rate_limited', 'oversized']);
+  const suppressGroupCache =
+    !!routeResult?.rejectionReason && SUPPRESS_GROUP_CACHE.has(routeResult.rejectionReason);
+
+  if (!wasProcessed && isGroup && !msg.streamOn && !suppressGroupCache) {
     const summary = renderMessageForContext(msg, config.apiUrl);
     if (summary) {
       groupContext.pushMessage(

--- a/src/octo/api.ts
+++ b/src/octo/api.ts
@@ -636,13 +636,44 @@ export async function getChannelMessages(params: {
       return {
         from_uid: String(m.from_uid ?? ''),
         from_name: typeof m.from_name === 'string' ? m.from_name : undefined,
-        content: typeof m.content === 'string' ? m.content : undefined,
+        // C1 / P1.5 (Stage 6): WuKongIM /v1/bot/messages/sync ships per-message
+        // content / type / url / name INSIDE the base64-encoded payload, not at
+        // the top level. Without merging the decoded payload up, every Text
+        // history row had `content: undefined`, so seedHistoryFromApi treated
+        // every backfilled message as empty and skipped the placeholder branch
+        // — G4 backfill was effectively a no-op for Text.
+        //
+        // Strategy: prefer the top-level field when it is a usable string /
+        // number, otherwise fall back to the decoded payload field. We never
+        // overwrite a populated top-level value with a payload value, so this
+        // is a strict superset of the previous behavior.
+        content:
+          typeof m.content === 'string' && m.content !== ''
+            ? m.content
+            : typeof payload?.content === 'string'
+              ? payload.content
+              : undefined,
         timestamp: typeof m.timestamp === 'number' ? m.timestamp : 0,
         message_id: typeof m.message_id === 'string' ? m.message_id : undefined,
         message_seq: typeof m.message_seq === 'number' ? m.message_seq : undefined,
-        type: typeof m.type === 'number' ? m.type : undefined,
-        url: typeof m.url === 'string' ? m.url : undefined,
-        name: typeof m.name === 'string' ? m.name : undefined,
+        type:
+          typeof m.type === 'number'
+            ? m.type
+            : typeof payload?.type === 'number'
+              ? payload.type
+              : undefined,
+        url:
+          typeof m.url === 'string'
+            ? m.url
+            : typeof payload?.url === 'string'
+              ? payload.url
+              : undefined,
+        name:
+          typeof m.name === 'string'
+            ? m.name
+            : typeof payload?.name === 'string'
+              ? payload.name
+              : undefined,
         payload,
       };
     });

--- a/src/session-router.ts
+++ b/src/session-router.ts
@@ -13,6 +13,24 @@ export interface RouteResult {
   message: BotMessage;
   /** User content with leading @botname stripped (for LLM input). */
   cleanContent?: string;
+  /**
+   * When shouldProcess is false, why the message was rejected. Allows the
+   * caller to skip downstream side-effects (group context caching, etc.)
+   * for messages that should not influence future turns.
+   *
+   * C1 / P2.5 (Stage 6): added to fix the channel where rate-limited or
+   * oversized messages still polluted the group context cache — a flooder
+   * could be limited at the router but still inject text the LLM would see
+   * in the next legitimate turn.
+   */
+  rejectionReason?:
+    | 'blocked_bot'
+    | 'self_message'
+    | 'system_event'
+    | 'rate_limited'
+    | 'global_rate_limited'
+    | 'oversized'
+    | 'not_mentioned';
 }
 
 interface TokenBucket {
@@ -92,16 +110,27 @@ export class SessionRouter {
    * under the same per-session lock. This ensures no gap between route decision
    * and pipeline execution — concurrent same-session messages cannot interleave.
    */
+  /**
+   * Route a message and, if it should be processed, run the handler callback
+   * under the same per-session lock. This ensures no gap between route decision
+   * and pipeline execution — concurrent same-session messages cannot interleave.
+   *
+   * Returns the RouteResult (or `null` for silent-drop cases) so the caller
+   * can inspect `rejectionReason` to decide whether the message should still
+   * influence downstream side-effects like group context caching
+   * (C1 / P2.5 — stage 6).
+   */
   async routeAndHandle(
     msg: BotMessage,
     handler: (result: RouteResult) => Promise<void>,
-  ): Promise<void> {
+  ): Promise<RouteResult | null> {
     const key = this.sessionKey(msg);
-    await this.withSessionLock(key, async () => {
+    return this.withSessionLock(key, async () => {
       const result = await this.processMessage(msg, key);
       if (result && result.shouldProcess) {
         await handler(result);
       }
+      return result;
     });
   }
 
@@ -239,7 +268,12 @@ export class SessionRouter {
         blocker.notified = true;
         await this.replySafe(msg, '请稍后再试');
       }
-      return { sessionKey: key, shouldProcess: false, message: msg };
+      return {
+        sessionKey: key,
+        shouldProcess: false,
+        message: msg,
+        rejectionReason: 'rate_limited',
+      };
     }
 
     // G1: All payload types are now resolved by inbound.resolveContent in
@@ -254,7 +288,12 @@ export class SessionRouter {
       Buffer.byteLength(content, 'utf-8') > MAX_CONTENT_BYTES
     ) {
       await this.replySafe(msg, '消息过长，请缩短后重试');
-      return { sessionKey: key, shouldProcess: false, message: msg };
+      return {
+        sessionKey: key,
+        shouldProcess: false,
+        message: msg,
+        rejectionReason: 'oversized',
+      };
     }
 
     // G13: Strip leading @botname from group TEXT messages for cleaner LLM input.


### PR DESCRIPTION
C1 五项修复 — 三个是我 PR#33 引入的真回归。P1.1 userContent typeof guard (RichText crash). P1.3 MultipleForward 3/50/8KiB caps. P1.4 RichText 50/20/32KiB caps. P1.5 G4 backfill 合并 decoded payload. P2.5 RouteResult.rejectionReason 抑制 group context 缓存。27 新测试，517/517 全绿。