### PR TITLE
fix(S2): truncateUtf8ByBytes N×4-byte boundary U+FFFD bug (PR#40 follow-up)

### DIFF
--- a/src/__tests__/file-inline-wrap.test.ts
+++ b/src/__tests__/file-inline-wrap.test.ts
@@ -201,6 +201,60 @@ describe('truncateUtf8ByBytes (PR#40 review nit fix — byte-safe truncation)', 
     expect(Buffer.byteLength(r.truncated, 'utf-8')).toBeLessThanOrEqual(10);
   });
 
+  // ─── Regression: PR#40 follow-up — N×4-byte clean boundary corner case ───
+  // Independently reported by Jerry-Xin + 李飞飞. When the cap lands exactly on
+  // the final continuation byte of a 4-byte sequence, the previous algorithm
+  // dropped the complete sequence's cont bytes and exited before the leader,
+  // producing U+FFFD.
+  it('REGRESSION: handles N×4-byte clean boundary (50×🚀 cap=100)', () => {
+    // 50×🚀 = 200 bytes. cap=100 is EXACTLY 25 complete emoji boundary.
+    // Corrected algorithm recognises completeness and returns all 25 emoji.
+    // Old buggy algorithm produced U+FFFD on this case.
+    const input = '🚀'.repeat(50);
+    const r = truncateUtf8ByBytes(input, 100);
+    expect(r.truncated).not.toContain('\uFFFD');
+    expect(Buffer.byteLength(r.truncated, 'utf-8')).toBe(100);
+    expect([...r.truncated].length).toBe(25);
+  });
+
+  it('REGRESSION: cap that lands on mid-cont byte trims back to clean (50×🚀 cap=99)', () => {
+    // cap=99 lands inside emoji[24] (1 byte short). Trim back to emoji[23].
+    const input = '🚀'.repeat(50);
+    const r = truncateUtf8ByBytes(input, 99);
+    expect(r.truncated).not.toContain('\uFFFD');
+    expect(Buffer.byteLength(r.truncated, 'utf-8')).toBe(96);
+    expect([...r.truncated].length).toBe(24);
+  });
+
+  it('REGRESSION: Jerry-Xin reproducer (X🚀🚀 cap=5)', () => {
+    // Cap=5: bytes 0=X, 1-4=emoji[0] (complete 4-byte sequence). Output = X🚀.
+    const input = 'X' + '🚀'.repeat(2);  // 1 + 8 = 9 bytes
+    const r = truncateUtf8ByBytes(input, 5);
+    expect(r.truncated).not.toContain('\uFFFD');
+    expect(Buffer.byteLength(r.truncated, 'utf-8')).toBe(5);
+    expect([...r.truncated].length).toBe(2);
+  });
+
+  it('REGRESSION: cap = N×4 exactly (10×🌍 cap=4 / 7 / 40)', () => {
+    const input = '🌍'.repeat(10); // 40 bytes total
+    // cap=40 = exact full length, no truncation
+    const r1 = truncateUtf8ByBytes(input, 40);
+    expect(r1.wasTruncated).toBe(false);
+    expect(r1.truncated).toBe(input);
+
+    // cap = 4 (one complete emoji)
+    const r2 = truncateUtf8ByBytes(input, 4);
+    expect(r2.truncated).not.toContain('\uFFFD');
+    expect([...r2.truncated].length).toBe(1);
+    expect(Buffer.byteLength(r2.truncated, 'utf-8')).toBe(4);
+
+    // cap = 7 (lands on emoji[1] cont byte) — trim back to emoji[0]
+    const r3 = truncateUtf8ByBytes(input, 7);
+    expect(r3.truncated).not.toContain('\uFFFD');
+    expect([...r3.truncated].length).toBe(1);
+    expect(Buffer.byteLength(r3.truncated, 'utf-8')).toBe(4);
+  });
+
   it('handles mixed ASCII + CJK + emoji', () => {
     const input = 'hello 世界 🌍 test';
     const r = truncateUtf8ByBytes(input, 12);

--- a/src/file-inline-wrap.ts
+++ b/src/file-inline-wrap.ts
@@ -129,14 +129,44 @@ export function truncateUtf8ByBytes(input: string, maxBytes: number): {
   if (buf.length <= maxBytes) {
     return { truncated: input, originalBytes: buf.length, wasTruncated: false };
   }
-  let trimmed = buf.subarray(0, maxBytes);
-  // Trim back to a valid UTF-8 boundary. At most 3 steps for valid UTF-8
-  // (4-byte max sequence). Continuation bytes are 10xxxxxx, leaders 11xxxxxx.
-  for (let i = 0; i < 3 && trimmed.length > 0; i++) {
-    const lastByte = trimmed[trimmed.length - 1];
-    if (lastByte < 0x80) break; // ASCII boundary — safe
-    trimmed = trimmed.subarray(0, trimmed.length - 1);
-    if ((lastByte & 0xC0) === 0xC0) break; // dropped a leader — sequence complete
+  const baseTrimmed = buf.subarray(0, maxBytes);
+  // Find a clean UTF-8 boundary.
+  //
+  // Strategy: scan back from the cap position over continuation bytes
+  // (10xxxxxx) until we find an ASCII byte (0xxxxxxx) or a leader byte
+  // (11xxxxxx). Then check whether the byte range from the leader to the
+  // cap forms a complete sequence (length matches leader's expected
+  // length). If complete → keep; if partial/malformed → drop from leader
+  // inclusive. O(1) backoff, max 3 walk-back steps for valid UTF-8.
+  //
+  // Bug history: previous `i < 3` loop with decrementing trim did the
+  // wrong thing on N×4-byte clean boundaries (cap = N × 4): it dropped
+  // the complete final sequence's cont bytes and exited before the
+  // leader, producing U+FFFD. Independently reported by Jerry-Xin and
+  // 李飞飞 in PR#40 review.
+  let trimmed = baseTrimmed;
+  let leaderPos = baseTrimmed.length - 1;
+  while (leaderPos >= 0 && (baseTrimmed[leaderPos] & 0xC0) === 0x80) {
+    leaderPos--;
+  }
+  if (leaderPos >= 0) {
+    const startByte = baseTrimmed[leaderPos];
+    if (startByte >= 0x80) {
+      // Leader. Determine expected sequence length.
+      let expectedLen: number;
+      if ((startByte & 0xF8) === 0xF0) expectedLen = 4;
+      else if ((startByte & 0xF0) === 0xE0) expectedLen = 3;
+      else if ((startByte & 0xE0) === 0xC0) expectedLen = 2;
+      else expectedLen = 0; // Invalid leader — treat as malformed, drop
+
+      const actualLen = baseTrimmed.length - leaderPos;
+      if (expectedLen === 0 || actualLen !== expectedLen) {
+        // Partial / malformed sequence — drop from leader inclusive.
+        trimmed = baseTrimmed.subarray(0, leaderPos);
+      }
+      // Else: complete sequence — keep baseTrimmed as-is.
+    }
+    // Else: ASCII — already at a clean boundary, keep baseTrimmed.
   }
   return {
     truncated: trimmed.toString('utf-8'),


### PR DESCRIPTION
Follow-up to PR#40 (merged). Independently reported by Jerry-Xin + 李飞飞 in re-review: `truncateUtf8ByBytes` produces U+FFFD when cap lands exactly on the final continuation byte of a 4-byte UTF-8 sequence.

## Bug reproduction (from main, pre-fix)

```
50×🚀 cap=100  →  output contains U+FFFD
X🚀🚀 cap=5    →  output contains U+FFFD
10×🌍 cap=4    →  output is '' (drops complete emoji!)
```

Root cause: `i < 3` loop walks back over up to 3 continuation bytes, but for a 4-byte emoji sequence whose cap lands on cont byte 3, all 3 trims hit conts and the loop exits before the leader is dropped — leaving an incomplete sequence that toString decodes as U+FFFD.

## Fix

Rewrite algorithm to: scan back over continuation bytes to find the leader, then check if the byte range from leader to cap matches the leader's expected sequence length. If complete → keep; if partial → drop from leader inclusive. O(1) backoff, max 3 walk-back steps.

## Test coverage (+4 regression tests)

| Case | Expected | Was |
|------|----------|-----|
| 50×🚀 cap=100 (N×4 boundary) | 100 bytes, 25 emoji | U+FFFD ❌ |
| 50×🚀 cap=99 (mid-cont) | 96 bytes, 24 emoji | U+FFFD or wrong count |
| X🚀🚀 cap=5 (Jerry-Xin) | 'X🚀' | 'X' + U+FFFD ❌ |
| 10×🌍 cap=4 (exact emoji) | '🌍' | '' (drops complete emoji) |
| 10×🌍 cap=7 (mid-cont) | '🌍' | wrong |

## Verification

- tsc clean
- eslint 0 warnings
- 549/549 tests pass (33 test files)
- 4 new tests directly probe the bug; reverting fix produces failures

## Lesson固化

Byte-safe truncation for variable-length encodings (UTF-8 / UTF-16 surrogates) must include "cap = N × max-sequence-bytes boundary" as default checklist item. Two reviewers independently finding the same bug = high-signal real defect, not edge case.