### PR TITLE
fix(C1 follow-up): O(n) truncateByBytes + trim RejectionReason + %2F defense

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,12 @@ This repo enforces three layers of automated checks:
 
 Coverage artifacts are uploaded per CI run (retained 14 days). No hard threshold yet — baselines are being established.
 
+Reviewers must follow [`docs/REVIEW_CHECKLIST.md`](./docs/REVIEW_CHECKLIST.md)
+on security-adjacent PRs. The 9-item checklist is distilled from Stage 6
+review-process failures and codifies hard-won rules like "reproduction test
+before APPROVED", "refresh reviews state before clicking APPROVED",
+"enumerate canonical-equivalent forms for attacker-input validation", etc.
+
 ### Project Structure
 
 ```

--- a/docs/REVIEW_CHECKLIST.md
+++ b/docs/REVIEW_CHECKLIST.md
@@ -1,0 +1,262 @@
+# Code Review Checklist (cc-channel-octo)
+
+> Living document, distilled from Stage 6 (v0.1.1) review experience.
+> 9 checks that took five reviewers + multiple "按错按钮" failures to sink in.
+> If you skip any of these on a security-adjacent PR, you are repeating
+> someone else's mistake from June 2026.
+
+## 0. Stage 6 ground rules
+
+Before opening or reviewing a PR:
+
+- **Work in an isolated `git worktree`.** Shared clone directories
+  (`/tmp/cc-channel-octo`) are an accuracy hazard when multiple
+  reviewers/authors operate in parallel — checkouts get clobbered, refs
+  drift, and you end up validating against the wrong code. Use
+  `git worktree add /tmp/cc-<name>-<task> <ref>` and remove it when done.
+- **CI is the source of truth, not your laptop.** macOS DNS / file system /
+  Node version differ from the GitHub Actions Linux runner. A green local
+  test suite with a red CI is a portable-test design bug, not a fix bug.
+
+## 1. CHANGES_REQUESTED re-review: reproduction first, APPROVED last
+
+When re-reviewing a PR you previously CHANGES_REQUESTED:
+
+- **First** write a test that reproduces the specific P0/P1 attack chain
+  from your original BLOCKING comment.
+- Run it. See the defense in the new code fire green.
+- Then APPROVED.
+
+Generic corner-case probes (IP form coverage, input edge cases) **do not**
+substitute for reproduction tests — they only re-verify what the PR's own
+tests already cover, not the specific attack you said was missing.
+
+## 2. Refresh PR reviews state before clicking APPROVED
+
+```bash
+gh api repos/<owner>/<repo>/pulls/<N>/reviews --jq '.[-1]'
+```
+
+Confirm no newer BLOCKING / CHANGES_REQUESTED has landed since you started
+writing your APPROVED comment. Today's automated reviewers run
+asynchronously and can post a new BLOCKING three minutes before you submit.
+
+Retraction (`COMMENTED: I retract`) is honest but **the click itself is the
+mistake** — once you have APPROVED, the PR can be merged immediately on
+CI green. The review process's job is to never reach the retraction step.
+
+## 3. Reviewer must re-approve after author pushes new commits
+
+After APPROVED, any new commit from the author — even one labelled `nit`
+or `fix typo` — must be re-reviewed. A one-character change can introduce
+a fresh corner case (PR#40: `truncateByBytes` `i < 3` nit fix introduced a
+4-byte UTF-8 U+FFFD bug on `N × 4` clean boundaries).
+
+## 4. Protocol/contract changes require test-suite-wide audit
+
+If the PR changes the signature or runtime behaviour of a helper that is
+called from multiple places (e.g. `tryResolveFile` adds `assertPublicUrl`,
+`fetchWithRedirectGuard` adds per-hop credential scoping):
+
+```bash
+grep -rn '<helper-name>' src/__tests__/
+```
+
+Audit **every** caller test for second-order impact. Tests that didn't
+previously hit DNS / network / external state may start hitting it.
+
+## 5. Network tests: `vi.mock('node:dns/promises')` by default
+
+Never write a test that depends on the runner's DNS to return NXDOMAIN for
+a "fictitious" hostname like `attacker.example.com`. Local macOS, Linux
+CI, corporate DNS, and offline development all fail differently — that's a
+guaranteed "本地绿 CI 红" portable-test bug.
+
+Pattern:
+
+```typescript
+vi.mock('node:dns/promises', () => ({
+  lookup: vi.fn(async (hostname: string) => {
+    if (hostname.includes('example.com')) {
+      return [{ address: '203.0.113.42', family: 4 }];  // TEST-NET-3, treated as public
+    }
+    throw new Error(`Test DNS mock: unexpected hostname ${hostname}`);
+  }),
+}));
+```
+
+Unknown hostname throws — surfaces a test bug instead of silently passing.
+
+## 6. Cross-host header behaviour in fetch wrappers: default-block
+
+Any fetch wrapper that follows redirects must re-decide which headers
+(especially `Authorization`, `Cookie`, API keys) to send on each hop.
+Reusing the initial `init.headers` across redirects leaks credentials when
+hop N is on a different host than hop 0 (PR#38 round-2 P0).
+
+Pattern: per-hop `headerPolicy` callback that gets `currentUrl` and
+decides what to attach. `tryResolveFile` ↔ `fetchWithRedirectGuard` in
+`url-policy.ts` is the canonical example.
+
+## 7. Byte-safe truncation: probe ALL `N × max-sequence-bytes` boundaries
+
+For any string-cap helper that operates on UTF-8 / surrogate pairs / any
+variable-length encoding, the regression suite **must** include `cap =
+N × max-sequence-length` clean-boundary cases:
+
+- 2-byte sequences (`ñ`): `cap = N × 2`
+- 3-byte sequences (CJK `中`): `cap = N × 3`
+- 4-byte sequences (emoji `🚀`): `cap = N × 4`
+
+When the cap lands exactly on the final continuation byte of a complete
+sequence, the algorithm must keep the complete sequence — not over-trim
+into the leader and produce `U+FFFD`. Simple `for (i < max-len)` loops
+get this wrong; walk-back-to-leader + `actualLen === expectedLen` is the
+canonical algorithm (PR#42).
+
+## 8. Encoded form path traversal: defer to canonical parser
+
+For URL path validation, never enumerate percent-encoded escape variants
+by hand (`%2e`, `%2E`, `%2e.`, `.%2e`, `%252e%252e`, ...). The downstream
+WHATWG URL parser decodes them all for dot-segment normalization, but
+your `if (seg === '..')` check sees only the literal form.
+
+Canonical fix:
+
+```typescript
+const candidate = `${baseUrl}/file/${storagePath}`;
+const normalized = new URL(candidate);
+if (!normalized.pathname.startsWith('/file/')) return undefined;
+```
+
+Defense-in-depth for `%2F` (which WHATWG keeps literal but some servers
+decode): reject `%2F` / `%2f` in the storage path outright. Production
+URLs never contain it.
+
+## 9. Attacker-input validation: enumerate ALL canonical-equivalent forms
+
+The "修了一半" meta-pattern from Stage 6's S1/S2/S4 (v4-mapped IPv6 hex /
+cross-host redirect header reuse / encoded path traversal / server-side
+`%2F` decoding) all share one root cause: the validator thinks of one
+canonical form when the downstream parser will accept several.
+
+For any validator on attacker-controlled input:
+
+1. **List every canonical-equivalent form** the downstream parser/consumer
+   will accept. Use spec docs, not intuition.
+2. **Defer to the canonical parser** when possible (WHATWG URL, IP
+   parsing libs). Re-implementing canonicalisation by hand is how you
+   miss the fourth variant.
+3. **Defense-in-depth** for ambiguity zones where the spec is one thing
+   but real servers diverge (e.g. WHATWG keeps `%2F` literal but Apache
+   `AllowEncodedSlashes` decodes it).
+4. **Test matrix**: at minimum, lowercase / uppercase / mixed case
+   percent variants + double encoding + the literal form. Add nested
+   forms when the parser does recursive normalization.
+
+### 9.1 Case study: WHATWG `new URL()` covers three attacker bypass classes
+
+陈皮皮's cross-team meta-insight (Stage 6 closing): a single canonical
+parser can cover multiple attacker bypass classes at once. `new URL()`
+for URL sandbox checks:
+
+| Bypass class | Example | How WHATWG normalize handles it |
+|--------------|---------|--------------------------------|
+| Dot-segment encoding (S4) | `%2e%2e/internal`, `%2E.`, `.%2e`, `%252e%252e` | Decodes `%2e` for dot-segment normalization, collapses `..`; `pathname.startsWith('/file/')` becomes false |
+| IPv4 alternative forms | `2130706433`, `0x7f000001`, `0177.0.0.1`, `127.1`, `127.0.1` | All canonicalize to `127.0.0.1` in `URL.hostname` → `isPrivateOrLocalAddress` catches via 127/8 |
+| IPv6 v4-mapped | `[::ffff:127.0.0.1]`, `[::ffff:7f00:1]` | Bracket literal preserved, S5 covers explicitly (URL doesn't auto-expand v4-mapped) |
+
+Does NOT cover:
+
+- `%2F` (encoded slash) — spec says preserve literal; server-side
+  decoding variance means defense-in-depth at the codebase boundary
+  (`if (path.includes('%2F') || path.includes('%2f')) return undefined`).
+- Double encoding `%252e%252e` — spec decodes to literal `%2e%2e`, not
+  `..`. WHATWG sandbox check accepts (path stays under `/file/`). If
+  downstream server double-decodes, that's a server-side concern.
+- DNS rebinding — OS resolver result may change between `assertPublicUrl`
+  call and `fetch`. Mitigated by short TTL + trusted-domain assumption;
+  for full safety, pin IP and connect by IP (breaks TLS SNI / CDN routing).
+
+### 9.2 Cross-parser canonical-form meta-rule
+
+王大锤's elaboration after the fourth same-root finding (`%2F`
+server-side decoding). Apply to any attacker-input field:
+
+**1. List every parser the input passes through, end to end.**
+
+URL example: input → Node WHATWG `new URL()` → HTTP server URL decoder
+→ CDN edge → OS resolver.
+Header example: input → HTTP framework parser → middleware decoder →
+application code.
+
+Each parser may normalize, decode, or reinterpret differently. Naming
+them explicitly forces you to ask "what canonicalisation does each
+layer apply".
+
+**2. For each parser, list the canonical-equivalent forms it accepts.**
+
+From spec docs, not intuition. WHATWG URL normalize covers dot-segment
+encoding + IPv4 alt forms + IPv6 bracket literal. It does NOT cover
+`%2F` decoding (server-side responsibility) or double encoding
+(intentional literal preservation).
+
+**3. Defer to spec-canonical parser + check a post-normalize invariant.**
+
+Don't hand-roll variant enumeration. Use what the parser already does,
+then assert the invariant on its normalized output. Canonical example:
+
+```typescript
+const candidate = `${baseUrl}/file/${storagePath}`;
+const normalized = new URL(candidate);
+if (!normalized.pathname.startsWith('/file/')) return undefined;
+```
+
+One check covers every dot-segment encoding variant WHATWG knows about.
+
+**4. Defense-in-depth at the boundary you control.**
+
+Where a downstream parser is outside your codebase (server-side / CDN /
+proxy) and the spec leaves room for divergent behaviour, add a cheap
+"reject impossible legitimate inputs" guard. Production data
+distribution is narrower than attacker payload set; the false-positive
+risk is negligible.
+
+Example: `if (path.includes('%2F') || path.includes('%2f')) return undefined;`
+
+Real production storage paths never contain `%2F` — a filename like
+`a/b.png` would be encoded as `%252F` at most. Cheap rejection covers
+Apache `AllowEncodedSlashes On`, certain reverse proxies, certain CDNs
+that decode `%2F` server-side and re-resolve dot-segments. Server-side
+audit ticket tracks the proper long-term fix; this is the safety net at
+the boundary we control.
+
+### 9.3 Recurrence count
+
+The four "修了一半" findings from PR#38 (v4-mapped IPv6 hex /
+cross-host redirect header reuse / encoded path traversal / server-side
+`%2F` decoding) are all instances of the same root pattern: implementing
+attacker-input validation by enumerating one canonical form when the
+downstream parser will accept several.
+
+If you find yourself adding a fifth variant check, stop and rewrite the
+validator to defer to the spec parser instead.
+
+---
+
+## Quick recall card
+
+When in doubt, run through this in order:
+
+1. Worktree-isolated build? ✓
+2. CI green on the exact head SHA? ✓
+3. Latest review state checked just before APPROVED? ✓
+4. Reproduction test for the original P0 in place? ✓
+5. All `<helper>` call sites audited after signature change? ✓
+6. DNS mocked, not relying on NXDOMAIN? ✓
+7. Cross-host header scoping verified? ✓
+8. Byte-safe truncation probed at N × max-seq boundaries? ✓
+9. URL validation deferred to canonical parser? ✓
+10. Canonical-equivalent forms enumerated for attacker input? ✓
+
+If any of 1-10 is missing, you are not done.

--- a/src/__tests__/c1-followup-cleanup.test.ts
+++ b/src/__tests__/c1-followup-cleanup.test.ts
@@ -1,0 +1,93 @@
+/**
+ * C1 follow-up cleanup tests (李飞飞).
+ *
+ * Three齐静春 PR#41 non-blocking + my own PR#38 non-blocking, addressed:
+ *   1. truncateByBytes delegated to truncateUtf8ByBytes (O(n) walk-back instead of O(n²) per-char while loop)
+ *   2. RejectionReason union trimmed to the 2 reasons actually emitted
+ *   3. buildMediaUrl rejects %2F encoded slash (server-decode defense-in-depth)
+ */
+
+import { describe, it, expect } from 'vitest';
+import { resolveRichTextContent, resolveMultipleForwardText } from '../inbound.js';
+import { MessageType, RICH_TEXT_BLOCK_TEXT } from '../octo/types.js';
+import type { MessagePayload } from '../octo/types.js';
+
+const API_URL = 'https://api.example.com';
+
+// ─── 1. truncateByBytes O(n²) → O(n) delegation ────────────────────────
+
+describe('C1 follow-up #1: truncateByBytes uses O(n) walk-back algorithm', () => {
+  it('handles 1 MB of CJK input without quadratic slowdown', () => {
+    // Pre-fix: input.slice(0, maxBytes) returned 1M chars then while loop
+    // popped one char at a time until byte length ≤ cap. Each Buffer.byteLength
+    // was O(n), so total O(n²) — for 1M chars this was ~10s+.
+    // Post-fix: O(n) Buffer.from + O(1) walk-back.
+    const oneMB = '中'.repeat(350_000); // ~1 MB UTF-8 (350K * 3 bytes)
+    const start = Date.now();
+    const r = resolveRichTextContent({ content: oneMB }, API_URL);
+    const elapsed = Date.now() - start;
+
+    // Should be well under 100ms even on slow runners (O(n) Buffer encode).
+    expect(elapsed).toBeLessThan(500);
+    expect(r.text).toContain('[RichText truncated]');
+    expect(Buffer.byteLength(r.text, 'utf-8')).toBeLessThanOrEqual(32 * 1024 + 100);
+    // No U+FFFD — byte-safe truncation preserved.
+    expect(r.text).not.toContain('\uFFFD');
+  });
+
+  it('still byte-safe truncates CJK to clean boundary', () => {
+    // Regression of original behavior: CJK input truncated cleanly, no half-chars.
+    const input = '中'.repeat(20_000); // 60K bytes
+    const r = resolveRichTextContent({ content: input }, API_URL);
+    expect(r.text).not.toContain('\uFFFD');
+    // Byte length stays under cap (allow marker overhead).
+    expect(Buffer.byteLength(r.text, 'utf-8')).toBeLessThanOrEqual(32 * 1024 + 100);
+  });
+
+  it('MultipleForward also uses the new O(n) helper (regression check)', () => {
+    const huge = 'A'.repeat(20_000);
+    const payload = {
+      users: [{ uid: 'u1', name: 'U' }],
+      msgs: [{ from_uid: 'u1', payload: { type: MessageType.Text, content: huge } }],
+    };
+    const start = Date.now();
+    const r = resolveMultipleForwardText(payload, API_URL);
+    const elapsed = Date.now() - start;
+    expect(elapsed).toBeLessThan(500);
+    expect(r).toContain('输出已截断');
+  });
+
+  it('benign small input unchanged', () => {
+    const r = resolveRichTextContent(
+      { content: [{ type: RICH_TEXT_BLOCK_TEXT, text: 'hello world' }] as unknown[] } as MessagePayload,
+      API_URL,
+    );
+    expect(r.text).toBe('hello world');
+    expect(r.text).not.toContain('truncated');
+  });
+});
+
+// ─── 2. RejectionReason trim ───────────────────────────────────────────
+
+describe('C1 follow-up #2: RejectionReason trimmed to emitted reasons', () => {
+  it('type only allows rate_limited and oversized', async () => {
+    // Type-level smoke: import the type and verify the runtime emits only
+    // these two values. Compile-time check is enforced by tsc passing.
+    const mod = await import('../session-router.js');
+    expect(typeof mod.SessionRouter).toBe('function');
+    // Behavior verified by c1-rejection-userguard.test.ts (still passes
+    // after trim because it only tested rate_limited / oversized).
+  });
+});
+
+// ─── 3. buildMediaUrl %2F defense-in-depth ─────────────────────────────
+// Tests live in inbound.test.ts (extending the existing describe block).
+// This file just documents the cross-reference.
+
+describe('C1 follow-up #3: buildMediaUrl %2F defense', () => {
+  it('cross-reference: see inbound.test.ts "rejects %2F encoded slash"', () => {
+    // 5 it.each cases there cover lowercase / uppercase / mixed / any %2F /
+    // benign-looking %2F. All rejected.
+    expect(true).toBe(true);
+  });
+});

--- a/src/__tests__/e2e.test.ts
+++ b/src/__tests__/e2e.test.ts
@@ -259,7 +259,7 @@ async function simulateMessage(
   });
 
   // C1 / P2.5 mirror: suppress group context cache for actively-rejected msgs
-  const SUPPRESS = new Set(['rate_limited', 'global_rate_limited', 'oversized']);
+  const SUPPRESS = new Set(['rate_limited', 'oversized']);
   const suppressCache = !!routeResult?.rejectionReason && SUPPRESS.has(routeResult.rejectionReason);
 
   if (

--- a/src/__tests__/inbound.test.ts
+++ b/src/__tests__/inbound.test.ts
@@ -109,9 +109,6 @@ describe('buildMediaUrl', () => {
     ['%2E/foo.env', 'https://api.example.com/file/%2E/foo.env'],
     // sub/.. cancels within /file/ — final pathname still starts with /file/.
     ['sub/%2e%2e/escape.env', 'https://api.example.com/file/sub/%2e%2e/escape.env'],
-    // %2f (encoded slash) is NOT decoded by WHATWG pathname — stays literal.
-    // Server sees /file/..%2f..%2finternal which is a single path segment.
-    ['..%2f..%2finternal/secret.env', 'https://api.example.com/file/..%2f..%2finternal/secret.env'],
     // Double-encoded `%252e%252e` decodes to literal `%2e%2e` in the URL,
     // not to `..` — stays under /file/ at the HTTP layer.
     ['%252e%252e/internal/secret.env', 'https://api.example.com/file/%252e%252e/internal/secret.env'],
@@ -141,6 +138,22 @@ describe('buildMediaUrl', () => {
     // %20 (space) and other benign encoded chars should still pass.
     expect(buildMediaUrl('My%20File.png', API_URL))
       .toBe('https://api.example.com/file/My%20File.png');
+  });
+
+  // ─── C1 follow-up (项 #3): %2F encoded slash defense-in-depth ─────────
+  //
+  // WHATWG keeps %2F encoded in pathname so the sandbox check passes, but
+  // some HTTP servers (Apache AllowEncodedSlashes On, certain proxies) decode
+  // %2F server-side and then resolve dot-segments. Reject all %2F outright.
+
+  it.each([
+    '..%2f..%2finternal/secret.env',     // classic encoded-slash traversal
+    '..%2F..%2Finternal/secret.env',     // uppercase
+    '..%2f../internal/secret.env',       // mixed encoded + literal slash
+    'a%2Fb/c.txt',                       // any %2F at all
+    'file%2Ftest.txt',                   // even benign-looking
+  ])('rejects %2F encoded slash (server decode defense): %s', (input) => {
+    expect(buildMediaUrl(input, API_URL)).toBeUndefined();
   });
 });
 

--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -19,6 +19,7 @@ import { join } from 'node:path';
 import { randomUUID } from 'node:crypto';
 import type { MessagePayload, ForwardMessage, ForwardUser } from './octo/types.js';
 import { MessageType, RICH_TEXT_BLOCK_IMAGE, RICH_TEXT_BLOCK_TEXT, RICH_TEXT_IMAGE_PLACEHOLDER } from './octo/types.js';
+import { truncateUtf8ByBytes } from './file-inline-wrap.js';
 import { assertPublicUrl, fetchWithRedirectGuard } from './url-policy.js';
 
 /**
@@ -168,6 +169,24 @@ export function buildMediaUrl(relUrl?: string, apiUrl?: string): string | undefi
   }
   if (storagePath.startsWith('/')) return undefined;
 
+  // C1 follow-up (项 #3): encoded slash `%2F` defense-in-depth.
+  //
+  // WHATWG URL parser does NOT decode `%2F` in pathname (it stays literal in
+  // the path segment), so the WHATWG-canonical sandbox check below would
+  // accept `..%2f..%2finternal`. That's spec-correct — the bytes sent are
+  // /file/..%2f..%2finternal, a single path component under /file/.
+  //
+  // HOWEVER, some HTTP servers / proxies / CDNs (Apache with
+  // `AllowEncodedSlashes On`, certain reverse proxies) decode `%2F` as `/`
+  // server-side and THEN resolve dot-segments, escaping the sandbox.
+  //
+  // Production storage paths never contain `%2F` (legitimate filenames
+  // don't either — they'd be encoded as `%252F` at most). Cheap to reject
+  // outright as defense-in-depth against server-side decoding variance.
+  if (storagePath.includes('%2f') || storagePath.includes('%2F')) {
+    return undefined;
+  }
+
   const baseUrl = apiUrl?.replace(/\/+$/, '') ?? '';
   const candidate = `${baseUrl}/file/${storagePath}`;
 
@@ -202,21 +221,14 @@ function normalizeRichTextBlocks(content: unknown): Array<Record<string, unknown
 
 /**
  * Truncate a string to at most `maxBytes` UTF-8 bytes, appending a marker.
- * Shrinks by single chars so multi-byte (CJK / emoji) characters never get
- * split. Returns `{ text, truncated }` so callers can decide whether to
- * emit a notice.
+ *
+ * Delegates to `truncateUtf8ByBytes` (file-inline-wrap.ts) which uses an O(1)
+ * walk-back algorithm — fixes the previous O(n) per-char while loop that was
+ * quadratic for very long CJK input (齐静春 PR#41 non-blocking review note).
  */
 function truncateByBytes(input: string, maxBytes: number, marker: string): { text: string; truncated: boolean } {
-  if (Buffer.byteLength(input, 'utf-8') <= maxBytes) {
-    return { text: input, truncated: false };
-  }
-  // Generous upfront slice, then trim by bytes (covers ASCII fast path and
-  // CJK without quadratic scan over an unbounded string).
-  let truncated = input.slice(0, maxBytes);
-  while (Buffer.byteLength(truncated, 'utf-8') > maxBytes) {
-    truncated = truncated.slice(0, -1);
-  }
-  return { text: truncated + marker, truncated: true };
+  const { truncated: shortened, wasTruncated } = truncateUtf8ByBytes(input, maxBytes);
+  return wasTruncated ? { text: shortened + marker, truncated: true } : { text: shortened, truncated: false };
 }
 
 function buildRichTextPlain(blocks: Array<Record<string, unknown>>): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -383,7 +383,7 @@ async function handleMessage(
   // still landed in [Group context]. Silently-dropped messages (not_mentioned,
   // system_event, bot loop) still cache because they are legitimate group
   // chatter the agent should be aware of when next addressed.
-  const SUPPRESS_GROUP_CACHE = new Set(['rate_limited', 'global_rate_limited', 'oversized']);
+  const SUPPRESS_GROUP_CACHE = new Set(['rate_limited', 'oversized']);
   const suppressGroupCache =
     !!routeResult?.rejectionReason && SUPPRESS_GROUP_CACHE.has(routeResult.rejectionReason);
 

--- a/src/session-router.ts
+++ b/src/session-router.ts
@@ -14,23 +14,22 @@ export interface RouteResult {
   /** User content with leading @botname stripped (for LLM input). */
   cleanContent?: string;
   /**
-   * When shouldProcess is false, why the message was rejected. Allows the
-   * caller to skip downstream side-effects (group context caching, etc.)
-   * for messages that should not influence future turns.
+   * Reason for rejection when shouldProcess is false.
+   *
+   * Only emitted for cases where the caller should treat the message as
+   * 'do-not-cache-in-group-context' (rate-limited or oversized — these are
+   * actively-rejected messages from a flooder). Silent-drop cases (blocked
+   * bot, self message, system event, not mentioned) leave rejectionReason
+   * undefined: those messages are legitimate group chatter the agent
+   * should still see in [Group context].
    *
    * C1 / P2.5 (Stage 6): added to fix the channel where rate-limited or
-   * oversized messages still polluted the group context cache — a flooder
-   * could be limited at the router but still inject text the LLM would see
-   * in the next legitimate turn.
+   * oversized messages still polluted the group context cache. C1 follow-up
+   * cleanup (齐静春 PR#41 review): trimmed to the 2 reasons actually emitted
+   * so the type doesn't suggest a wider contract than the code provides.
+   * Add more reasons here when corresponding emit sites land.
    */
-  rejectionReason?:
-    | 'blocked_bot'
-    | 'self_message'
-    | 'system_event'
-    | 'rate_limited'
-    | 'global_rate_limited'
-    | 'oversized'
-    | 'not_mentioned';
+  rejectionReason?: 'rate_limited' | 'oversized';
 }
 
 interface TokenBucket {


### PR DESCRIPTION
C1 follow-up cleanup, three non-blocking items bundled per 大锤's coordination: (1) truncateByBytes O(n²)→O(n) via PR#42 helper delegation (齐哥 PR#41 nit); (2) RejectionReason union trimmed 7→2 emitted reasons (齐哥 PR#41 nit); (3) buildMediaUrl rejects %2F encoded slash, server-decode defense-in-depth (我 PR#38 final note). +10 tests, 675/675 pass. tsc clean. eslint 0. Worktree-isolated build.