### PR TITLE
test(C1 follow-up): remove tautology smokes per REVIEW_CHECKLIST §11

### DIFF
--- a/src/__tests__/c1-followup-cleanup.test.ts
+++ b/src/__tests__/c1-followup-cleanup.test.ts
@@ -68,26 +68,16 @@ describe('C1 follow-up #1: truncateByBytes uses O(n) walk-back algorithm', () =>
 });
 
 // ─── 2. RejectionReason trim ───────────────────────────────────────────
-
-describe('C1 follow-up #2: RejectionReason trimmed to emitted reasons', () => {
-  it('type only allows rate_limited and oversized', async () => {
-    // Type-level smoke: import the type and verify the runtime emits only
-    // these two values. Compile-time check is enforced by tsc passing.
-    const mod = await import('../session-router.js');
-    expect(typeof mod.SessionRouter).toBe('function');
-    // Behavior verified by c1-rejection-userguard.test.ts (still passes
-    // after trim because it only tested rate_limited / oversized).
-  });
-});
-
+// Type contract is enforced by `tsc --noEmit` (compile-time). Runtime
+// behavior is exercised by `c1-rejection-userguard.test.ts`. A separate
+// `expect(typeof mod.SessionRouter).toBe('function')` assertion here would
+// test module loading, not the type trim — that is, it would pass even if
+// the union were reverted to the pre-trim 7 members. Tautology removed per
+// REVIEW_CHECKLIST §11 ("if reverting the change does not fail the test,
+// the test is not testing the change").
+//
 // ─── 3. buildMediaUrl %2F defense-in-depth ─────────────────────────────
-// Tests live in inbound.test.ts (extending the existing describe block).
-// This file just documents the cross-reference.
-
-describe('C1 follow-up #3: buildMediaUrl %2F defense', () => {
-  it('cross-reference: see inbound.test.ts "rejects %2F encoded slash"', () => {
-    // 5 it.each cases there cover lowercase / uppercase / mixed / any %2F /
-    // benign-looking %2F. All rejected.
-    expect(true).toBe(true);
-  });
-});
+// Real coverage lives in inbound.test.ts (`describe('buildMediaUrl')` →
+// `it.each(['..%2f..%2finternal/secret.env', ...])`). A placeholder
+// `expect(true).toBe(true)` here would have the same defect as #2.
+// Pointer kept as a comment so a future reader knows where to look.


### PR DESCRIPTION
## Summary

Removes the two tautology asserts in `src/__tests__/c1-followup-cleanup.test.ts` cases #2 and #3 per `REVIEW_CHECKLIST.md` §11 ("if reverting the change does not fail the test, the test is not testing the change").

## Diff

1 file, +12/-22 (net -10), pure test cleanup, no production code touched.

```
src/__tests__/c1-followup-cleanup.test.ts | 34 +++++++++++--------------------
```

## What was removed and why

### #2 — `expect(typeof mod.SessionRouter).toBe('function')`

Tested module loading, not the `RejectionReason` type trim. The union could be reverted to its pre-trim 7 members and this test would still pass — that is the definition of tautology coverage. Real coverage:

- **Type contract**: enforced by `tsc --noEmit` at compile time (already in CI).
- **Runtime behavior**: exercised by `c1-rejection-userguard.test.ts` (unchanged, still pass).

### #3 — `expect(true).toBe(true)` cross-reference placeholder

Commentary in an assertion body where a future reader may mistake it for real coverage. Real coverage is unchanged:

- `it.each` in `inbound.test.ts` `describe('buildMediaUrl')` covers all 5 `%2F` rejection variants (lowercase, uppercase, mixed, any `%2F`, benign-looking).

Pointer comments are preserved at both removal sites so future readers can navigate to the actual coverage.

## Independence trail (tonight's calibration data point)

This same tautology nit was independently surfaced **three times** within 17 minutes on PR #46:

| Reviewer | Time (GMT+8) | Where |
|---|---|---|
| yujiawei | 02:18:41 | PR #46 d0abb5b official review (P2 nits) |
| guo-shouwei | 02:21 | Octo group chat, peer review |
| 李飞飞 (self-audit) | 02:21 | Same |

Three independent reviewers hitting the same primary evidence (the test file contents) = the kind of healthy convergence `REVIEW_CHECKLIST.md` §11 codifies. yujiawei's surfacing landed in the GitHub PR review **17 minutes before** the group-chat convergence, demonstrating that GitHub review comment is itself a ground-truth source — internal group discussions should `gh api .../pulls/<N>/reviews | jq '.body'` to pull external reviewer findings before independently re-deriving them.

## Verification

```
$ npx tsc --noEmit       # clean
$ npx eslint src/        # 0 warnings
$ npx vitest run         # 690 passed (was 692, -2 deleted)
```

The test count delta (-2) matches exactly the two tautology asserts removed; no other tests were affected.

## Refs

- `REVIEW_CHECKLIST.md` §11 — "tautology removal" canonical rule
- PR #44 — earlier instance of the same pattern (王大锤's tautology cleanup)
- PR #46 yujiawei review at d0abb5b — independent surface of these specific nits
- PR #46 — landed the test file these tautologies were introduced in
