### PR TITLE
fix(C2 P1-5 hardening): reject legacy `image/svg` MIME alongside `image/svg+xml`

### DIFF
--- a/src/__tests__/media-upload.test.ts
+++ b/src/__tests__/media-upload.test.ts
@@ -735,4 +735,45 @@ describe('sendRichTextCombined', () => {
       expect(putCall.ContentDisposition).toMatch(/^attachment/i);
     }
   });
+
+  it('P1-5 hardening: legacy `image/svg` (no +xml suffix) also rejected (PR#49 belt-and-suspenders)', async () => {
+    // 王大锤 PR#45 re-review (5bab2f0, 02:55:28 GMT+8) documented gap:
+    // Firefox in some legacy contexts renders `image/svg` (without the
+    // `+xml` suffix) as SVG. Body HTML comment
+    // `<!-- 王大锤 re-review verdict: LGTM -->` locks author through
+    // the shared lml2468 keyring. isSafeInlineImage now rejects both
+    // `image/svg+xml` AND `image/svg` — 1-condition change covers an
+    // attacker-reachable edge case.
+    const svgPayload = '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>';
+    const dataUri = `data:image/svg;base64,${Buffer.from(svgPayload).toString('base64')}`;
+
+    fetchMock.mockReset();
+    cosPutObjectMock.mockReset();
+    fetchMock.mockResolvedValueOnce(new Response(JSON.stringify({
+      bucket: 'b', region: 'r', key: 'path/x.svg',
+      credentials: { tmpSecretId: 'i', tmpSecretKey: 'k', sessionToken: 't' },
+      startTime: 1, expiredTime: 4600,
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } }));
+    cosPutObjectMock.mockImplementation((_params, cb) => {
+      cb(null, { Location: 'b.cos.r.myqcloud.com/path/x.svg' });
+    });
+    fetchMock.mockResolvedValueOnce(new Response(JSON.stringify({
+      message_id: 'm1', client_msg_no: 'c1', message_seq: 1,
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } }));
+
+    await uploadAndSendMedia({
+      apiUrl: 'https://test.example.com',
+      botToken: 'bf_test',
+      channelId: 'ch1',
+      channelType: ChannelType.Group,
+      mediaUrl: dataUri,
+    });
+
+    // Must route to File (type=8), not Image (type=2) — same defense as +xml variant.
+    const sendBody = JSON.parse(fetchMock.mock.calls[1][1].body as string);
+    expect(sendBody.payload.type).toBe(8);
+    // Must also force Content-Disposition: attachment at COS layer.
+    const putCall = cosPutObjectMock.mock.calls[0][0] as { ContentDisposition?: string };
+    expect(putCall.ContentDisposition).toMatch(/^attachment/i);
+  });
 });

--- a/src/media-upload.ts
+++ b/src/media-upload.ts
@@ -166,7 +166,16 @@ export function isSafeInlineImage(contentType: string): boolean {
   // lowercase, since MIME types and the `image/` prefix are case-insensitive.
   const baseType = contentType.split(";")[0].trim().toLowerCase();
   if (!baseType.startsWith("image/")) return false;
-  if (baseType === "image/svg+xml") return false;
+  // Belt-and-suspenders (PR#49, 王大锤 PR#45 re-review on 5bab2f0
+  // documented gap; body HTML comment "<!-- 王大锤 re-review verdict:
+  // LGTM -->" locks author through the shared lml2468 keyring):
+  // Reject `image/svg+xml` AND legacy `image/svg`. Firefox in some legacy
+  // contexts will render `image/svg` (without the `+xml` suffix) as SVG,
+  // so we reject both. Most browsers treat it as octet-stream so no inline
+  // render = no XSS, but it's a non-zero edge. The cost is 1 condition; the
+  // upside covers an attacker-reachable edge case in browsers that render
+  // the legacy form.
+  if (baseType === "image/svg+xml" || baseType === "image/svg") return false;
   return true;
 }
 
@@ -228,12 +237,17 @@ export async function uploadFileToCOS(params: {
     const ct = params.contentType.split(";")[0].trim().toLowerCase();
     if (ct.startsWith('video/') || ct.startsWith('audio/')) {
       contentDisposition = buildContentDisposition(params.filename, 'inline');
-    } else if (!ct.startsWith('image/') || ct === 'image/svg+xml') {
+    } else if (!ct.startsWith('image/') || ct === 'image/svg+xml' || ct === 'image/svg') {
       // Force `attachment` for SVG too: even when routed to MessageType.File
       // in the IM payload, the COS object served via CDN with
-      // Content-Type: image/svg+xml will render inline in browsers (XSS
-      // vector — embedded <script>/<foreignObject>). Content-Disposition:
-      // attachment forces download instead of inline render.
+      // Content-Type: image/svg+xml (or legacy image/svg, which Firefox in
+      // some legacy contexts still renders as SVG — surfaced by 王大锤
+      // PR#45 re-review on 5bab2f0, body HTML comment-locked author) will
+      // render inline in browsers (XSS vector — embedded
+      // <script>/<foreignObject>). Content-Disposition: attachment forces
+      // download instead of inline render. Mirror coverage on
+      // isSafeInlineImage above so both layers close the same
+      // attacker-reachable edge case.
       contentDisposition = buildContentDisposition(params.filename, 'attachment');
     }
   }


### PR DESCRIPTION
## Summary

Closes the SVG XSS edge case 王大锤 documented in his PR #45 round-2 review at 5bab2f0 (2026-06-05T18:55:28Z = 02:55:28 GMT+8): legacy `image/svg` MIME (without the `+xml` suffix) is rare and wrong, but Firefox in some legacy contexts has been observed to render it as SVG. Since SVG can embed `<script>`/`<foreignObject>` and execute in the CDN origin, this is an attacker-reachable edge — strict improvement to close it.

**Attribution note**: the review user.login is `lml2468` (the shared keyring used by author tooling), but the body HTML comment `<!-- 王大锤 re-review verdict: LGTM -->` locks 王大锤 as the actual review author. dolphinsboy's two 5bab2f0 reviews (18:48:14 / 18:48:40) do not mention this edge case at all. (Initial PR description / commit / comments incorrectly attributed to dolphinsboy and were force-pushed corrected after 郭守卫's QA CR at 03:32 GMT+8 — see §"Audit trail discipline" below.)

## Two-layer fix (mirrors existing `image/svg+xml` defenses)

**Layer 1 — `isSafeInlineImage`** (`src/media-upload.ts`)

```diff
- if (baseType === "image/svg+xml") return false;
+ if (baseType === "image/svg+xml" || baseType === "image/svg") return false;
```

Routes legacy variant to `MessageType.File` instead of `MessageType.Image`, same as the canonical form.

**Layer 2 — `uploadFileToCOS` Content-Disposition** (`src/media-upload.ts`)

```diff
- } else if (!ct.startsWith('image/') || ct === 'image/svg+xml') {
+ } else if (!ct.startsWith('image/') || ct === 'image/svg+xml' || ct === 'image/svg') {
```

Forces `Content-Disposition: attachment` for the legacy variant too — so even if the IM bubble routing layer is bypassed in the future, the CDN-served object still downloads instead of inline-rendering.

## Pinned at strictest enforcement boundary per §11

Per `REVIEW_CHECKLIST.md` §11 ("pin strictest enforcement boundary, not familiar parser layer"):

- **Terminal parser** = the browser fetching from CDN
- **PRIMARY invariant** = `Content-Disposition: attachment` (Layer 2) — what the CDN serves and the browser enforces
- **SECONDARY** = `msgType=File` (Layer 1) — correlates and helps IM bubble UX, doesn't enforce security

The new test asserts both layers, with the PRIMARY invariant asserted first per the PR #47 §11 application pattern.

## §11 reverse-revert verification

```
With fix:    43/43 in media-upload.test.ts pass
Without fix: new "legacy image/svg" test fails (expected 8 to be 2)
```

Defense is not theatre — reverting the change to either layer fails the new assertion. This satisfies the §11 rule: "if reverting the change does not fail the test, the test is not testing the change".

## Diff

2 files, +60/-5 (after attribution fix-up):

```
src/media-upload.ts                | 18 ++++++++++++++++--
src/__tests__/media-upload.test.ts | 42 ++++++++++++++++++++++++++++++++++++++
```

No other production paths touched. No test file deletions.

## Audit trail discipline (PR description, code comments, commit message)

After 郭守卫's QA CR at 03:32 GMT+8 (`gh api .../pulls/45/reviews | grep` showed original surfacer = 王大锤, not dolphinsboy), the three audit-trail locations were corrected via force-push to head `1e2bff4`:

1. **Commit message** — `dolphinsboy` → `王大锤 (lml2468 keyring, body HTML comment-locked author)`
2. **Code comments** (`isSafeInlineImage` + `uploadFileToCOS`) — same change
3. **This PR description** — same change

The root cause was a "partial application failure" of HEARTBEAT defense #6 (`gh api .../pulls/<N>/reviews | jq '.body'` before attribution claims) — I pulled the review body but stopped at `user.login = lml2468` without grep'ing the body for HTML-comment attribution markers used when reviewers share a keyring. 郭守卫 surfaced this as a candidate HEARTBEAT defense #12 ("partial application failure — verify to source-of-truth ground, not first-hit hit-stop").

## Independence trail

Original gap surfaced by **王大锤** in PR #45 round-2 LGTM review:

> "The `image/svg` case (no `+xml`) is rare/wrong but Firefox HAS rendered it as SVG in some legacy contexts. Most browsers treat it as octet-stream so no inline render = no XSS, but it's a non-zero edge. Suggested fix: add `image/svg` to SVG check list as belt-and-suspenders (1 char change in the `===` comparison)."

PR #45 was approved & merged with this as a non-blocking documented gap; this PR closes the gap as a separate follow-up per "one PR one review surface" scope discipline (tonight's PR #46 lesson).

## Verification

```
$ npx tsc --noEmit       # clean
$ npx eslint src/        # 0 warnings
$ npx vitest run         # 693 passed (was 692, +1 new "legacy image/svg" test)
```

## Refs

- 王大锤 PR #45 re-review on 5bab2f0 at 2026-06-05T18:55:28Z (body HTML comment `<!-- 王大锤 re-review verdict: LGTM -->` locks author through the shared lml2468 keyring) — original gap documentation
- `REVIEW_CHECKLIST.md` §11 — invariant pinning + reverse-revert rule
- PR #45 P1-5 — main `image/svg+xml` SVG XSS defense (same threat model)
- PR #38 — cross-parser canonical-equivalent forms lesson (root pattern these defenses derive from)
- 郭守卫 QA CR on this PR (head a81c74e) — surfaced attribution mis-routing
