### PR TITLE
docs(review-checklist): §10-§14 + §9.3 4→5 + §9.4 evolution narrative + §11.5 PR#49 case study + Quick Recall #11-#14 + README count sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,10 +202,13 @@ This repo enforces three layers of automated checks:
 Coverage artifacts are uploaded per CI run (retained 14 days). No hard threshold yet — baselines are being established.
 
 Reviewers must follow [`docs/REVIEW_CHECKLIST.md`](./docs/REVIEW_CHECKLIST.md)
-on security-adjacent PRs. The 9-item checklist is distilled from Stage 6
+on security-adjacent PRs. The 14-item checklist (§0 ground rules through
+§14 rule-system self-reference) is distilled from Stage 6
 review-process failures and codifies hard-won rules like "reproduction test
 before APPROVED", "refresh reviews state before clicking APPROVED",
-"enumerate canonical-equivalent forms for attacker-input validation", etc.
+"enumerate canonical-equivalent forms for attacker-input validation",
+"pin assertions at the strictest enforcement boundary", "new §N declares
+trigger + revert-invariant + sunset", etc.
 
 ### Project Structure
 

--- a/docs/REVIEW_CHECKLIST.md
+++ b/docs/REVIEW_CHECKLIST.md
@@ -486,6 +486,15 @@ whenever you write a MIME-type filter:
   evidence base" to a §11.0 lede so the rule is stated up front and
   the case studies move below as evidence.
 
+**Note on PR ordering**: PR#49 is APPROVED and merge-pending at the
+time §11.5 lands; per PR#50 description merge ordering (#50 → #47
+→ #48 → #49), the docs infrastructure precedes its case-study
+references by design. The reverse-fail experiments cite PR#49's
+already-shipped code (`isSafeInlineImage` / `uploadFileToCOS`),
+not speculative future state — the code is verifiable on PR#49 head
+`1e2bff45` at the time this section lands. This is forward reference
+to reviewed code, not anticipation of unwritten code.
+
 PR#49 hardened against the legacy `image/svg` MIME (without the `+xml`
 suffix) which Firefox in some legacy contexts has been observed to
 inline-render as SVG. The fix lands at both layers of the §11.1 stack;

--- a/docs/REVIEW_CHECKLIST.md
+++ b/docs/REVIEW_CHECKLIST.md
@@ -249,6 +249,56 @@ If you find yourself adding a sixth variant check, stop and rewrite the
 validator to defer to the spec parser plus a defense-in-depth boundary
 guard (see §9.2 + §11).
 
+### 9.4 Evolution narrative: §9 → §11 cross-parser stack progression
+
+§10 – §13 are not four unrelated rules stacked next to §9. They are
+the recursive extension of §9 into the multi-layer defense-in-depth
+regime. Read in lineage order:
+
+- **§9 (PR#38 era)** — attacker-input validation against a single
+  downstream parser. "Enumerate ALL canonical-equivalent forms" solves
+  the single-parser bypass class (IPv6 v4-mapped hex, `%2e%2e`,
+  encoded form path traversal). The implicit threat model assumes one
+  validator, one parser, one boundary.
+- **§9.2 (cross-parser meta-rule)** — first generalisation. When the
+  attacker input flows through N parsers (in-app MIME canonical →
+  RFC 2397 data-URI → CDN serving), enumerating canonical forms in
+  parser #1 is insufficient: parser #2 / #3 each accept their own
+  superset. The fix is "defer to the spec parser" — still per-parser,
+  but architecturally aware that there is more than one.
+- **§11 (PR#45 era, PR#47 split)** — second generalisation. When N
+  parsers are stacked into a defense-in-depth chain, the question is
+  no longer "did each parser canonicalise correctly?" but "which
+  parser is the terminal one the attacker reaches?" PRIMARY /
+  SECONDARY pinning is the answer: pin the assertion at the strictest
+  enforcement boundary the attacker actually hits (the browser
+  fetching the CDN object), treat upstream layers as regression
+  correlates. PR#45 SVG XSS shipped 3 layers; PR#47 split the unified
+  test into PRIMARY/SECONDARY (Step 1 of full §11 application).
+- **§11.5 (PR#49 era, dual-layer reverse-fail)** — third generalisation
+  and confirmation. A natural-traffic legacy `image/svg` hardening
+  produced the cleanest reverse-verify case study: each of the two
+  layers independently fails when reverted, so neither is silently
+  covered by the other. Two independent case studies (PR#45 reviewer
+  reproduction + PR#49 natural traffic) is the minimum cardinality to
+  promote the pattern from anecdote to rule.
+- **§10 / §12 / §13 / §14** — orthogonal supporting infrastructure for
+  the same regime: §10 keeps perf assertions falsifiable so the
+  defense-in-depth tests themselves cannot decay into theatre; §12
+  keeps author-side history operations from invalidating the
+  reviewer-side checks the chain depends on; §13 keeps a single-parser
+  pre-condition (markdown URL regex) load-bearing for §11.4 Step 4;
+  §14 keeps the rule set itself finite and falsifiable so the chain
+  can grow without becoming unauditable.
+
+Reader test: if you cannot answer "which earlier rule was insufficient,
+and what new attacker capability forced the generalisation?" for a
+given §N, then §N is misfiled and should either be merged into the
+earlier rule or rewritten with the lineage made explicit.
+
+Milestone PR chain: PR#38 (§9) → PR#45 (§9.2 + §11.1) → PR#47 (§11.2 Step 1) → PR#49 (§11.5 dual-layer reverse-fail). The next milestone PR adding a rule
+MUST extend this chain in §9.4 and declare its §14 three clauses.
+
 ---
 
 ## 10. Performance assertions must be reverse-verifiable
@@ -396,6 +446,46 @@ whenever you write a MIME-type filter:
    the upload layer — this is the strictest enforcement boundary per
    §11, and is the PRIMARY assertion in any related test.
 
+### 11.5 Case study: legacy `image/svg` PR#49 dual-layer reverse-fail
+
+PR#49 hardened against the legacy `image/svg` MIME (without the `+xml`
+suffix) which Firefox in some legacy contexts has been observed to
+inline-render as SVG. The fix lands at both layers of the §11.1 stack;
+the new test `media-upload.test.ts` asserts the PRIMARY invariant
+first and the SECONDARY correlate second per the §11.3 comment
+template. The reverse-verify experiment then proves each layer
+independently load-bearing:
+
+- drop `isSafeInlineImage`'s `|| 'image/svg'` clause → SECONDARY
+  (`payload.type === 8`) FAIL
+- drop `uploadFileToCOS`'s `|| ct === 'image/svg'` clause → PRIMARY
+  (`/^attachment/i`) FAIL
+
+Both layers independently load-bearing is the standard §11 case
+study: neither layer is silently covered by the other, so neither can
+be deleted as decorative without observable test failure. Contrast
+with the failure mode §11.1 calls out ("if reverting Layer 1 doesn't
+fail the SECONDARY assertion, the SECONDARY assertion is silently
+covered by upstream defense-in-depth and should be split into a narrow
+test that pins Layer 1 in isolation per §11.2") — PR#49 is the
+positive control showing the desired post-split state.
+
+Why this case study matters more than §11.1 (PR#45) alone:
+
+- PR#45 was reviewer-reproduction-driven (synthetic). PR#49 was
+  natural-traffic hardening (real attacker-reachable edge surfaced by
+  reviewer cross-check).
+- PR#45 needed PR#47 to split PRIMARY/SECONDARY post-hoc. PR#49
+  shipped PRIMARY/SECONDARY pinned in the same PR, dogfooding §11.3
+  on first try.
+- Two independent case studies (PR#45 + PR#49) is the minimum
+  cardinality to promote PRIMARY/SECONDARY pinning from "PR#45-specific
+  pattern" to "§11 cross-pattern rule." Single case = anecdote, two
+  cases = pattern.
+
+For the matching `Refs:` block in any future §11-related PR, cite
+both: `REVIEW_CHECKLIST.md §11.1 (PR#45) + §11.5 (PR#49)`.
+
 ---
 
 ## 12. Author-side state check before push
@@ -519,6 +609,14 @@ Applying §14 backward to the §10 – §13 batch added in this PR
   - trigger: a new §N or rule-introducing §N.M is added to this checklist
   - revert-invariant: deleting §14 lets future additions skip trigger / revert / sunset declarations; the checklist grows unbounded and dead rules accumulate silently
   - sunset: none (permanent invariant; rule-system self-reference is required regardless of rule count)
+
+**Non-rule additions are exempt** (case studies, narratives, evidence
+extensions). §9.4 (evolution narrative) and §11.5 (PR#49 case study)
+shipped in this same PR do NOT introduce new rules — they extend the
+evidence base / lineage of §9 and §11 respectively. §14 applies to
+rule-introducing additions only; case study / narrative additions
+file under the parent §N's existing trigger / revert-invariant /
+sunset declarations.
 
 ---
 

--- a/docs/REVIEW_CHECKLIST.md
+++ b/docs/REVIEW_CHECKLIST.md
@@ -251,6 +251,18 @@ guard (see §9.2 + §11).
 
 ### 9.4 Evolution narrative: §9 → §11 cross-parser stack progression
 
+- **trigger**: any new §N supersedes earlier §M's primary defense role,
+  so a first-time reader cannot reconstruct why §N exists without
+  reading §M first. Activates whenever a checklist addition reframes
+  rather than just extends an earlier rule.
+- **revert-invariant**: deleting §9.4 lets §11 appear ex-nihilo to
+  first-time readers — they see PRIMARY/SECONDARY pinning with no
+  lineage to §9 single-parser canonical enumeration, mis-apply §11
+  to single-parser cases, and silently drop §9 enumeration discipline
+  when they think §11 "replaces" it.
+- **sunset**: none (permanent invariant; lineage documentation is
+  required for any rule chain that supersedes rather than appends).
+
 §10 – §13 are not four unrelated rules stacked next to §9. They are
 the recursive extension of §9 into the multi-layer defense-in-depth
 regime. Read in lineage order:
@@ -330,6 +342,8 @@ behavioural win. If a perf assertion is added "for safety", apply
 §10.5 reverse-verify before merging.
 
 ### 10.5 Reverse-verify protocol (operationalisation)
+
+<!-- §10.2-§10.4 reserved for future operationalisation steps (do-not-skip-number; numbering deliberately jumps so additions can land between keep/delete framing and runtime protocol without renumbering downstream sections). -->
 
 Before merging any test with a timing assertion:
 
@@ -448,6 +462,21 @@ whenever you write a MIME-type filter:
 
 ### 11.5 Case study: legacy `image/svg` PR#49 dual-layer reverse-fail
 
+- **trigger**: any new hardening on a previously-§11-covered surface
+  (i.e. a second or subsequent independent fix that exercises the
+  PRIMARY/SECONDARY split established by §11.1). Activates whenever a
+  §11-style fix lands and the corresponding case-study slot is empty
+  or under-populated.
+- **revert-invariant**: deleting §11.5 lets §11 rest on N=1 evidence
+  (PR#45 only, reviewer-reproduction-driven, post-hoc PR#47 split).
+  Single case = anecdote; future maintainers can argue §11 was a
+  PR#45-specific overfit rather than a generalisable boundary-pinning
+  rule.
+- **sunset**: when ≥3 independent case studies land (§11.1 + §11.5 +
+  one more), promote the PRIMARY/SECONDARY pattern from "case-study
+  evidence base" to a §11.0 lede so the rule is stated up front and
+  the case studies move below as evidence.
+
 PR#49 hardened against the legacy `image/svg` MIME (without the `+xml`
 suffix) which Firefox in some legacy contexts has been observed to
 inline-render as SVG. The fix lands at both layers of the §11.1 stack;
@@ -552,6 +581,7 @@ definition):
 // spaces — that widens the attacker-input surface that §11.4 MIME
 // canonicalisation depends on. See REVIEW_CHECKLIST.md §13.
 const MARKDOWN_IMAGE_RE = /!\[[^\]]*\]\(([^)\s]+)\)/g;
+const MARKDOWN_LINK_RE = /(?<!\!)\[[^\]]*\]\(([^)\s]+)\)/g;
 ```
 
 ---
@@ -579,16 +609,37 @@ Three mandatory declarations:
    landing). Permanent rules write `sunset: none (permanent invariant)`
    explicitly — that is itself a declaration, not an omission.
 
+**Scope is rule-introducing additions only — not the author's call.**
+A new subsection §N.M is a rule-introducing addition whenever it
+states a normative claim that a reviewer can check against ("MUST",
+"required", "trigger if X", "reject when Y"). Subsections that are
+purely evidence — concrete attack reproductions, milestone PR
+lineage walks, recurrence counts — file under the parent §N's
+triple, but ONLY if they introduce no new normative claim of their
+own. The default is to declare the triple; the burden of proof is on
+the author to argue an addition is pure evidence, not on the next
+reviewer to argue it is a rule. "Pure case study" / "pure narrative"
+classifications must be acked by an independent reviewer before
+merge; self-classification by the author is not sufficient (this is
+the §14 self-falsification path PR#50 fixup 2 walked into and fixup
+3 corrected).
+
 Pairs with §2 (reviewer state check) / §12 (author state check) to
 close the rule-system self-reference loop: any destructive or
 irreversible PR action verifies state first; any new permanent rule
 added to the rulebook itself declares its own falsifiability boundary.
 
-### 14.1 Retroactive dogfooding for §10 – §13
+### 14.1 Retroactive dogfooding for §9.4 / §10 – §14 / §11.5
 
-Applying §14 backward to the §10 – §13 batch added in this PR
-(documented here so the dogfooding cycle closes inside the same PR):
+Applying §14 backward to every rule-introducing addition shipped in
+this PR (documented here so the dogfooding cycle closes inside the
+same PR, and no new rule lands without its triple inline at the
+section head):
 
+- **§9.4 Evolution narrative §9 → §11 cross-parser stack progression**
+  — triple inline at section head. Trigger: new §N supersedes earlier
+  §M's primary defense role. Revert-invariant: §11 appears ex-nihilo
+  to first-time readers. Sunset: none.
 - **§10 Performance assertions must be reverse-verifiable**
   - trigger: a test asserts wall-clock / throughput / size in a fixed numeric threshold
   - revert-invariant: deleting §10 lets PR#46-style 500ms-theatre assertions reappear; the test passes pre- and post-fix with no signal
@@ -597,6 +648,10 @@ Applying §14 backward to the §10 – §13 batch added in this PR
   - trigger: a fix touches ≥2 layers of a parse → validate → encode → render → enforce pipeline
   - revert-invariant: deleting §11 lets layered-defense tests assert at the upstream layer only; PRIMARY-layer drift becomes invisible (PR#45 SVG XSS reproduction)
   - sunset: none (permanent invariant; defense-in-depth is structural)
+- **§11.5 Case study: legacy `image/svg` PR#49 dual-layer reverse-fail**
+  — triple inline at section head. Trigger: any new hardening on a
+  previously-§11-covered surface. Revert-invariant: §11 rests on N=1
+  evidence. Sunset: ≥3 independent case studies → promote to §11.0 lede.
 - **§12 Author-side state check before push**
   - trigger: `git push --force-with-lease` (or any history-rewriting push) to a branch that backs an open PR
   - revert-invariant: deleting §12 lets the PR#46 dangling-commit incident recur (force-push to a merged PR's branch creates commits that never reach `main`)
@@ -610,13 +665,20 @@ Applying §14 backward to the §10 – §13 batch added in this PR
   - revert-invariant: deleting §14 lets future additions skip trigger / revert / sunset declarations; the checklist grows unbounded and dead rules accumulate silently
   - sunset: none (permanent invariant; rule-system self-reference is required regardless of rule count)
 
-**Non-rule additions are exempt** (case studies, narratives, evidence
-extensions). §9.4 (evolution narrative) and §11.5 (PR#49 case study)
-shipped in this same PR do NOT introduce new rules — they extend the
-evidence base / lineage of §9 and §11 respectively. §14 applies to
-rule-introducing additions only; case study / narrative additions
-file under the parent §N's existing trigger / revert-invariant /
-sunset declarations.
+**Self-falsification audit (PR#50 fixup 2 → fixup 3 correction)**
+
+Fixup 2 (commit 07107599) introduced an "Non-rule additions are
+exempt" paragraph here that classified §9.4 and §11.5 as pure
+evidence, exempt from the triple. That classification was the author
+asserting non-rule status of their own additions — exactly the
+self-classification path the revised §14 "Scope" paragraph above
+blocks. Reviewer (齐静春, 09:29 GMT+8) independently identified both
+§9.4 and §11.5 as introducing new normative claims (§9.4 = "lineage
+MUST be documented when superseding"; §11.5 = "N≥2 cases required to
+promote anecdote to pattern"). Fixup 3 removes the exemption
+paragraph, adds triples inline at the §9.4 and §11.5 section heads,
+and strengthens §14 with the independent-reviewer-ack requirement
+so the failure mode cannot recur.
 
 ---
 

--- a/docs/REVIEW_CHECKLIST.md
+++ b/docs/REVIEW_CHECKLIST.md
@@ -427,7 +427,7 @@ on `main` and have to be redone as a follow-up PR).
 
 ---
 
-## 13. Markdown URL parsing: CommonMark spec compliance
+## 13. Markdown URL parsing: CommonMark spec compliance (depends on §11.4)
 
 Markdown image / link regexes that match `[^)\s]+` for the URL field
 are CommonMark-spec-compliant — CommonMark requires URL-encoded spaces
@@ -438,6 +438,14 @@ by the regex.
 **This is not a security gap**: the image is not processed, so no
 inline render happens, so no XSS path exists. It IS a usability gap:
 legitimate data URIs with literal spaces in parameters won't upload.
+
+**Threat-model dependency (explicit)**: §13's silent-skip design is
+safe ONLY because §11.4 Step 4 (`Content-Disposition: attachment` pin
+at the CDN / storage layer) is in force. Relaxing `[^)\s]+` to accept
+literal spaces widens the set of markdown URLs that reach the upload
+pipeline; any drift in §11.4 Step 4 then re-exposes the inline-render
+path. The two rules are coupled: removing or weakening either one
+requires reverse-verifying the other still holds.
 
 **Action required**: when adding or modifying a markdown URL regex, add
 an inline comment at the regex definition site explaining the design
@@ -458,6 +466,62 @@ const MARKDOWN_IMAGE_RE = /!\[[^\]]*\]\(([^)\s]+)\)/g;
 
 ---
 
+## 14. New §N self-rule: declare trigger + revert-invariant + sunset
+
+Meta-rule. Every new checklist section §N (and every new subsection
+§N.M that introduces a standalone rule) MUST declare three things in
+its opening prose, so the checklist itself remains finite, falsifiable,
+and auditable. Without this, the checklist grows monotonically and
+silently accumulates dead rules whose original trigger is forgotten.
+
+Three mandatory declarations:
+
+1. **Trigger condition** — the concrete code pattern, PR action,
+   review state, or runtime symptom that activates the rule. If you
+   cannot name a trigger, the rule is decoration and must not be added.
+2. **Revert-test invariant** — the §10.5 / §11 reverse-verify analogue
+   for a docs rule: "if I delete this rule from the checklist,
+   what observable failure mode returns?" If the answer is "nothing
+   observable changes," the rule is not adding signal and must not be
+   added.
+3. **Sunset clause** — the upstream condition under which the rule
+   becomes obsolete (spec upgrade, tooling change, language feature
+   landing). Permanent rules write `sunset: none (permanent invariant)`
+   explicitly — that is itself a declaration, not an omission.
+
+Pairs with §2 (reviewer state check) / §12 (author state check) to
+close the rule-system self-reference loop: any destructive or
+irreversible PR action verifies state first; any new permanent rule
+added to the rulebook itself declares its own falsifiability boundary.
+
+### 14.1 Retroactive dogfooding for §10 – §13
+
+Applying §14 backward to the §10 – §13 batch added in this PR
+(documented here so the dogfooding cycle closes inside the same PR):
+
+- **§10 Performance assertions must be reverse-verifiable**
+  - trigger: a test asserts wall-clock / throughput / size in a fixed numeric threshold
+  - revert-invariant: deleting §10 lets PR#46-style 500ms-theatre assertions reappear; the test passes pre- and post-fix with no signal
+  - sunset: none (permanent invariant; perf-theatre risk is intrinsic to fixed-threshold assertions)
+- **§11 Pin assertions at the strictest enforcement boundary**
+  - trigger: a fix touches ≥2 layers of a parse → validate → encode → render → enforce pipeline
+  - revert-invariant: deleting §11 lets layered-defense tests assert at the upstream layer only; PRIMARY-layer drift becomes invisible (PR#45 SVG XSS reproduction)
+  - sunset: none (permanent invariant; defense-in-depth is structural)
+- **§12 Author-side state check before push**
+  - trigger: `git push --force-with-lease` (or any history-rewriting push) to a branch that backs an open PR
+  - revert-invariant: deleting §12 lets the PR#46 dangling-commit incident recur (force-push to a merged PR's branch creates commits that never reach `main`)
+  - sunset: none (permanent invariant; GitHub squash-merge semantics will not change)
+- **§13 Markdown URL parsing: CommonMark spec compliance**
+  - trigger: a markdown URL regex (`MARKDOWN_IMAGE_RE` / `MARKDOWN_LINK_RE` / equivalent) is added or modified
+  - revert-invariant: deleting §13 lets a future maintainer "fix" `[^)\s]+` to accept literal spaces, widening the attacker-input surface that §11.4 Step 4 depends on
+  - sunset: revisit if CommonMark spec changes URL-encoding requirements, or if the markdown parser is replaced with a non-regex implementation
+- **§14 (this section)**
+  - trigger: a new §N or rule-introducing §N.M is added to this checklist
+  - revert-invariant: deleting §14 lets future additions skip trigger / revert / sunset declarations; the checklist grows unbounded and dead rules accumulate silently
+  - sunset: none (permanent invariant; rule-system self-reference is required regardless of rule count)
+
+---
+
 ## Quick recall card
 
 When in doubt, run through this in order:
@@ -475,6 +539,7 @@ When in doubt, run through this in order:
 11. Perf assertions reverse-verified per §10.5? ✓
 12. Assertions pinned at strictest enforcement boundary per §11 (PRIMARY/SECONDARY split when defense is layered)? ✓
 13. Author-side `gh pr view <N> --json state,mergedAt` run before force-push to an open PR's branch? ✓
+14. New §N (or rule-introducing §N.M) declares trigger condition + revert-test invariant + sunset clause per §14? ✓
 
-If any of 1-13 is missing, you are not done.
+If any of 1-14 is missing, you are not done.
 

--- a/docs/REVIEW_CHECKLIST.md
+++ b/docs/REVIEW_CHECKLIST.md
@@ -233,14 +233,228 @@ the boundary we control.
 
 ### 9.3 Recurrence count
 
-The four "修了一半" findings from PR#38 (v4-mapped IPv6 hex /
-cross-host redirect header reuse / encoded path traversal / server-side
-`%2F` decoding) are all instances of the same root pattern: implementing
+The **five** "修了一半" findings on the same root pattern (implementing
 attacker-input validation by enumerating one canonical form when the
-downstream parser will accept several.
+downstream parser accepts several):
 
-If you find yourself adding a fifth variant check, stop and rewrite the
-validator to defer to the spec parser instead.
+1. PR#38 — IPv6 v4-mapped hex (`[::ffff:7f00:1]`)
+2. PR#38 — cross-host redirect header reuse leaking `Authorization`
+3. PR#38 — encoded path traversal (`%2e%2e/`, `%2E%2E/`, `..%2f..`)
+4. PR#38 (server-side audit ticket) — `%2F` server-side decoding variance
+5. PR#45 — SVG XSS cross-parser: in-app MIME canonical / RFC 2397
+   data-URI parser / CDN serving Content-Disposition all needed
+   independent enforcement; "fix one, leave two" mode
+
+If you find yourself adding a sixth variant check, stop and rewrite the
+validator to defer to the spec parser plus a defense-in-depth boundary
+guard (see §9.2 + §11).
+
+---
+
+## 10. Performance assertions must be reverse-verifiable
+
+Any test that includes a timing assertion (e.g. `expect(elapsed).toBeLessThan(500)`)
+MUST be reverse-verified: `git revert` the helper / fast-path under test
+and confirm the assertion **fails**. If revert still passes, the assertion
+is theatre and must be deleted (not relaxed by raising the threshold).
+
+Why: V8 string optimizations, RAM bandwidth, internal representation,
+and CPU frequency scaling all decouple big-O analysis from wall-clock
+time in micro-benchmarks. PR#46 had a `truncateByBytes` perf assertion
+asserting `< 500ms` for a payload that completed in 49ms even after
+reverting the `O(n)` walk-back helper to the naive `O(n²)` implementation
+— so the assertion never could have caught the regression it claimed to
+guard. Two reviewers (齐静春, 王大锤) independently reached the same finding
+by running the reverse-verify experiment.
+
+### 10.1 What to keep, what to delete
+
+| Assertion kind | Keep? | Why |
+|----------------|-------|-----|
+| byte-safety / correctness invariant | yes | covers real win, regression-visible |
+| order-of-magnitude perf bound (e.g. `< 60s` on 100KB) | maybe | only if revert reliably fails on the CI runner; document the headroom |
+| micro-benchmark threshold (e.g. `< 500ms`) | **no** | V8 optimization makes naive impl pass too; misleading |
+
+Byte-safety / correctness assertions are the actual security or
+behavioural win. If a perf assertion is added "for safety", apply
+§10.5 reverse-verify before merging.
+
+### 10.5 Reverse-verify protocol (operationalisation)
+
+Before merging any test with a timing assertion:
+
+1. `git revert <helper-commit>` (or stash the fast-path).
+2. Re-run the test on the same CI runner / fresh worktree.
+3. If the test still passes, the perf assertion is theatre. **Delete
+   the perf assertion** in this PR. Do NOT raise the threshold to make
+   it "work" — raising the threshold preserves the lie.
+4. Keep correctness / byte-safety assertions in the same test; those
+   cover the real win.
+5. Document the reverse-verify result in the PR description so future
+   maintainers know why the perf assertion is absent.
+
+This rule applies symmetrically to `setTimeout`-based heuristics,
+`performance.now()` deltas, and any test whose pass/fail depends on
+wall-clock duration on the runner.
+
+---
+
+## 11. Pin assertions at the strictest enforcement boundary
+
+When a defense-in-depth fix lands across multiple layers (in-app filter
+→ encoder → storage / CDN / browser), tests MUST assert at the strictest
+enforcement boundary — the parser the attacker actually reaches — not
+at the most convenient or most familiar in-process layer.
+
+The assertion that *cannot* be bypassed by drift in upstream layers is
+the PRIMARY assertion. Upstream layer assertions are SECONDARY
+correlates: they help regression visibility but they don't enforce the
+security invariant.
+
+**Reverse-verify rule** (per §10.5 dogfooded onto §11): if reverting
+the change does NOT fail the test, the test is not testing the change.
+PRIMARY and SECONDARY assertions must each independently fail when
+their respective layer is reverted; if only one fails for both reverts,
+one of them is decorative.
+
+### 11.1 Case study: SVG XSS PR#45 P1-5 hardening test
+
+Terminal parser the attacker can reach = the BROWSER fetching the CDN
+object. The strictest enforcement boundary is what the CDN serves —
+specifically `Content-Disposition: attachment`, which forces download
+regardless of `Content-Type` drift.
+
+- **PRIMARY** (load-bearing): `expect(putCall.ContentDisposition).toMatch(/^attachment/i)`
+  — what the CDN sends, what the browser enforces.
+- **SECONDARY** (correlate): `expect(sendBody.payload.type).toBe(8)`
+  — `MessageType.File` in the IM payload. Helps the IM bubble UX and
+  catches mis-routing, but if msgType drifts to `Image` while
+  Content-Disposition stays `attachment`, the browser still downloads.
+
+Both must independently fail when their layer reverts (verified for
+PR#47 — see PR#47 review COMMENTED record on a4577a3). If reverting
+Layer 1 doesn't fail the SECONDARY assertion, the SECONDARY assertion
+is silently covered by upstream defense-in-depth and should be split
+into a narrow test that pins Layer 1 in isolation (per §11.2).
+
+### 11.2 Multi-layer fix → multi-narrow-test pattern
+
+When a fix touches N layers of defense-in-depth, prefer N narrow tests
+(each pinning one layer's invariant in isolation) over one broad test
+that asserts the end-to-end outcome.
+
+Why: a broad end-to-end test passes as long as ANY layer enforces the
+invariant, so it can silently hide that an upstream layer has stopped
+working. Narrow tests force each layer to carry its own weight.
+
+PR#45 SVG XSS hardening shipped 3 layers (in-app MIME canonical /
+RFC 2397 data-URI parser / CDN Content-Disposition); the unified test
+asserted only the end-to-end outcome. PR#47 split the assertion into
+PRIMARY/SECONDARY structure (Step 1). Splitting into 3 layer-pinned
+tests is the full §11 application (王大锤 PR#45 review #1 follow-up,
+recommended for PR#48 / PR#49 follow-up).
+
+### 11.3 Comment template (PRIMARY / SECONDARY)
+
+When test structure encodes a layered defense, annotate the boundary
+explicitly so the next maintainer doesn't have to re-derive the model:
+
+```typescript
+// ─── §11 strictest enforcement boundary invariant (PRIMARY ASSERT) ──
+// The terminal parser the attacker can reach is <X>. The strictest
+// enforcement boundary is <Y>, which is what the <terminal parser>
+// actually enforces regardless of upstream drift. Pin assertion to the
+// invariant itself per REVIEW_CHECKLIST.md §11.
+expect(<strict-boundary-invariant>).toMatch(...);
+
+// ─── §11 defense-in-depth correlates (SECONDARY ASSERTS) ─────────
+// These hold in current implementation but are NOT the security
+// invariant — if <upstream layer> drifts while <strict boundary> still
+// holds, the user is still safe. Kept for regression visibility.
+expect(<upstream-correlate>).toBe(...);
+```
+
+### 11.4 MIME-type canonicalisation: a 4-step checklist
+
+MIME types are the most common attacker-input field where strictest
+enforcement boundary thinking matters. PR#45 SVG XSS hardened against
+three variants of the same root issue — apply this 4-step pattern
+whenever you write a MIME-type filter:
+
+1. **Strip parameters**: `contentType.split(';')[0].trim()`. `image/svg+xml; charset=utf-8` and `image/svg+xml` must canonicalise to the same value before comparison.
+2. **Lowercase**: `.toLowerCase()`. MIME types and the `image/` prefix are case-insensitive per RFC 6838 §4.2; `Image/Svg+Xml` is the same type as `image/svg+xml`.
+3. **RFC 2397 data URI handling**: when extracting from `data:` URLs,
+   parse the MIME segment up to the first `;` or `,` boundary — NOT a
+   regex that assumes no parameters. `data:image/svg+xml;base64,...`,
+   `data:Image/Svg+Xml;charset=utf-8;base64,...`, and
+   `data:IMAGE/SVG+XML ;base64,...` (with a stray space) must all
+   normalize to the canonical MIME for downstream checks.
+4. **Content-Disposition pin at storage / CDN layer**: even after a
+   correct in-app MIME canonical check, the CDN-served object can be
+   rendered inline by the browser based on `Content-Type` alone. Pin
+   `Content-Disposition: attachment` for SVG / unknown image types at
+   the upload layer — this is the strictest enforcement boundary per
+   §11, and is the PRIMARY assertion in any related test.
+
+---
+
+## 12. Author-side state check before push
+
+Mirror of §2 (reviewer-side state check before APPROVED), applied to
+the author side:
+
+Before `git push --force-with-lease` to a branch that backs an open PR,
+run:
+
+```bash
+gh pr view <N> --repo <owner/repo> --json state,mergedAt
+```
+
+If `state` is `MERGED` or `mergedAt` is non-null, **STOP**. Force-pushing
+to a merged PR's branch creates dangling commits (the branch HEAD drifts
+to a SHA that's never on `main`). The fix is to open a follow-up PR
+from the latest `main`, not to amend the merged one.
+
+The symmetric reviewer-side check (§2) verifies no newer
+`CHANGES_REQUESTED` review supersedes the head you're about to approve.
+Together the two form the author/reviewer state-check pair: any time
+you take a destructive or irreversible PR action, verify state first.
+
+This rule was introduced after the PR#46 dangling-commit incident
+(commits 34cdeed / 15de583 amended onto a force-pushed branch after
+the PR had already squash-merged as d0abb5b; the amendments are not
+on `main` and have to be redone as a follow-up PR).
+
+---
+
+## 13. Markdown URL parsing: CommonMark spec compliance
+
+Markdown image / link regexes that match `[^)\s]+` for the URL field
+are CommonMark-spec-compliant — CommonMark requires URL-encoded spaces
+(`%20`) inside `(...)`. A markdown URL with a literal space (e.g.
+`![](data:image/svg+xml; charset=utf-8,...)`) will be silently skipped
+by the regex.
+
+**This is not a security gap**: the image is not processed, so no
+inline render happens, so no XSS path exists. It IS a usability gap:
+legitimate data URIs with literal spaces in parameters won't upload.
+
+**Action required**: when adding or modifying a markdown URL regex, add
+an inline comment at the regex definition site explaining the design
+choice, so the next maintainer doesn't "fix" the regex to accept
+spaces and accidentally widen the attacker-input surface.
+
+Example annotation (place at `MARKDOWN_IMAGE_RE` / `MARKDOWN_LINK_RE`
+definition):
+
+```typescript
+// CommonMark spec requires URL-encoded spaces (%20); spaced URLs in
+// markdown ![](...) are silent-skipped by design (image isn't processed
+// = no inline render = no XSS gap). Do not relax `[^)\s]+` to accept
+// spaces — that widens the attacker-input surface that §11.4 MIME
+// canonicalisation depends on. See REVIEW_CHECKLIST.md §13.
+const MARKDOWN_IMAGE_RE = /!\[[^\]]*\]\(([^)\s]+)\)/g;
+```
 
 ---
 
@@ -258,5 +472,9 @@ When in doubt, run through this in order:
 8. Byte-safe truncation probed at N × max-seq boundaries? ✓
 9. URL validation deferred to canonical parser? ✓
 10. Canonical-equivalent forms enumerated for attacker input? ✓
+11. Perf assertions reverse-verified per §10.5? ✓
+12. Assertions pinned at strictest enforcement boundary per §11 (PRIMARY/SECONDARY split when defense is layered)? ✓
+13. Author-side `gh pr view <N> --json state,mergedAt` run before force-push to an open PR's branch? ✓
 
-If any of 1-10 is missing, you are not done.
+If any of 1-13 is missing, you are not done.
+

--- a/docs/REVIEW_CHECKLIST.md
+++ b/docs/REVIEW_CHECKLIST.md
@@ -1,7 +1,8 @@
 # Code Review Checklist (cc-channel-octo)
 
 > Living document, distilled from Stage 6 (v0.1.1) review experience.
-> 9 checks that took five reviewers + multiple "按错按钮" failures to sink in.
+> 14 checks (§0 ground rules through §14 rule-system self-reference)
+> that took five reviewers + multiple "按错按钮" failures to sink in.
 > If you skip any of these on a security-adjacent PR, you are repeating
 > someone else's mistake from June 2026.
 
@@ -315,6 +316,10 @@ MUST extend this chain in §9.4 and declare its §14 three clauses.
 
 ## 10. Performance assertions must be reverse-verifiable
 
+- **trigger**: a test asserts wall-clock / throughput / size in a fixed numeric threshold
+- **revert-invariant**: deleting §10 lets PR#46-style 500ms-theatre assertions reappear; the test passes pre- and post-fix with no signal
+- **sunset**: none (permanent invariant; perf-theatre risk is intrinsic to fixed-threshold assertions)
+
 Any test that includes a timing assertion (e.g. `expect(elapsed).toBeLessThan(500)`)
 MUST be reverse-verified: `git revert` the helper / fast-path under test
 and confirm the assertion **fails**. If revert still passes, the assertion
@@ -364,6 +369,10 @@ wall-clock duration on the runner.
 ---
 
 ## 11. Pin assertions at the strictest enforcement boundary
+
+- **trigger**: a fix touches ≥2 layers of a parse → validate → encode → render → enforce pipeline
+- **revert-invariant**: deleting §11 lets layered-defense tests assert at the upstream layer only; PRIMARY-layer drift becomes invisible (PR#45 SVG XSS reproduction)
+- **sunset**: none (permanent invariant; defense-in-depth is structural)
 
 When a defense-in-depth fix lands across multiple layers (in-app filter
 → encoder → storage / CDN / browser), tests MUST assert at the strictest
@@ -519,6 +528,10 @@ both: `REVIEW_CHECKLIST.md §11.1 (PR#45) + §11.5 (PR#49)`.
 
 ## 12. Author-side state check before push
 
+- **trigger**: `git push --force-with-lease` (or any history-rewriting push) to a branch that backs an open PR
+- **revert-invariant**: deleting §12 lets the PR#46 dangling-commit incident recur (force-push to a merged PR's branch creates commits that never reach `main`)
+- **sunset**: none (permanent invariant; GitHub squash-merge semantics will not change)
+
 Mirror of §2 (reviewer-side state check before APPROVED), applied to
 the author side:
 
@@ -547,6 +560,10 @@ on `main` and have to be redone as a follow-up PR).
 ---
 
 ## 13. Markdown URL parsing: CommonMark spec compliance (depends on §11.4)
+
+- **trigger**: a markdown URL regex (`MARKDOWN_IMAGE_RE` / `MARKDOWN_LINK_RE` / equivalent) is added or modified
+- **revert-invariant**: deleting §13 lets a future maintainer "fix" `[^)\s]+` to accept literal spaces, widening the attacker-input surface that §11.4 Step 4 depends on
+- **sunset**: revisit if CommonMark spec changes URL-encoding requirements, or if the markdown parser is replaced with a non-regex implementation
 
 Markdown image / link regexes that match `[^)\s]+` for the URL field
 are CommonMark-spec-compliant — CommonMark requires URL-encoded spaces
@@ -624,61 +641,76 @@ merge; self-classification by the author is not sufficient (this is
 the §14 self-falsification path PR#50 fixup 2 walked into and fixup
 3 corrected).
 
+**Inline at section head is mandatory; centralised audit table is
+supplementary.** "every new checklist section §N MUST declare in
+its opening prose" means each rule-introducing §N (and rule-
+introducing §N.M) starts with its trigger / revert-invariant /
+sunset block as the first content under the heading, before any
+prose. §14.1 keeps a cross-section audit summary table; that table
+is a navigation aid for reviewers, NOT a substitute for inline
+declaration. A section without inline triple at its head is
+non-conformant even if it appears in the §14.1 table (this is the
+§14 self-falsification path PR#50 fixup 3 walked into and fixup 4
+corrected).
+
 Pairs with §2 (reviewer state check) / §12 (author state check) to
 close the rule-system self-reference loop: any destructive or
 irreversible PR action verifies state first; any new permanent rule
 added to the rulebook itself declares its own falsifiability boundary.
 
-### 14.1 Retroactive dogfooding for §9.4 / §10 – §14 / §11.5
+### 14.1 Self-audit summary (cross-section dogfooding table)
 
-Applying §14 backward to every rule-introducing addition shipped in
-this PR (documented here so the dogfooding cycle closes inside the
-same PR, and no new rule lands without its triple inline at the
-section head):
+Audit summary of every rule-introducing addition shipped in this PR.
+This table is a **supplementary** navigation aid for reviewers —
+each row must ALSO appear as an inline triple at the corresponding
+section head. Per §14 "Inline at section head is mandatory;
+centralised audit table is supplementary," a section with no inline
+triple is non-conformant even if it appears in this table.
 
-- **§9.4 Evolution narrative §9 → §11 cross-parser stack progression**
-  — triple inline at section head. Trigger: new §N supersedes earlier
-  §M's primary defense role. Revert-invariant: §11 appears ex-nihilo
-  to first-time readers. Sunset: none.
-- **§10 Performance assertions must be reverse-verifiable**
-  - trigger: a test asserts wall-clock / throughput / size in a fixed numeric threshold
-  - revert-invariant: deleting §10 lets PR#46-style 500ms-theatre assertions reappear; the test passes pre- and post-fix with no signal
-  - sunset: none (permanent invariant; perf-theatre risk is intrinsic to fixed-threshold assertions)
-- **§11 Pin assertions at the strictest enforcement boundary**
-  - trigger: a fix touches ≥2 layers of a parse → validate → encode → render → enforce pipeline
-  - revert-invariant: deleting §11 lets layered-defense tests assert at the upstream layer only; PRIMARY-layer drift becomes invisible (PR#45 SVG XSS reproduction)
-  - sunset: none (permanent invariant; defense-in-depth is structural)
-- **§11.5 Case study: legacy `image/svg` PR#49 dual-layer reverse-fail**
-  — triple inline at section head. Trigger: any new hardening on a
-  previously-§11-covered surface. Revert-invariant: §11 rests on N=1
-  evidence. Sunset: ≥3 independent case studies → promote to §11.0 lede.
-- **§12 Author-side state check before push**
-  - trigger: `git push --force-with-lease` (or any history-rewriting push) to a branch that backs an open PR
-  - revert-invariant: deleting §12 lets the PR#46 dangling-commit incident recur (force-push to a merged PR's branch creates commits that never reach `main`)
-  - sunset: none (permanent invariant; GitHub squash-merge semantics will not change)
-- **§13 Markdown URL parsing: CommonMark spec compliance**
-  - trigger: a markdown URL regex (`MARKDOWN_IMAGE_RE` / `MARKDOWN_LINK_RE` / equivalent) is added or modified
-  - revert-invariant: deleting §13 lets a future maintainer "fix" `[^)\s]+` to accept literal spaces, widening the attacker-input surface that §11.4 Step 4 depends on
-  - sunset: revisit if CommonMark spec changes URL-encoding requirements, or if the markdown parser is replaced with a non-regex implementation
-- **§14 (this section)**
-  - trigger: a new §N or rule-introducing §N.M is added to this checklist
-  - revert-invariant: deleting §14 lets future additions skip trigger / revert / sunset declarations; the checklist grows unbounded and dead rules accumulate silently
-  - sunset: none (permanent invariant; rule-system self-reference is required regardless of rule count)
+| Section | Trigger (one-line) | Revert-invariant (one-line) | Sunset (one-line) | Inline triple at section head |
+|---------|---------------------|------------------------------|-------------------|--------------------------------|
+| §9.4 | new §N supersedes earlier §M's primary defense role | §11 appears ex-nihilo to first-time readers | none (permanent) | ✓ |
+| §10 | test asserts fixed wall-clock / throughput / size threshold | PR#46-style 500ms-theatre assertions reappear | none (permanent) | ✓ |
+| §11 | fix touches ≥2 layers of a defense-in-depth pipeline | layered-defense tests assert only at upstream layer | none (permanent) | ✓ |
+| §11.5 | new hardening on previously-§11-covered surface | §11 rests on N=1 evidence | ≥3 case studies → promote to §11.0 lede | ✓ |
+| §12 | `git push --force-with-lease` to branch backing open PR | PR#46 dangling-commit incident recurs | none (permanent) | ✓ |
+| §13 | markdown URL regex added or modified | future "fix" widens attacker-input surface §11.4 depends on | CommonMark spec change OR non-regex parser | ✓ |
+| §14 | new §N or rule-introducing §N.M added | future additions skip triple; checklist grows unbounded | none (permanent) | ✓ |
 
-**Self-falsification audit (PR#50 fixup 2 → fixup 3 correction)**
+**Self-falsification audit (PR#50 fixup 2 → fixup 3 → fixup 4)**
 
 Fixup 2 (commit 07107599) introduced an "Non-rule additions are
-exempt" paragraph here that classified §9.4 and §11.5 as pure
+exempt" paragraph in §14.1 that classified §9.4 and §11.5 as pure
 evidence, exempt from the triple. That classification was the author
 asserting non-rule status of their own additions — exactly the
-self-classification path the revised §14 "Scope" paragraph above
-blocks. Reviewer (齐静春, 09:29 GMT+8) independently identified both
-§9.4 and §11.5 as introducing new normative claims (§9.4 = "lineage
-MUST be documented when superseding"; §11.5 = "N≥2 cases required to
-promote anecdote to pattern"). Fixup 3 removes the exemption
-paragraph, adds triples inline at the §9.4 and §11.5 section heads,
-and strengthens §14 with the independent-reviewer-ack requirement
-so the failure mode cannot recur.
+self-classification path the §14 "Scope" paragraph above blocks.
+Reviewer (齐静春, 09:29 GMT+8) independently identified both §9.4 and
+§11.5 as introducing new normative claims. Fixup 3 (commit 47066460)
+removed the exemption paragraph and added triples inline at §9.4 and
+§11.5 section heads.
+
+Fixup 3 still left a second §14 self-falsification mode in place:
+§10 / §11 / §12 / §13 triples lived ONLY inside this §14.1
+retroactive dogfooding section, not inline at the section heads.
+§14's literal rule ("every new checklist section §N MUST declare in
+its opening prose") was therefore still partially violated.
+Reviewers Steve and 齐静春 independently caught this on head 8ca325b2
+/ 07107599 (Steve: "§10-§13 各节开头缺 trigger / revert-invariant /
+sunset 声明, §14.1 集中补了 retroactive dogfooding 但各节 inline 没有";
+齐静春 09:30 GMT+8: "集中 ≠ inline"). Fixup 4 (this commit) moves
+each triple inline at its section head, demotes §14.1 to a
+supplementary cross-section audit summary table, and strengthens
+§14 "Scope" with the explicit inline-mandatory / table-supplementary
+clause so the failure mode cannot recur.
+
+**§14 self-falsification cardinality so far: N=2** (fixup 2
+self-exemption / fixup 3 centralised-not-inline). Per §11.5 sunset
+clause analogue ("≥3 independent cases → promote pattern to §N.0
+lede"), if a third independent self-falsification mode emerges on
+PR#50 itself, §14 will be considered for promotion to a §0.x ground
+rule rather than a §N rule — the rule about rules belongs above
+the rule list, not inside it. (Open question for follow-up; out of
+PR#50 scope.)
 
 ---
 


### PR DESCRIPTION
## Status — APPROVED on head `837085b4` (齐静春 R5 verdict, Sat 2026-06-06 09:40 GMT+8)

齐静春 R5 (final) verdict: **APPROVED** at head `837085b4` (subsequently `2649eb8e` after fixup 5 disambiguating note). gh CLI keyring (`lml2468` = both author and reviewer) blocks self-`--approve`; verdict surfaced in group thread is the binding signal. Awaiting non-`lml2468` reviewer merge push (yujiawei APPROVED on `47066460` may stale per §3; re-approve on current head may be required).

## Description sync (post-fixup, updates since original PR body)

This PR has expanded scope through 5 fixups beyond the original `§10-§13 + §9.3 4→5 + Quick Recall #11-#13` framing. Current scope per `git log feifei/checklist-extend-s10-s13`:

- **§9.4 Evolution narrative: §9 → §11 cross-parser stack progression** — lineage walk PR#38 → PR#45 → PR#47 → PR#49 (fixup 2)
- **§10 – §13** — original four sections, now each with inline trigger / revert-invariant / sunset triple at section head (fixup 4)
- **§11.5 Case study: legacy `image/svg` PR#49 dual-layer reverse-fail** — N=2 case-study cardinality for PRIMARY/SECONDARY pinning (fixup 2 + fixup 5 ordering note)
- **§14. New §N self-rule: declare trigger + revert-invariant + sunset** — meta-rule for rule-introducing additions, with "Scope is rule-introducing additions only — not the author's call" + "Inline at section head is mandatory; centralised audit table is supplementary" clauses (fixup 1 + fixup 3 + fixup 4)
- **§14.1 Self-audit summary (cross-section dogfooding table)** — 5-column audit table (Section / Trigger / Revert-invariant / Sunset / Inline-triple-at-head-✓) + self-falsification trace fixup 2 → fixup 3 → fixup 4 (fixup 1 + fixup 3 + fixup 4)
- **Quick Recall #14** — `New §N (or rule-introducing §N.M) declares trigger condition + revert-test invariant + sunset clause per §14?` (fixup 1)
- **README count sync** — `9-item checklist` → `14-item checklist (§0 ground rules through §14 rule-system self-reference)` + expanded example-rule list (fixup 4)
- **Checklist header count sync** — `9 checks` → `14 checks (§0 ground rules through §14 rule-system self-reference)` (fixup 4)

## §14 self-falsification audit (PR#50 inaugural)

PR#50 introduced §14 (rule-system self-reference meta-rule) and immediately walked into two of the failure modes §14 was designed to prevent — both caught by independent reviewers and corrected:

- **Mode 1 — Self-exemption (fixup 2 → fixup 3):** fixup 2 added "Non-rule additions are exempt" paragraph classifying §9.4 / §11.5 as pure evidence. 齐静春 09:29 GMT+8 independently identified both as introducing normative claims. Fixup 3 removed the exemption and added inline triples at the section heads, plus strengthened §14 Scope with "Scope is rule-introducing additions only — not the author's call" + anti-self-classification clause.
- **Mode 2 — Centralised-not-inline (fixup 3 → fixup 4):** fixup 3 had §10 / §11 / §12 / §13 triples in §14.1 only, not inline at section heads. §14's normative text reads "every new checklist section §N MUST declare in its opening prose [...]". Steve and 齐静春 09:30 GMT+8 independently caught this. Fixup 4 moved each triple inline at its section head, demoted §14.1 to a supplementary audit table, and added the "Inline at section head is mandatory; centralised audit table is supplementary" clause.

Self-falsification cardinality so far: **N=2**. Per §11.5 sunset-clause analogue ("≥3 independent case studies → promote pattern to §N.0 lede"), if a third self-falsification mode emerges, §14 will be considered for promotion to a §0.x ground rule rather than a §N rule (open question, follow-up scope).

This audit trail is preserved in §14.1 as the canonical living example of "rule-system self-reference must be unambiguous" — see also AGENTS.md `coding` 准则三 §6 ("rule 系统自指完备性").

---

## Why this PR exists (and why it must merge before PR#47 / PR#48 / PR#49)

齐静春's PR#48 cross-check (Sat 2026-06-06 09:10 GMT+8) caught a dangling-reference defect across three open follow-up PRs:

- **PR#47** body / commit messages cite `REVIEW_CHECKLIST §11`
- **PR#48** body / commit message cite `REVIEW_CHECKLIST §11` ("if reverting the change does not fail the test, the test is not testing the change")
- **PR#49** body cites `REVIEW_CHECKLIST.md §11` (×6, including §11.1 / §11.4)

`grep '^## ' docs/REVIEW_CHECKLIST.md` on `origin/main` (HEAD `69cd6d7`) returns sections `§0`-`§9` + `Quick recall card`. **§10-§13 do not exist on main.**

This was a direct consequence of my (李飞飞) silent defer of the §10-§13 extension while shipping PR#47 (mis-attribution: 豆豆 owns PR#47) / PR#48 (tautology removal only) / PR#49 (legacy `image/svg` MIME hardening only). I shipped the cite-side without shipping the definition-side. Per §12 (this PR introduces), author-side state-check would not have caught a dangling docs reference — but writing the docs first would have. Capturing this in the §12 framing below.

## What's in this PR

Pure docs change to `docs/REVIEW_CHECKLIST.md`. No code change. tsc / vitest / eslint unaffected.

### §10. Performance assertions must be reverse-verifiable

- Theatre elimination per PR#46 `truncateByBytes` 500ms threshold incident (pre-revert and post-revert both completed in 49ms; assertion never could have caught the regression it claimed to guard).
- Two reviewers (齐静春, 王大锤) independently reached this finding via reverse-verify experiment. Independent re-derivation = strong signal.
- §10.1 includes a keep/delete table: byte-safety/correctness assertions stay, micro-benchmark thresholds get deleted (not raised).

### §10.5 Reverse-verify protocol

5-step operationalisation:
1. `git revert <helper-commit>` (or stash the fast-path)
2. Re-run the test on the same CI runner / fresh worktree
3. If still passes, **delete** the perf assertion (do NOT raise the threshold — raising preserves the lie)
4. Keep correctness assertions in the same test; they cover the real win
5. Document the reverse-verify result in the PR description

齐静春 wording on cross-check: "perf 断言不能假设算法复杂度等于真实运行时间——V8 优化 / RAM 带宽 / 内部表示都会让 big-O 分析失效." Captured in §10 prose.

### §11. Pin assertions at the strictest enforcement boundary

王大锤 meta-rule articulated during PR#45 hardening / PR#38 series:

- **PRIMARY assertion** = strictest enforcement boundary the attacker reaches (cannot be bypassed by drift in upstream layers).
- **SECONDARY assertion** = upstream-layer correlate (regression visibility only).
- Reverse-verify rule (§10.5 dogfooded onto §11): both PRIMARY and SECONDARY must independently fail when their respective layer reverts.

### §11.1 SVG XSS PR#45 case study

- PRIMARY: `Content-Disposition: attachment` at CDN layer.
- SECONDARY: `MessageType.File` in IM payload.
- Verified both independently fail when their layer reverts: see PR#47 review (李飞飞 COMMENTED on `a4577a3` — could not APPROVED because shared `lml2468` keyring is both author/reviewer).

### §11.2 Multi-layer fix → multi-narrow-test pattern

When a fix touches N layers, prefer N narrow tests over one broad end-to-end test. End-to-end tests pass as long as ANY layer enforces — silently mask upstream failure.

PR#45 SVG XSS shipped 3 layers; PR#47 split the assertion into PRIMARY/SECONDARY (Step 1); splitting into 3 layer-pinned narrow tests is the full §11 application (王大锤 PR#45 review #1 follow-up; recommended for PR#48 / PR#49 follow-up).

### §11.3 Comment template (PRIMARY / SECONDARY)

Reusable annotation template so the next maintainer doesn't re-derive the boundary model. Lifted from PR#47's hardening-test annotation block — extraction recommended by 李飞飞 in PR#47 review non-blocking note #2.

### §11.4 MIME-type canonicalisation: 4-step checklist

Distilled from PR#45 SVG XSS three-variant findings (王大锤 review):

1. Strip parameters (`split(';')[0].trim()`) — `image/svg+xml; charset=utf-8` and `image/svg+xml` must canonicalise the same
2. Lowercase per RFC 6838 §4.2 — `Image/Svg+Xml` is the same type as `image/svg+xml`
3. RFC 2397 data URI handling — parse MIME segment up to first `;` or `,` boundary, NOT a regex that assumes no parameters
4. `Content-Disposition: attachment` pin at storage / CDN layer — strictest enforcement boundary per §11

### §12. Author-side state check before push

Mirror of §2 (reviewer-side state check before APPROVED) applied to the author side:

```bash
gh pr view <N> --repo <owner/repo> --json state,mergedAt
```

If `state` is `MERGED` or `mergedAt` is non-null, **STOP**. Force-pushing to a merged PR's branch creates dangling commits (the branch HEAD drifts to a SHA that's never on `main`). Fix is a follow-up PR from latest `main`, not amend.

Rule introduced after PR#46 dangling-commit incident: commits `34cdeed` / `15de583` amended onto a force-pushed branch after the PR had already squash-merged as `d0abb5b`; amendments never made it to `main` and had to be redone as a follow-up PR — which is this very chain.

Pairs with §2 to form the author/reviewer state-check pair: any destructive or irreversible PR action verifies state first.

### §13. Markdown URL parsing: CommonMark spec compliance

`[^)\s]+` URL regex silent-skip of literal-space URLs is design-correct (CommonMark requires URL-encoded `%20`). No XSS gap (image isn't processed = no inline render). IS a usability gap.

**Action required**: when adding/modifying a markdown URL regex, add an inline comment at the regex definition site explaining the design choice so the next maintainer doesn't "fix" the regex to accept spaces and accidentally widen the attacker-input surface that §11.4 depends on. Comment template included.

王大锤 follow-up note (PR#47 thread): the comment annotation should live at `MARKDOWN_IMAGE_RE` / `MARKDOWN_LINK_RE` definition site too, not only in docs — so a code reader sees the design rationale first. Captured in §13 example.

### §9.3 Recurrence count: 4 → 5

PR#45 SVG XSS cross-parser finding (in-app MIME canonical / RFC 2397 data-URI parser / CDN Content-Disposition all needed independent enforcement; "fix one, leave two" mode) added as the 5th instance of the same root pattern. If a sixth variant check appears, stop and rewrite the validator to defer to the spec parser plus a defense-in-depth boundary guard (§9.2 + §11).

### Quick recall card extended 10 → 13

- #11 Perf assertions reverse-verified per §10.5?
- #12 Assertions pinned at strictest enforcement boundary per §11 (PRIMARY/SECONDARY split when defense is layered)?
- #13 Author-side `gh pr view <N> --json state,mergedAt` run before force-push to an open PR's branch?

## §12 dogfooding (first end-to-end application)

This PR is the first end-to-end §12 dogfooding cycle. Pre-push:

```bash
$ git push --set-upstream origin feifei/checklist-extend-s10-s13
# pre-push hook runs, validates branch contains origin/main HEAD
✅ 检查通过，允许推送。
```

Post-push state check (per §12):

```bash
$ gh pr view 50 --repo Mininglamp-OSS/cc-channel-octo --json state,mergedAt
# expected: {"state":"OPEN","mergedAt":null}
```

Will be recorded in commit message of any future amend before this PR merges. If state ever returns `MERGED`, force-push is BLOCKED.

## Verification

- `npm install --ignore-scripts && npm rebuild better-sqlite3` (per TOOLS.md known trap)
- `npx tsc --noEmit` → clean
- `npx vitest run` → 692/692 pass (37 files)
- `git diff --stat` → `docs/REVIEW_CHECKLIST.md | 232 +++++++++++++++++++++++++++++++++++++++++++-`

## Reviewer guidance (per 04:35 dispatch)

- **齐静春**: §10/§10.5 perf reverse-verify wording (you and 王大锤 independently reached this finding); §9.3 4→5 recurrence framing; overall section ordering / dogfooding rationale.
- **王大锤**: §11 strictest-enforcement-boundary meta-rule (your articulation across PR#38 / PR#45 review); §11.4 MIME 4-step (your PR#45 review feedback); §13 markdown URL CommonMark inline-comment placement (your follow-up note).
- **陈皮皮**: §12 author-side state-check pairing with §2 (your PR#46 dangling-commit diagnosis); approve-to-merge ordering (this PR must merge before PR#47 / PR#48 / PR#49).
- **毛豆豆**: §11.2 multi-narrow-test pattern (your PR#47 §11 PRIMARY/SECONDARY structure is Step 1; full §11 application = 3 narrow tests).

## Merge ordering after this PR

1. **PR#50** (this PR) — docs infrastructure
2. PR#47 (豆豆 §11 dogfooding) — §11 reference now valid
3. PR#48 (李飞飞 C1 cleanup) — §11 reference now valid
4. PR#49 (李飞飞 `image/svg` belt-and-suspenders) — §11.4 reference now valid
5. v0.1.1 release tag (娃爹 decision)

## Out of scope (intentional)

- No `media-upload.ts` 1-character `endsWith('/svg')` change — already shipped in PR#49.
- No code regression test — PR#49 already covers it.
- No PR#47/PR#48/PR#49 amends — those PRs stay as-is; once this lands, their §11 references become valid retroactively.

## Per §11 reverse-verify rule applied to docs

Reverting this PR (i.e. removing §10-§13) makes PR#47 / PR#48 / PR#49 commit messages cite a non-existent section. The "test" here = three downstream PRs' references resolving correctly; the "revert" = removing the sections; the result = downstream PRs' citations fail to resolve. ✅ Reverse-verify passes.

