### PR TITLE
feat(config): anthropicBaseUrl + allowedTools simplify + per-session cwd isolation (7d TTL)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,10 +85,10 @@ Three-level priority: **environment variables** > **config.json** > **defaults**
 |-------|---------|---------|-------------|
 | `botToken` | `CC_OCTO_BOT_TOKEN` | *(required)* | Octo bot token (`bf_*`) |
 | `apiUrl` | `CC_OCTO_API_URL` | *(required)* | Octo API base URL |
-| `cwdBase` | `CC_OCTO_CWDBASE` | `process.cwd()` | Base directory for per-session sandboxes. Each DM peer and group gets its own SHA-256 hex subdirectory under it; subdirs idle >7d are auto-cleaned every 6h. Thread isolation is reserved until Octo messages expose a thread/topic id. Legacy `cwd` / `CC_OCTO_CWD` still accepted with a deprecation warning. |
+| `cwdBase` | `CC_OCTO_CWDBASE` | `process.cwd()` | Base directory for per-session sandboxes. Each session (DM peer, or individual group member) gets its own SHA-256 hex subdirectory under it, matching how conversation history is partitioned; subdirs idle >7d are auto-cleaned every 6h. Legacy `cwd` / `CC_OCTO_CWD` still accepted with a deprecation warning. |
 | `dataDir` | `CC_OCTO_DATA_DIR` | `./data` | SQLite database directory (created with `0700` permissions) |
 | `sdk.model` | `CC_OCTO_SDK_MODEL` | *(SDK default)* | Claude model override |
-| `sdk.allowedTools` | `CC_OCTO_SDK_ALLOWED_TOOLS` | `"*"` | Either `"*"` (allow every tool the SDK exposes) or an explicit string array whitelist. Env accepts the literal `*` token or a CSV list. |
+| `sdk.allowedTools` | `CC_OCTO_SDK_ALLOWED_TOOLS` | `"*"` | Either `"*"` (allow every tool the SDK exposes) or an explicit string array whitelist. Env accepts a value containing `*` (wildcard) or a CSV list. |
 | `sdk.permissionMode` | `CC_OCTO_SDK_PERMISSION_MODE` | `bypassPermissions` | SDK permission mode |
 | `sdk.maxTurns` | `CC_OCTO_SDK_MAX_TURNS` | *(SDK default)* | Max agentic turns per query |
 | `sdk.systemPrompt` | `CC_OCTO_SDK_SYSTEM_PROMPT` | *(built-in)* | Custom system prompt |
@@ -105,8 +105,14 @@ Three-level priority: **environment variables** > **config.json** > **defaults**
 If you proxy the Claude API through your own gateway (corporate egress, regional
 endpoint, model router, etc.), set `sdk.anthropicBaseUrl` to the gateway origin.
 The value is forwarded to the Claude Agent SDK subprocess as the standard
-`ANTHROPIC_BASE_URL` environment variable, so any deployment that already speaks
+`ANTHROPIC_BASE_URL` environment variable (scoped to the subprocess — it does
+not mutate the gateway's own environment), so any deployment that already speaks
 the Anthropic protocol will Just Work — no code changes required.
+
+Because this endpoint receives the Anthropic API key and all prompt/response
+content, it is SSRF-validated at boot exactly like `apiUrl`: it must be `https://`
+(or `http://localhost` / `http://127.0.0.1` for local development), and may not
+resolve to a private/link-local address. An unsafe value fails fast at startup.
 
 ```jsonc
 {
@@ -145,16 +151,22 @@ the list to reduce risk:
 
 ### 2. `cwdBase` Isolation
 
-**`cwdBase` is the parent directory under which each conversation gets its own
-hashed sandbox.** A 16-hex SHA-256 subdirectory is created per DM peer or group,
-so one user's Claude Code session cannot read or mutate another's working tree.
-Thread-level isolation is reserved until Octo messages expose a thread/topic id.
-Subdirectories idle for more than 7 days are cleaned up automatically every 6
-hours.
+**`cwdBase` is the parent directory under which each session gets its own
+hashed sandbox.** A 16-hex SHA-256 subdirectory is derived from the same
+per-session key used for conversation history, so isolation is **per user** —
+including inside groups, where each member's sessionKey embeds their uid. One
+user's Claude Code session cannot read or mutate another's working tree.
+Subdirectories idle for more than 7 days (measured from the last inbound
+message) are cleaned up automatically every 6 hours.
 
-Any Octo user who can message the bot can still instruct Claude Code to read
-files within *their own* session sandbox, so `cwdBase` itself must not contain
-secrets you don't want exposed.
+**Limitation — cwd is a starting directory, not a chroot.** With `Bash`/`Read`
+in the tool set and `bypassPermissions`, the agent can still be instructed to
+read absolute paths outside the sandbox (e.g. `/etc/passwd`, or the gateway's
+own `config.json`). Per-session `cwdBase` partitions sessions from *each other*;
+it does not confine a single session to its directory. For a hard boundary, run
+the gateway as an unprivileged user in a container/VM and tighten `allowedTools`
+(drop `Bash`). Treat `cwdBase` itself as untrusted ground: any user who can
+message the bot can read files within their own session sandbox.
 
 Do **NOT** put these in `cwdBase`:
 - `config.json` (contains your bot token)
@@ -267,7 +279,7 @@ src/
 ## Known Limitations (v0.1)
 
 - **Text only** — Image, file, and voice messages are not processed (the bot replies with a notice).
-- **Per-session `cwdBase` isolation** — Each DM peer and group gets its own SHA-256 hex sandbox under `cwdBase`; idle sandboxes (>7d) are auto-cleaned every 6h. Thread-level isolation is reserved for a future Octo message shape that carries a thread id.
+- **Per-session `cwdBase` isolation** — Each session (DM peer, or individual group member) gets its own SHA-256 hex sandbox under `cwdBase`, partitioned by the same key as conversation history; idle sandboxes (>7d) are auto-cleaned every 6h. Note: `cwdBase` separates sessions from each other but does not confine a session to its directory (absolute-path reads via Bash/Read remain possible) — see the Security Model section.
 - **Stateless sessions** — Uses the v1 `query()` API. Workspace state (open files, command history) does not persist across messages. The v2 Session API is planned for v0.3.
 - **Single bot** — One bot per process. Multi-bot support is planned for v0.3.
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Users talk to a bot in Octo (DM or group @mention). The bot sends messages to Cl
 - **Group chat awareness** — Responds only to @mentions. Injects recent group conversation as context so Claude understands the discussion.
 - **Session persistence** — SQLite-backed conversation history (40-message sliding window) with automatic 7-day expiry.
 - **Rate limiting** — Per-session token bucket (default 5 req/min) with debounced rejection notices.
-- **Security by configuration** — `allowedTools` whitelist + `cwd` isolation. No runtime permission prompts (headless mode).
+- **Security by configuration** — `allowedTools` whitelist + per-session `cwdBase` isolation. No runtime permission prompts (headless mode).
 - **Zero infrastructure** — Single process, single SQLite file, `npm start` and go.
 
 ## Quick Start
@@ -54,7 +54,7 @@ Edit `config.json` with your credentials:
 {
   "botToken": "bf_YOUR_BOT_TOKEN",
   "apiUrl": "https://your-octo-instance.com",
-  "cwd": "/path/to/isolated/project"  // ⚠️ Must NOT contain config.json or secrets
+  "cwdBase": "/path/to/isolated/sandbox-root"  // ⚠️ parent dir for per-session sandboxes — must NOT contain config.json or secrets
 }
 ```
 
@@ -73,7 +73,7 @@ Every config field can be overridden via environment variables (highest priority
 ```bash
 CC_OCTO_BOT_TOKEN=bf_xxx \
 CC_OCTO_API_URL=https://octo.example.com \
-CC_OCTO_CWD=/home/deploy/project \
+CC_OCTO_CWDBASE=/home/deploy/sandbox-root \
 npm start
 ```
 
@@ -85,19 +85,45 @@ Three-level priority: **environment variables** > **config.json** > **defaults**
 |-------|---------|---------|-------------|
 | `botToken` | `CC_OCTO_BOT_TOKEN` | *(required)* | Octo bot token (`bf_*`) |
 | `apiUrl` | `CC_OCTO_API_URL` | *(required)* | Octo API base URL |
-| `cwd` | `CC_OCTO_CWD` | `process.cwd()` | Working directory for Claude Code |
+| `cwdBase` | `CC_OCTO_CWDBASE` | `process.cwd()` | Base directory for per-session sandboxes. Each DM peer and group gets its own SHA-256 hex subdirectory under it; subdirs idle >7d are auto-cleaned every 6h. Thread isolation is reserved until Octo messages expose a thread/topic id. Legacy `cwd` / `CC_OCTO_CWD` still accepted with a deprecation warning. |
 | `dataDir` | `CC_OCTO_DATA_DIR` | `./data` | SQLite database directory (created with `0700` permissions) |
 | `sdk.model` | `CC_OCTO_SDK_MODEL` | *(SDK default)* | Claude model override |
-| `sdk.allowedTools` | `CC_OCTO_SDK_ALLOWED_TOOLS` | `Read,Write,Edit,Bash,Glob,Grep,WebFetch,WebSearch` | Comma-separated tool whitelist |
+| `sdk.allowedTools` | `CC_OCTO_SDK_ALLOWED_TOOLS` | `"*"` | Either `"*"` (allow every tool the SDK exposes) or an explicit string array whitelist. Env accepts the literal `*` token or a CSV list. |
 | `sdk.permissionMode` | `CC_OCTO_SDK_PERMISSION_MODE` | `bypassPermissions` | SDK permission mode |
 | `sdk.maxTurns` | `CC_OCTO_SDK_MAX_TURNS` | *(SDK default)* | Max agentic turns per query |
 | `sdk.systemPrompt` | `CC_OCTO_SDK_SYSTEM_PROMPT` | *(built-in)* | Custom system prompt |
 | `sdk.settingSources` | `CC_OCTO_SDK_SETTING_SOURCES` | `user` | Comma-separated setting sources (e.g. `user,project`) |
+| `sdk.anthropicBaseUrl` | `ANTHROPIC_BASE_URL` | *(unset)* | Override the upstream Claude API endpoint. See [Self-hosted gateway](#self-hosted-gateway) below. |
 | `rateLimit.maxPerMinute` | `CC_OCTO_RATE_LIMIT_MAX_PER_MINUTE` | `5` | Max requests per minute per session |
 | `context.maxContextChars` | `CC_OCTO_CONTEXT_MAX_CHARS` | `6000` | Max characters of group context injected into prompts |
 | `context.historyLimit` | `CC_OCTO_CONTEXT_HISTORY_LIMIT` | `40` | Max messages in session history window |
 | `botBlocklist` | `CC_OCTO_BOT_BLOCKLIST` | `[]` | Comma-separated bot UIDs to ignore in DMs (prevents bot loops) |
 | `mentionFreeGroups` | `CC_OCTO_MENTION_FREE_GROUPS` | `[]` | Comma-separated group channel IDs where the bot responds to every text message without requiring an `@bot` mention (G12). |
+
+### Self-hosted gateway
+
+If you proxy the Claude API through your own gateway (corporate egress, regional
+endpoint, model router, etc.), set `sdk.anthropicBaseUrl` to the gateway origin.
+The value is forwarded to the Claude Agent SDK subprocess as the standard
+`ANTHROPIC_BASE_URL` environment variable, so any deployment that already speaks
+the Anthropic protocol will Just Work — no code changes required.
+
+```jsonc
+{
+  "sdk": {
+    "anthropicBaseUrl": "https://claude-gw.internal.example.com"
+  }
+}
+```
+
+Or via environment (highest priority, no `CC_OCTO_` prefix — uses the Anthropic
+SDK standard variable name):
+
+```bash
+ANTHROPIC_BASE_URL=https://claude-gw.internal.example.com npm start
+```
+
+Leave the field unset to talk to Anthropic's public endpoint directly.
 
 ## Security Model
 
@@ -105,35 +131,47 @@ cc-channel-octo runs Claude Code in **headless automation mode**. There is no te
 
 ### 1. `allowedTools` Whitelist
 
-The `allowedTools` array is the primary security control. Claude Code can only use tools in this list. Reduce the list to reduce risk:
+The `allowedTools` field accepts either the wildcard `"*"` (allow every tool
+the SDK exposes — the default) or an explicit string array whitelist. Reduce
+the list to reduce risk:
 
 | Profile | `allowedTools` | Risk Level |
 |---------|---------------|------------|
-| **Full** (default) | `Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch` | High — full automation |
-| **No network** | `Read, Write, Edit, Bash, Glob, Grep` | Medium — no SSRF risk |
-| **No shell** | `Read, Write, Edit, Glob, Grep` | Medium — no arbitrary commands |
-| **Read-only** | `Read, Glob, Grep` | Low — code reading only |
+| **Full** (default) | `"*"` | High — every SDK tool available |
+| **Explicit full** | `["Read", "Write", "Edit", "Bash", "Glob", "Grep", "WebFetch", "WebSearch"]` | High — same surface, pinned list |
+| **No network** | `["Read", "Write", "Edit", "Bash", "Glob", "Grep"]` | Medium — no SSRF risk |
+| **No shell** | `["Read", "Write", "Edit", "Glob", "Grep"]` | Medium — no arbitrary commands |
+| **Read-only** | `["Read", "Glob", "Grep"]` | Low — code reading only |
 
-### 2. `cwd` Isolation
+### 2. `cwdBase` Isolation
 
-**`cwd` must point to an isolated working directory.** Any Octo user who can message the bot can instruct Claude Code to read files within `cwd`.
+**`cwdBase` is the parent directory under which each conversation gets its own
+hashed sandbox.** A 16-hex SHA-256 subdirectory is created per DM peer or group,
+so one user's Claude Code session cannot read or mutate another's working tree.
+Thread-level isolation is reserved until Octo messages expose a thread/topic id.
+Subdirectories idle for more than 7 days are cleaned up automatically every 6
+hours.
 
-Do **NOT** put these in `cwd`:
+Any Octo user who can message the bot can still instruct Claude Code to read
+files within *their own* session sandbox, so `cwdBase` itself must not contain
+secrets you don't want exposed.
+
+Do **NOT** put these in `cwdBase`:
 - `config.json` (contains your bot token)
 - Private keys, credentials, or `.env` files
 - Sensitive configuration outside the project scope
 
 ```
-# ✅ Good — isolated project directory
-"cwd": "/home/deploy/my-project"
+# ✅ Good — isolated sandbox root, no secrets inside
+"cwdBase": "/home/deploy/cc-octo-sandboxes"
 
-# ❌ Bad — config.json is in the same directory
-"cwd": "."
+# ❌ Bad — config.json sits in the same directory
+"cwdBase": "."
 ```
 
 ### Built-in System Prompt
 
-A default system prompt instructs Claude to treat input as untrusted and decline requests for sensitive file reads or credential exfiltration. This is a **soft constraint** (model-level guidance), not a security boundary. The `allowedTools` whitelist and `cwd` isolation are the real security controls.
+A default system prompt instructs Claude to treat input as untrusted and decline requests for sensitive file reads or credential exfiltration. This is a **soft constraint** (model-level guidance), not a security boundary. The `allowedTools` whitelist and per-session `cwdBase` isolation are the real security controls.
 
 ### Bot Loop Prevention
 
@@ -229,7 +267,7 @@ src/
 ## Known Limitations (v0.1)
 
 - **Text only** — Image, file, and voice messages are not processed (the bot replies with a notice).
-- **Shared `cwd`** — All users share a single Claude Code working directory. Per-session isolation is planned for v0.2.
+- **Per-session `cwdBase` isolation** — Each DM peer and group gets its own SHA-256 hex sandbox under `cwdBase`; idle sandboxes (>7d) are auto-cleaned every 6h. Thread-level isolation is reserved for a future Octo message shape that carries a thread id.
 - **Stateless sessions** — Uses the v1 `query()` API. Workspace state (open files, command history) does not persist across messages. The v2 Session API is planned for v0.3.
 - **Single bot** — One bot per process. Multi-bot support is planned for v0.3.
 
@@ -238,7 +276,7 @@ src/
 | Version | Scope |
 |---------|-------|
 | **v0.1** *(current)* | Text messaging, streaming, session persistence, rate limiting, security model |
-| **v0.2** | Media reception (image/file), `/reset` and `/config` commands, per-session `cwd` isolation |
+| **v0.2** | Media reception (image/file), `/reset` and `/config` commands |
 | **v0.3** | v2 Session API, multi-bot support, tool progress display |
 | **v1.0** | Media sending, GROUP.md/THREAD.md configuration, webhook mode |
 

--- a/config.example.json
+++ b/config.example.json
@@ -8,9 +8,8 @@
   "dataDir": "./data",
 
   "sdk": {
-    "_comment_anthropic_base_url": "Q1: Optional. Set to a self-hosted Claude API gateway base URL. Forwarded to the SDK subprocess as ANTHROPIC_BASE_URL. Env override (highest priority): ANTHROPIC_BASE_URL (Anthropic SDK standard variable name, no CC_OCTO_ prefix).",
-    "anthropicBaseUrl": "https://your-gateway.example.com",
-    "_comment_allowed_tools": "Q2: either '*' (allow every tool the SDK exposes) or an explicit string[] whitelist, e.g. ['Read', 'Write', 'Edit', 'Bash', 'Glob', 'Grep', 'WebFetch', 'WebSearch']. Env override CC_OCTO_SDK_ALLOWED_TOOLS accepts the same two shapes (literal '*' or CSV).",
+    "_comment_anthropic_base_url": "Q1: Optional self-hosted Claude API gateway base URL. Forwarded to the SDK subprocess (scoped, not via global process.env). Must be https:// (or http://localhost for dev) — it is SSRF-validated at boot like apiUrl. To enable, add a real \"anthropicBaseUrl\": \"https://your-gateway.example.com\" key here, or set the ANTHROPIC_BASE_URL env var (highest priority, Anthropic SDK standard name, no CC_OCTO_ prefix). Leave it out entirely to use Anthropic's public endpoint.",
+    "_comment_allowed_tools": "Q2: either '*' (allow every tool the SDK exposes) or an explicit string[] whitelist, e.g. ['Read', 'Write', 'Edit', 'Bash', 'Glob', 'Grep', 'WebFetch', 'WebSearch']. Env override CC_OCTO_SDK_ALLOWED_TOOLS accepts the same two shapes (a value containing '*' means wildcard; otherwise CSV).",
     "allowedTools": "*",
     "permissionMode": "bypassPermissions",
     "settingSources": ["user"]

--- a/config.example.json
+++ b/config.example.json
@@ -1,13 +1,17 @@
 {
-  "_comment": "Default: full tool set + bypassPermissions (headless automation). Security relies on allowedTools whitelist, not permissionMode. IMPORTANT: set cwd to an isolated working directory — do NOT point it at a directory containing config.json, tokens, or other secrets.",
-  "_comment_safe_mode": "Optional safe downgrade: set allowedTools to ['Read', 'Glob', 'Grep'] and remove Bash/Write/Edit/WebFetch/WebSearch to restrict to read-only operations. Remove WebFetch/WebSearch to eliminate SSRF risk.",
+  "_comment": "Default: allowedTools='*' (SDK full set) + bypassPermissions (headless automation). IMPORTANT: cwdBase is the parent dir for per-session sandboxes — each (DM peer | group | thread) gets its own hashed subdirectory under it. Do NOT point cwdBase at a directory containing config.json, tokens, or other secrets.",
+  "_comment_safe_mode": "Optional safe downgrade: set allowedTools to ['Read', 'Glob', 'Grep'] to restrict to read-only operations. Use '*' to allow every tool the SDK exposes.",
   "botToken": "bf_YOUR_BOT_TOKEN",
   "apiUrl": "https://your-octo-instance.com",
-  "cwd": "/path/to/isolated/project",
+  "_comment_cwd_base": "Q3: base directory for per-session cwd isolation. Each session gets a 16-hex SHA-256 subdirectory under this path; subdirs idle for >7d are auto-cleaned every 6h. Env override: CC_OCTO_CWDBASE (legacy CC_OCTO_CWD still accepted with a deprecation warning).",
+  "cwdBase": "/path/to/isolated/sandbox-root",
   "dataDir": "./data",
 
   "sdk": {
-    "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep", "WebFetch", "WebSearch"],
+    "_comment_anthropic_base_url": "Q1: Optional. Set to a self-hosted Claude API gateway base URL. Forwarded to the SDK subprocess as ANTHROPIC_BASE_URL. Env override (highest priority): ANTHROPIC_BASE_URL (Anthropic SDK standard variable name, no CC_OCTO_ prefix).",
+    "anthropicBaseUrl": "https://your-gateway.example.com",
+    "_comment_allowed_tools": "Q2: either '*' (allow every tool the SDK exposes) or an explicit string[] whitelist, e.g. ['Read', 'Write', 'Edit', 'Bash', 'Glob', 'Grep', 'WebFetch', 'WebSearch']. Env override CC_OCTO_SDK_ALLOWED_TOOLS accepts the same two shapes (literal '*' or CSV).",
+    "allowedTools": "*",
     "permissionMode": "bypassPermissions",
     "settingSources": ["user"]
   },

--- a/src/__tests__/agent-bridge-config.test.ts
+++ b/src/__tests__/agent-bridge-config.test.ts
@@ -2,8 +2,10 @@
  * Agent Bridge config-forwarding tests (P2 nit-2).
  *
  * Covers two SDK option behaviors that previously had no test:
- *  - Q1: `anthropicBaseUrl` is written to `process.env.ANTHROPIC_BASE_URL`
- *        before the SDK call. When unset, process.env stays untouched.
+ *  - Q1: `anthropicBaseUrl` is forwarded via the scoped `options.env`
+ *        (spread over process.env) so it reaches the SDK subprocess without
+ *        mutating the gateway's own global env. When unset, `options.env` is
+ *        omitted entirely.
  *  - Q2: `allowedTools: "*"` is the "no whitelist" sentinel — the option is
  *        omitted entirely so the SDK falls back to its built-in tool set. An
  *        explicit string[] is forwarded as-is.
@@ -70,22 +72,19 @@ describe('queryAgent SDK configuration forwarding', () => {
     }
   });
 
-  it('sets ANTHROPIC_BASE_URL before calling the SDK when configured', async () => {
-    let envAtCall: string | undefined;
-    mockQuery.mockImplementation(() => {
-      envAtCall = process.env.ANTHROPIC_BASE_URL;
-      return createMockStream();
-    });
-
+  it('forwards ANTHROPIC_BASE_URL via scoped options.env, not global process.env', async () => {
     await drain(makeConfig({ anthropicBaseUrl: 'https://gw.example.com' }));
 
     const options = mockQuery.mock.calls[0][0].options;
-    expect(envAtCall).toBe('https://gw.example.com');
-    expect(options.env).toBeUndefined();
-    expect(process.env.ANTHROPIC_BASE_URL).toBe('https://gw.example.com');
+    // Scoped to the subprocess env, spread over process.env to preserve PATH etc.
+    expect(options.env).toBeDefined();
+    expect(options.env.ANTHROPIC_BASE_URL).toBe('https://gw.example.com');
+    expect(options.env.PATH).toBe(process.env.PATH);
+    // The gateway's own global env must NOT be mutated (no cross-request leak).
+    expect(process.env.ANTHROPIC_BASE_URL).toBeUndefined();
   });
 
-  it('does not mutate ANTHROPIC_BASE_URL when not configured', async () => {
+  it('does not set options.env or mutate process.env when not configured', async () => {
     await drain(makeConfig());
 
     const options = mockQuery.mock.calls[0][0].options;

--- a/src/__tests__/agent-bridge-config.test.ts
+++ b/src/__tests__/agent-bridge-config.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Agent Bridge config-forwarding tests (P2 nit-2).
+ *
+ * Covers two SDK option behaviors that previously had no test:
+ *  - Q1: `anthropicBaseUrl` is written to `process.env.ANTHROPIC_BASE_URL`
+ *        before the SDK call. When unset, process.env stays untouched.
+ *  - Q2: `allowedTools: "*"` is the "no whitelist" sentinel — the option is
+ *        omitted entirely so the SDK falls back to its built-in tool set. An
+ *        explicit string[] is forwarded as-is.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockQuery = vi.hoisted(() => vi.fn());
+vi.mock('@anthropic-ai/claude-agent-sdk', () => ({
+  query: mockQuery,
+}));
+
+import { queryAgent } from '../agent-bridge.js';
+import type { Config } from '../config.js';
+
+const originalAnthropicBaseUrl = process.env.ANTHROPIC_BASE_URL;
+
+function makeConfig(sdkOverrides: Partial<Config['sdk']> = {}): Config {
+  return {
+    botToken: 'test-token',
+    apiUrl: 'https://test.example.com',
+    cwd: '/tmp/test',
+    dataDir: '/tmp/data',
+    sdk: {
+      allowedTools: '*',
+      permissionMode: 'bypassPermissions',
+      settingSources: ['user'],
+      ...sdkOverrides,
+    },
+    rateLimit: { maxPerMinute: 5 },
+    context: { maxContextChars: 6000, historyLimit: 40 },
+    maxResponseChars: 1000,
+  };
+}
+
+function createMockStream() {
+  return {
+    [Symbol.asyncIterator]: async function* () {
+      yield { type: 'result', subtype: 'success' };
+    },
+    close: vi.fn(),
+  };
+}
+
+async function drain(config: Config): Promise<void> {
+  for await (const chunk of queryAgent('hello', '', '', config)) {
+    void chunk;
+    // Drain generator so queryAgent invokes the SDK mock.
+  }
+}
+
+describe('queryAgent SDK configuration forwarding', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.ANTHROPIC_BASE_URL;
+    mockQuery.mockReturnValue(createMockStream());
+  });
+
+  afterEach(() => {
+    if (originalAnthropicBaseUrl === undefined) {
+      delete process.env.ANTHROPIC_BASE_URL;
+    } else {
+      process.env.ANTHROPIC_BASE_URL = originalAnthropicBaseUrl;
+    }
+  });
+
+  it('sets ANTHROPIC_BASE_URL before calling the SDK when configured', async () => {
+    let envAtCall: string | undefined;
+    mockQuery.mockImplementation(() => {
+      envAtCall = process.env.ANTHROPIC_BASE_URL;
+      return createMockStream();
+    });
+
+    await drain(makeConfig({ anthropicBaseUrl: 'https://gw.example.com' }));
+
+    const options = mockQuery.mock.calls[0][0].options;
+    expect(envAtCall).toBe('https://gw.example.com');
+    expect(options.env).toBeUndefined();
+    expect(process.env.ANTHROPIC_BASE_URL).toBe('https://gw.example.com');
+  });
+
+  it('does not mutate ANTHROPIC_BASE_URL when not configured', async () => {
+    await drain(makeConfig());
+
+    const options = mockQuery.mock.calls[0][0].options;
+    expect(options.env).toBeUndefined();
+    expect(process.env.ANTHROPIC_BASE_URL).toBeUndefined();
+  });
+
+  it('omits allowedTools when configured as wildcard', async () => {
+    await drain(makeConfig({ allowedTools: '*' }));
+
+    const options = mockQuery.mock.calls[0][0].options;
+    expect(options).not.toHaveProperty('allowedTools');
+  });
+
+  it('forwards allowedTools arrays to the SDK', async () => {
+    await drain(makeConfig({ allowedTools: ['Read'] }));
+
+    const options = mockQuery.mock.calls[0][0].options;
+    expect(options.allowedTools).toEqual(['Read']);
+  });
+});

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -21,12 +21,14 @@ import { loadConfig } from '../config.js';
 let tmpDir: string;
 const savedEnv: Record<string, string | undefined> = {};
 const CC_VARS = [
-  'CC_OCTO_BOT_TOKEN', 'CC_OCTO_API_URL', 'CC_OCTO_CWD', 'CC_OCTO_DATA_DIR',
+  'CC_OCTO_BOT_TOKEN', 'CC_OCTO_API_URL', 'CC_OCTO_CWD', 'CC_OCTO_CWDBASE',
+  'CC_OCTO_DATA_DIR',
   'CC_OCTO_SDK_MODEL', 'CC_OCTO_SDK_ALLOWED_TOOLS', 'CC_OCTO_SDK_PERMISSION_MODE',
   'CC_OCTO_SDK_MAX_TURNS', 'CC_OCTO_SDK_SYSTEM_PROMPT', 'CC_OCTO_SDK_SETTING_SOURCES',
   'CC_OCTO_RATE_LIMIT_MAX_PER_MINUTE', 'CC_OCTO_CONTEXT_MAX_CHARS',
   'CC_OCTO_CONTEXT_HISTORY_LIMIT', 'CC_OCTO_BOT_BLOCKLIST',
   'CC_OCTO_MENTION_FREE_GROUPS', 'CC_OCTO_MAX_RESPONSE_CHARS',
+  'ANTHROPIC_BASE_URL',
 ];
 
 function setup() {
@@ -66,11 +68,13 @@ describe('loadConfig defaults', () => {
 
     expect(cfg.botToken).toBe('bf_test');
     expect(cfg.apiUrl).toBe('https://api.test');
-    expect(cfg.cwd).toBe(process.cwd());
+    expect(cfg.cwdBase).toBe(process.cwd()); // Q3: cwdBase replaces cwd
     expect(cfg.dataDir).toBe('./data');
-    expect(cfg.sdk.allowedTools).toEqual(['Read', 'Write', 'Edit', 'Bash', 'Glob', 'Grep', 'WebFetch', 'WebSearch']);
+    // Q2: default is the wildcard sentinel — no whitelist applied at the SDK layer.
+    expect(cfg.sdk.allowedTools).toBe('*');
     expect(cfg.sdk.permissionMode).toBe('bypassPermissions');
     expect(cfg.sdk.settingSources).toEqual(['user']);
+    expect(cfg.sdk.anthropicBaseUrl).toBeUndefined(); // Q1: unset by default
     expect(cfg.rateLimit.maxPerMinute).toBe(5);
     expect(cfg.context.maxContextChars).toBe(6000);
     expect(cfg.context.historyLimit).toBe(40);
@@ -187,10 +191,27 @@ describe('CC_OCTO_* env override coverage', () => {
     expect(cfg.apiUrl).toBe('https://env-api');
   });
 
-  it('CC_OCTO_CWD', () => {
+  it('CC_OCTO_CWDBASE', () => {
     const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
-    process.env.CC_OCTO_CWD = '/env-cwd';
-    expect(loadConfig(path).cwd).toBe('/env-cwd');
+    process.env.CC_OCTO_CWDBASE = '/env-cwdbase';
+    expect(loadConfig(path).cwdBase).toBe('/env-cwdbase');
+  });
+
+  it('CC_OCTO_CWD (legacy alias) still applies with a deprecation warning', () => {
+    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
+    process.env.CC_OCTO_CWD = '/env-cwd-legacy';
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const cfg = loadConfig(path);
+    expect(cfg.cwdBase).toBe('/env-cwd-legacy');
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('CC_OCTO_CWD is deprecated'));
+    warnSpy.mockRestore();
+  });
+
+  it('CC_OCTO_CWDBASE wins when both CC_OCTO_CWDBASE and CC_OCTO_CWD are set', () => {
+    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
+    process.env.CC_OCTO_CWDBASE = '/env-cwdbase-wins';
+    process.env.CC_OCTO_CWD = '/env-cwd-loses';
+    expect(loadConfig(path).cwdBase).toBe('/env-cwdbase-wins');
   });
 
   it('CC_OCTO_SDK_MODEL', () => {
@@ -396,6 +417,133 @@ describe('Config file permission warning (Q12)', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     loadConfig(cfgPath);
     expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+});
+
+// ─── Q1: anthropicBaseUrl ──────────────────────────────────────────────
+
+describe('Q1: anthropicBaseUrl', () => {
+  beforeEach(setup);
+  afterEach(teardown);
+
+  it('reads sdk.anthropicBaseUrl from config file', () => {
+    const path = writeConfig({
+      botToken: 'bf_t',
+      apiUrl: 'https://a',
+      sdk: { anthropicBaseUrl: 'https://gw.example.com' },
+    });
+    expect(loadConfig(path).sdk.anthropicBaseUrl).toBe('https://gw.example.com');
+  });
+
+  it('ANTHROPIC_BASE_URL env overrides config file', () => {
+    const path = writeConfig({
+      botToken: 'bf_t',
+      apiUrl: 'https://a',
+      sdk: { anthropicBaseUrl: 'https://from-file' },
+    });
+    process.env.ANTHROPIC_BASE_URL = 'https://from-env';
+    expect(loadConfig(path).sdk.anthropicBaseUrl).toBe('https://from-env');
+  });
+
+  it('uses Anthropic SDK standard variable name (no CC_OCTO_ prefix)', () => {
+    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
+    // A CC_OCTO_ANTHROPIC_BASE_URL would NOT take effect — only the bare var.
+    process.env.ANTHROPIC_BASE_URL = 'https://standard';
+    expect(loadConfig(path).sdk.anthropicBaseUrl).toBe('https://standard');
+  });
+});
+
+// ─── Q2: allowedTools "*" | string[] ───────────────────────────────────
+
+describe('Q2: allowedTools wildcard', () => {
+  beforeEach(setup);
+  afterEach(teardown);
+
+  it('config file can set allowedTools to "*"', () => {
+    const path = writeConfig({
+      botToken: 'bf_t',
+      apiUrl: 'https://a',
+      sdk: { allowedTools: '*' },
+    });
+    expect(loadConfig(path).sdk.allowedTools).toBe('*');
+  });
+
+  it('config file can set allowedTools to an explicit array', () => {
+    const path = writeConfig({
+      botToken: 'bf_t',
+      apiUrl: 'https://a',
+      sdk: { allowedTools: ['Read', 'Glob', 'Grep'] },
+    });
+    expect(loadConfig(path).sdk.allowedTools).toEqual(['Read', 'Glob', 'Grep']);
+  });
+
+  it('CC_OCTO_SDK_ALLOWED_TOOLS="*" maps to the wildcard sentinel', () => {
+    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
+    process.env.CC_OCTO_SDK_ALLOWED_TOOLS = '*';
+    expect(loadConfig(path).sdk.allowedTools).toBe('*');
+  });
+
+  it('CC_OCTO_SDK_ALLOWED_TOOLS=" * " (whitespace) still maps to wildcard', () => {
+    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
+    process.env.CC_OCTO_SDK_ALLOWED_TOOLS = ' * ';
+    expect(loadConfig(path).sdk.allowedTools).toBe('*');
+  });
+
+  it('env "*" overrides a config-file array', () => {
+    const path = writeConfig({
+      botToken: 'bf_t',
+      apiUrl: 'https://a',
+      sdk: { allowedTools: ['Read'] },
+    });
+    process.env.CC_OCTO_SDK_ALLOWED_TOOLS = '*';
+    expect(loadConfig(path).sdk.allowedTools).toBe('*');
+  });
+});
+
+// ─── Q3: cwdBase / cwd alias ───────────────────────────────────────────
+
+describe('Q3: cwdBase + deprecated cwd alias', () => {
+  beforeEach(setup);
+  afterEach(teardown);
+
+  it('config.cwdBase is honored directly', () => {
+    const path = writeConfig({
+      botToken: 'bf_t',
+      apiUrl: 'https://a',
+      cwdBase: '/explicit/base',
+    });
+    expect(loadConfig(path).cwdBase).toBe('/explicit/base');
+  });
+
+  it('legacy config.cwd still maps to cwdBase with a deprecation warning', () => {
+    const path = writeConfig({
+      botToken: 'bf_t',
+      apiUrl: 'https://a',
+      cwd: '/legacy/dir',
+    });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const cfg = loadConfig(path);
+    expect(cfg.cwdBase).toBe('/legacy/dir');
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('config.cwd is deprecated'));
+    warnSpy.mockRestore();
+  });
+
+  it('config.cwdBase wins over config.cwd when both are present', () => {
+    const path = writeConfig({
+      botToken: 'bf_t',
+      apiUrl: 'https://a',
+      cwdBase: '/wins',
+      cwd: '/loses',
+    });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const cfg = loadConfig(path);
+    expect(cfg.cwdBase).toBe('/wins');
+    // cwdBase is defined → cwd alias must NOT trigger its deprecation warning.
+    const cwdWarnings = warnSpy.mock.calls.filter((c) =>
+      typeof c[0] === 'string' && c[0].includes('config.cwd is deprecated'),
+    );
+    expect(cwdWarnings).toHaveLength(0);
     warnSpy.mockRestore();
   });
 });

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -452,6 +452,33 @@ describe('Q1: anthropicBaseUrl', () => {
     process.env.ANTHROPIC_BASE_URL = 'https://standard';
     expect(loadConfig(path).sdk.anthropicBaseUrl).toBe('https://standard');
   });
+
+  it('rejects an http:// (non-localhost) anthropicBaseUrl (SSRF protection)', () => {
+    const path = writeConfig({
+      botToken: 'bf_t',
+      apiUrl: 'https://a',
+      sdk: { anthropicBaseUrl: 'http://evil.example.com' },
+    });
+    expect(() => loadConfig(path)).toThrow(/Unsafe sdk\.anthropicBaseUrl/);
+  });
+
+  it('rejects an anthropicBaseUrl resolving to a private IP literal', () => {
+    const path = writeConfig({
+      botToken: 'bf_t',
+      apiUrl: 'https://a',
+      sdk: { anthropicBaseUrl: 'https://169.254.169.254' },
+    });
+    expect(() => loadConfig(path)).toThrow(/Unsafe sdk\.anthropicBaseUrl/);
+  });
+
+  it('allows http://localhost for local development', () => {
+    const path = writeConfig({
+      botToken: 'bf_t',
+      apiUrl: 'https://a',
+      sdk: { anthropicBaseUrl: 'http://localhost:8080' },
+    });
+    expect(loadConfig(path).sdk.anthropicBaseUrl).toBe('http://localhost:8080');
+  });
 });
 
 // ─── Q2: allowedTools "*" | string[] ───────────────────────────────────
@@ -488,6 +515,20 @@ describe('Q2: allowedTools wildcard', () => {
     const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
     process.env.CC_OCTO_SDK_ALLOWED_TOOLS = ' * ';
     expect(loadConfig(path).sdk.allowedTools).toBe('*');
+  });
+
+  it('CC_OCTO_SDK_ALLOWED_TOOLS with a "*" element anywhere maps to wildcard', () => {
+    // Regression: a CSV containing `*` must collapse to the wildcard sentinel
+    // rather than passing a literal `*` through as a (bogus) tool name.
+    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
+    process.env.CC_OCTO_SDK_ALLOWED_TOOLS = '*,Read';
+    expect(loadConfig(path).sdk.allowedTools).toBe('*');
+  });
+
+  it('CC_OCTO_SDK_ALLOWED_TOOLS without "*" stays a CSV array', () => {
+    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
+    process.env.CC_OCTO_SDK_ALLOWED_TOOLS = 'Read, Glob ,Grep';
+    expect(loadConfig(path).sdk.allowedTools).toEqual(['Read', 'Glob', 'Grep']);
   });
 
   it('env "*" overrides a config-file array', () => {
@@ -545,5 +586,26 @@ describe('Q3: cwdBase + deprecated cwd alias', () => {
     );
     expect(cwdWarnings).toHaveLength(0);
     warnSpy.mockRestore();
+  });
+
+  it('blank config.cwdBase falls back to the default (not "")', () => {
+    // A `"cwdBase": ""` typo must not slip past the nullish fallback and land
+    // sandboxes relative to process.cwd().
+    const path = writeConfig({
+      botToken: 'bf_t',
+      apiUrl: 'https://a',
+      cwdBase: '   ',
+    });
+    expect(loadConfig(path).cwdBase).toBe(process.cwd());
+  });
+
+  it('blank CC_OCTO_CWDBASE env is ignored (treated as unset)', () => {
+    const path = writeConfig({
+      botToken: 'bf_t',
+      apiUrl: 'https://a',
+      cwdBase: '/explicit/base',
+    });
+    process.env.CC_OCTO_CWDBASE = '  ';
+    expect(loadConfig(path).cwdBase).toBe('/explicit/base');
   });
 });

--- a/src/__tests__/cwd-resolver.test.ts
+++ b/src/__tests__/cwd-resolver.test.ts
@@ -1,0 +1,256 @@
+/**
+ * cwd-resolver tests (Q3).
+ *
+ * Coverage:
+ *  - Hash stability: same SessionCtx → same path on every call.
+ *  - Hash uniqueness across DM / Group / Thread namespaces.
+ *  - mkdir idempotency on repeated resolveSessionCwd calls.
+ *  - TTL cleanup deletes dirs older than ttlMs; preserves fresh dirs.
+ *  - cleanup silently returns when cwdBase does not exist.
+ *  - cleanup ignores non-hash-pattern entries (operator's own files).
+ */
+
+import { createHash } from 'node:crypto';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  utimesSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, basename } from 'node:path';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  resolveSessionCwd,
+  cleanupExpiredCwds,
+  DEFAULT_CWD_TTL_MS,
+  type SessionCtx,
+} from '../cwd-resolver.js';
+
+const MARKER = '.cc-octo-session';
+
+function expectedName(key: string): string {
+  return createHash('sha256').update(key).digest('hex').slice(0, 16);
+}
+
+function oldTimeSeconds(days: number): number {
+  return (Date.now() - days * 24 * 60 * 60 * 1000) / 1000;
+}
+
+let base: string;
+
+beforeEach(() => {
+  base = mkdtempSync(join(tmpdir(), 'cwd-resolver-test-'));
+});
+
+afterEach(() => {
+  rmSync(base, { recursive: true, force: true });
+});
+
+describe('resolveSessionCwd — hash stability', () => {
+  it('returns the same path for repeated DM calls with the same uid', () => {
+    const ctx: SessionCtx = { kind: 'dm', userId: 'alice' };
+    const a = resolveSessionCwd(base, ctx);
+    const b = resolveSessionCwd(base, ctx);
+    const c = resolveSessionCwd(base, { kind: 'dm', userId: 'alice' });
+    expect(a).toBe(b);
+    expect(b).toBe(c);
+  });
+
+  it('returns the same path for repeated Group calls', () => {
+    const a = resolveSessionCwd(base, { kind: 'group', groupId: 'gid-1' });
+    const b = resolveSessionCwd(base, { kind: 'group', groupId: 'gid-1' });
+    expect(a).toBe(b);
+  });
+
+  it('returns the same path for repeated Thread calls', () => {
+    const a = resolveSessionCwd(base, { kind: 'thread', groupId: 'g', threadId: 't' });
+    const b = resolveSessionCwd(base, { kind: 'thread', groupId: 'g', threadId: 't' });
+    expect(a).toBe(b);
+  });
+});
+
+describe('resolveSessionCwd — hash uniqueness', () => {
+  it('different DM uids map to different dirs', () => {
+    const a = resolveSessionCwd(base, { kind: 'dm', userId: 'alice' });
+    const b = resolveSessionCwd(base, { kind: 'dm', userId: 'bob' });
+    expect(a).not.toBe(b);
+  });
+
+  it('different Group ids map to different dirs', () => {
+    const a = resolveSessionCwd(base, { kind: 'group', groupId: 'g1' });
+    const b = resolveSessionCwd(base, { kind: 'group', groupId: 'g2' });
+    expect(a).not.toBe(b);
+  });
+
+  it('same DM uid in different spaces maps to different dirs', () => {
+    const a = resolveSessionCwd(base, { kind: 'dm', userId: 'alice', spaceId: 's1' });
+    const b = resolveSessionCwd(base, { kind: 'dm', userId: 'alice', spaceId: 's2' });
+    expect(a).not.toBe(b);
+    expect(basename(a)).toBe(expectedName('dm:s1:alice'));
+    expect(basename(b)).toBe(expectedName('dm:s2:alice'));
+  });
+
+  it('DM uid without spaceId keeps the legacy hash', () => {
+    const dir = resolveSessionCwd(base, { kind: 'dm', userId: 'alice' });
+    expect(basename(dir)).toBe(expectedName('dm:alice'));
+  });
+
+  it('namespace separation: dm:foo != group:foo', () => {
+    const dm = resolveSessionCwd(base, { kind: 'dm', userId: 'foo' });
+    const grp = resolveSessionCwd(base, { kind: 'group', groupId: 'foo' });
+    expect(dm).not.toBe(grp);
+  });
+
+  it('thread != its parent group', () => {
+    const grp = resolveSessionCwd(base, { kind: 'group', groupId: 'gA' });
+    const thr = resolveSessionCwd(base, { kind: 'thread', groupId: 'gA', threadId: 'tX' });
+    expect(grp).not.toBe(thr);
+  });
+
+  it('different thread ids under the same group are isolated', () => {
+    const t1 = resolveSessionCwd(base, { kind: 'thread', groupId: 'g', threadId: 't1' });
+    const t2 = resolveSessionCwd(base, { kind: 'thread', groupId: 'g', threadId: 't2' });
+    expect(t1).not.toBe(t2);
+  });
+});
+
+describe('resolveSessionCwd — directory creation', () => {
+  it('creates a 16-hex subdir under cwdBase', () => {
+    const dir = resolveSessionCwd(base, { kind: 'dm', userId: 'alice' });
+    expect(existsSync(dir)).toBe(true);
+    const stat = statSync(dir);
+    expect(stat.isDirectory()).toBe(true);
+    const name = dir.substring(dir.lastIndexOf('/') + 1);
+    expect(name).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  it('writes a session provenance marker', () => {
+    const dir = resolveSessionCwd(base, { kind: 'dm', userId: 'alice' });
+    expect(existsSync(join(dir, MARKER))).toBe(true);
+  });
+
+  it('mkdir is idempotent — repeated calls do not throw', () => {
+    const ctx: SessionCtx = { kind: 'dm', userId: 'alice' };
+    expect(() => {
+      for (let i = 0; i < 5; i++) resolveSessionCwd(base, ctx);
+    }).not.toThrow();
+  });
+
+  it('creates cwdBase itself if missing', () => {
+    const nested = join(base, 'nested', 'deeper');
+    expect(existsSync(nested)).toBe(false);
+    const dir = resolveSessionCwd(nested, { kind: 'dm', userId: 'x' });
+    expect(existsSync(dir)).toBe(true);
+  });
+});
+
+describe('cleanupExpiredCwds — TTL behavior', () => {
+  it('removes a session dir whose mtime is older than ttlMs', () => {
+    const dir = resolveSessionCwd(base, { kind: 'dm', userId: 'stale' });
+    // Force mtime ~8 days in the past
+    const oldTime = oldTimeSeconds(8);
+    utimesSync(dir, oldTime, oldTime);
+    cleanupExpiredCwds(base, DEFAULT_CWD_TTL_MS);
+    expect(existsSync(dir)).toBe(false);
+  });
+
+  it('preserves a session dir whose mtime is within ttlMs', () => {
+    const dir = resolveSessionCwd(base, { kind: 'dm', userId: 'fresh' });
+    // mtime is "now" by virtue of just being created
+    cleanupExpiredCwds(base, DEFAULT_CWD_TTL_MS);
+    expect(existsSync(dir)).toBe(true);
+  });
+
+  it('refreshes an old active session mtime before cleanup can delete it', () => {
+    const dir = resolveSessionCwd(base, { kind: 'dm', userId: 'active' });
+    const oldTime = oldTimeSeconds(8);
+    utimesSync(dir, oldTime, oldTime);
+
+    resolveSessionCwd(base, { kind: 'dm', userId: 'active' });
+    cleanupExpiredCwds(base, DEFAULT_CWD_TTL_MS);
+
+    expect(existsSync(dir)).toBe(true);
+  });
+
+  it('removes only the expired dir when both fresh + stale coexist', () => {
+    const fresh = resolveSessionCwd(base, { kind: 'dm', userId: 'fresh' });
+    const stale = resolveSessionCwd(base, { kind: 'dm', userId: 'stale' });
+    const oldTime = oldTimeSeconds(30);
+    utimesSync(stale, oldTime, oldTime);
+    cleanupExpiredCwds(base, DEFAULT_CWD_TTL_MS);
+    expect(existsSync(fresh)).toBe(true);
+    expect(existsSync(stale)).toBe(false);
+  });
+});
+
+describe('cleanupExpiredCwds — safety', () => {
+  it('does NOT throw when cwdBase does not exist', () => {
+    const missing = join(base, 'never-created');
+    expect(() => cleanupExpiredCwds(missing)).not.toThrow();
+  });
+
+  it('ignores files / dirs whose name does not match the hash pattern', () => {
+    // Operator-owned scratch files
+    const scratch = join(base, 'README.txt');
+    writeFileSync(scratch, 'do not delete');
+    const otherDir = join(base, 'not-a-session');
+    mkdirSync(otherDir);
+    const oldTime = oldTimeSeconds(30);
+    utimesSync(scratch, oldTime, oldTime);
+    utimesSync(otherDir, oldTime, oldTime);
+
+    cleanupExpiredCwds(base, DEFAULT_CWD_TTL_MS);
+    expect(existsSync(scratch)).toBe(true);
+    expect(existsSync(otherDir)).toBe(true);
+  });
+
+  it('does not delete an old 16-hex dir without the session marker', () => {
+    const unrelated = join(base, '0123456789abcdef');
+    mkdirSync(unrelated);
+    const oldTime = oldTimeSeconds(8);
+    utimesSync(unrelated, oldTime, oldTime);
+
+    cleanupExpiredCwds(base, DEFAULT_CWD_TTL_MS);
+
+    expect(existsSync(unrelated)).toBe(true);
+  });
+
+  it('does not delete a recent 16-hex dir with the session marker', () => {
+    const recent = join(base, 'abcdef0123456789');
+    mkdirSync(recent);
+    writeFileSync(join(recent, MARKER), '{"created":"now","kind":"dm"}');
+
+    cleanupExpiredCwds(base, DEFAULT_CWD_TTL_MS);
+
+    expect(existsSync(recent)).toBe(true);
+  });
+
+  it('deletes an old 16-hex dir with the session marker', () => {
+    const stale = join(base, 'fedcba9876543210');
+    mkdirSync(stale);
+    writeFileSync(join(stale, MARKER), '{"created":"old","kind":"dm"}');
+    const oldTime = oldTimeSeconds(8);
+    utimesSync(stale, oldTime, oldTime);
+
+    cleanupExpiredCwds(base, DEFAULT_CWD_TTL_MS);
+
+    expect(existsSync(stale)).toBe(false);
+  });
+
+  it('survives a malformed entry without aborting the sweep', () => {
+    // Create one stale + one fresh; even if listing hits an oddball file the
+    // sweep should still delete the stale session.
+    const stale = resolveSessionCwd(base, { kind: 'dm', userId: 'stale' });
+    writeFileSync(join(base, 'sidecar.log'), 'noise');
+    const oldTime = oldTimeSeconds(30);
+    utimesSync(stale, oldTime, oldTime);
+    cleanupExpiredCwds(base, DEFAULT_CWD_TTL_MS);
+    expect(existsSync(stale)).toBe(false);
+    expect(readdirSync(base)).toContain('sidecar.log');
+  });
+});

--- a/src/__tests__/cwd-resolver.test.ts
+++ b/src/__tests__/cwd-resolver.test.ts
@@ -3,11 +3,15 @@
  *
  * Coverage:
  *  - Hash stability: same SessionCtx → same path on every call.
- *  - Hash uniqueness across DM / Group / Thread namespaces.
+ *  - Hash uniqueness across DM / Group and across distinct sessionKeys.
+ *  - kind-prefix separation: a dm and group key that are byte-identical differ.
  *  - mkdir idempotency on repeated resolveSessionCwd calls.
+ *  - Provenance recorded in the sidecar registry (outside the session dir).
  *  - TTL cleanup deletes dirs older than ttlMs; preserves fresh dirs.
+ *  - Marker self-heals on every resolve (no permanent cleanup exemption).
  *  - cleanup silently returns when cwdBase does not exist.
  *  - cleanup ignores non-hash-pattern entries (operator's own files).
+ *  - cleanup only deletes dirs with a registry entry; removes the entry too.
  */
 
 import { createHash } from 'node:crypto';
@@ -31,10 +35,15 @@ import {
   type SessionCtx,
 } from '../cwd-resolver.js';
 
-const MARKER = '.cc-octo-session';
+const REGISTRY_DIR = '.cc-octo-sessions';
 
 function expectedName(key: string): string {
   return createHash('sha256').update(key).digest('hex').slice(0, 16);
+}
+
+/** Path to the sidecar registry marker for a given 16-hex dir name. */
+function markerFor(baseDir: string, name: string): string {
+  return join(baseDir, REGISTRY_DIR, name);
 }
 
 function oldTimeSeconds(days: number): number {
@@ -52,76 +61,67 @@ afterEach(() => {
 });
 
 describe('resolveSessionCwd — hash stability', () => {
-  it('returns the same path for repeated DM calls with the same uid', () => {
-    const ctx: SessionCtx = { kind: 'dm', userId: 'alice' };
+  it('returns the same path for repeated DM calls with the same key', () => {
+    const ctx: SessionCtx = { kind: 'dm', sessionKey: 'alice' };
     const a = resolveSessionCwd(base, ctx);
     const b = resolveSessionCwd(base, ctx);
-    const c = resolveSessionCwd(base, { kind: 'dm', userId: 'alice' });
+    const c = resolveSessionCwd(base, { kind: 'dm', sessionKey: 'alice' });
     expect(a).toBe(b);
     expect(b).toBe(c);
   });
 
   it('returns the same path for repeated Group calls', () => {
-    const a = resolveSessionCwd(base, { kind: 'group', groupId: 'gid-1' });
-    const b = resolveSessionCwd(base, { kind: 'group', groupId: 'gid-1' });
-    expect(a).toBe(b);
-  });
-
-  it('returns the same path for repeated Thread calls', () => {
-    const a = resolveSessionCwd(base, { kind: 'thread', groupId: 'g', threadId: 't' });
-    const b = resolveSessionCwd(base, { kind: 'thread', groupId: 'g', threadId: 't' });
+    const a = resolveSessionCwd(base, { kind: 'group', sessionKey: 'gid-1:bob' });
+    const b = resolveSessionCwd(base, { kind: 'group', sessionKey: 'gid-1:bob' });
     expect(a).toBe(b);
   });
 });
 
 describe('resolveSessionCwd — hash uniqueness', () => {
-  it('different DM uids map to different dirs', () => {
-    const a = resolveSessionCwd(base, { kind: 'dm', userId: 'alice' });
-    const b = resolveSessionCwd(base, { kind: 'dm', userId: 'bob' });
+  it('different DM keys map to different dirs', () => {
+    const a = resolveSessionCwd(base, { kind: 'dm', sessionKey: 'alice' });
+    const b = resolveSessionCwd(base, { kind: 'dm', sessionKey: 'bob' });
     expect(a).not.toBe(b);
   });
 
-  it('different Group ids map to different dirs', () => {
-    const a = resolveSessionCwd(base, { kind: 'group', groupId: 'g1' });
-    const b = resolveSessionCwd(base, { kind: 'group', groupId: 'g2' });
+  it('different group sessionKeys map to different dirs', () => {
+    const a = resolveSessionCwd(base, { kind: 'group', sessionKey: 'g1:alice' });
+    const b = resolveSessionCwd(base, { kind: 'group', sessionKey: 'g1:bob' });
     expect(a).not.toBe(b);
   });
 
-  it('same DM uid in different spaces maps to different dirs', () => {
-    const a = resolveSessionCwd(base, { kind: 'dm', userId: 'alice', spaceId: 's1' });
-    const b = resolveSessionCwd(base, { kind: 'dm', userId: 'alice', spaceId: 's2' });
+  it('same uid in different spaces maps to different dirs (router key differs)', () => {
+    // Router DM key is `${spaceId}:${uid}` — the resolver just hashes it.
+    const a = resolveSessionCwd(base, { kind: 'dm', sessionKey: 's1:alice' });
+    const b = resolveSessionCwd(base, { kind: 'dm', sessionKey: 's2:alice' });
     expect(a).not.toBe(b);
     expect(basename(a)).toBe(expectedName('dm:s1:alice'));
     expect(basename(b)).toBe(expectedName('dm:s2:alice'));
   });
 
-  it('DM uid without spaceId keeps the legacy hash', () => {
-    const dir = resolveSessionCwd(base, { kind: 'dm', userId: 'alice' });
+  it('hashes the kind-prefixed router key', () => {
+    const dir = resolveSessionCwd(base, { kind: 'dm', sessionKey: 'alice' });
     expect(basename(dir)).toBe(expectedName('dm:alice'));
   });
 
-  it('namespace separation: dm:foo != group:foo', () => {
-    const dm = resolveSessionCwd(base, { kind: 'dm', userId: 'foo' });
-    const grp = resolveSessionCwd(base, { kind: 'group', groupId: 'foo' });
+  it('kind-prefix separation: a dm and group key that are byte-identical differ', () => {
+    const dm = resolveSessionCwd(base, { kind: 'dm', sessionKey: 'foo' });
+    const grp = resolveSessionCwd(base, { kind: 'group', sessionKey: 'foo' });
     expect(dm).not.toBe(grp);
+    expect(basename(dm)).toBe(expectedName('dm:foo'));
+    expect(basename(grp)).toBe(expectedName('group:foo'));
   });
 
-  it('thread != its parent group', () => {
-    const grp = resolveSessionCwd(base, { kind: 'group', groupId: 'gA' });
-    const thr = resolveSessionCwd(base, { kind: 'thread', groupId: 'gA', threadId: 'tX' });
-    expect(grp).not.toBe(thr);
-  });
-
-  it('different thread ids under the same group are isolated', () => {
-    const t1 = resolveSessionCwd(base, { kind: 'thread', groupId: 'g', threadId: 't1' });
-    const t2 = resolveSessionCwd(base, { kind: 'thread', groupId: 'g', threadId: 't2' });
-    expect(t1).not.toBe(t2);
+  it('every group member gets their own sandbox (uid embedded in key)', () => {
+    const memberA = resolveSessionCwd(base, { kind: 'group', sessionKey: 'gA:alice' });
+    const memberB = resolveSessionCwd(base, { kind: 'group', sessionKey: 'gA:bob' });
+    expect(memberA).not.toBe(memberB);
   });
 });
 
 describe('resolveSessionCwd — directory creation', () => {
   it('creates a 16-hex subdir under cwdBase', () => {
-    const dir = resolveSessionCwd(base, { kind: 'dm', userId: 'alice' });
+    const dir = resolveSessionCwd(base, { kind: 'dm', sessionKey: 'alice' });
     expect(existsSync(dir)).toBe(true);
     const stat = statSync(dir);
     expect(stat.isDirectory()).toBe(true);
@@ -129,29 +129,46 @@ describe('resolveSessionCwd — directory creation', () => {
     expect(name).toMatch(/^[0-9a-f]{16}$/);
   });
 
-  it('writes a session provenance marker', () => {
-    const dir = resolveSessionCwd(base, { kind: 'dm', userId: 'alice' });
-    expect(existsSync(join(dir, MARKER))).toBe(true);
+  it('records provenance in the sidecar registry (NOT inside the session dir)', () => {
+    const dir = resolveSessionCwd(base, { kind: 'dm', sessionKey: 'alice' });
+    const name = basename(dir);
+    // Marker lives in the registry, outside the agent's own cwd.
+    expect(existsSync(markerFor(base, name))).toBe(true);
+    // Nothing leaks into the session dir itself.
+    expect(readdirSync(dir)).toHaveLength(0);
   });
 
   it('mkdir is idempotent — repeated calls do not throw', () => {
-    const ctx: SessionCtx = { kind: 'dm', userId: 'alice' };
+    const ctx: SessionCtx = { kind: 'dm', sessionKey: 'alice' };
     expect(() => {
       for (let i = 0; i < 5; i++) resolveSessionCwd(base, ctx);
     }).not.toThrow();
   });
 
+  it('re-creates a missing registry marker on the next resolve (self-heal)', () => {
+    const dir = resolveSessionCwd(base, { kind: 'dm', sessionKey: 'alice' });
+    const name = basename(dir);
+    const marker = markerFor(base, name);
+    expect(existsSync(marker)).toBe(true);
+    // Simulate a first-write failure / external deletion of the marker.
+    rmSync(marker, { force: true });
+    expect(existsSync(marker)).toBe(false);
+    // Next resolve must restore it so the dir stays cleanup-eligible.
+    resolveSessionCwd(base, { kind: 'dm', sessionKey: 'alice' });
+    expect(existsSync(marker)).toBe(true);
+  });
+
   it('creates cwdBase itself if missing', () => {
     const nested = join(base, 'nested', 'deeper');
     expect(existsSync(nested)).toBe(false);
-    const dir = resolveSessionCwd(nested, { kind: 'dm', userId: 'x' });
+    const dir = resolveSessionCwd(nested, { kind: 'dm', sessionKey: 'x' });
     expect(existsSync(dir)).toBe(true);
   });
 });
 
 describe('cleanupExpiredCwds — TTL behavior', () => {
   it('removes a session dir whose mtime is older than ttlMs', () => {
-    const dir = resolveSessionCwd(base, { kind: 'dm', userId: 'stale' });
+    const dir = resolveSessionCwd(base, { kind: 'dm', sessionKey: 'stale' });
     // Force mtime ~8 days in the past
     const oldTime = oldTimeSeconds(8);
     utimesSync(dir, oldTime, oldTime);
@@ -159,27 +176,37 @@ describe('cleanupExpiredCwds — TTL behavior', () => {
     expect(existsSync(dir)).toBe(false);
   });
 
+  it('removes the registry marker alongside the deleted dir', () => {
+    const dir = resolveSessionCwd(base, { kind: 'dm', sessionKey: 'stale' });
+    const name = basename(dir);
+    const oldTime = oldTimeSeconds(8);
+    utimesSync(dir, oldTime, oldTime);
+    cleanupExpiredCwds(base, DEFAULT_CWD_TTL_MS);
+    expect(existsSync(dir)).toBe(false);
+    expect(existsSync(markerFor(base, name))).toBe(false);
+  });
+
   it('preserves a session dir whose mtime is within ttlMs', () => {
-    const dir = resolveSessionCwd(base, { kind: 'dm', userId: 'fresh' });
+    const dir = resolveSessionCwd(base, { kind: 'dm', sessionKey: 'fresh' });
     // mtime is "now" by virtue of just being created
     cleanupExpiredCwds(base, DEFAULT_CWD_TTL_MS);
     expect(existsSync(dir)).toBe(true);
   });
 
   it('refreshes an old active session mtime before cleanup can delete it', () => {
-    const dir = resolveSessionCwd(base, { kind: 'dm', userId: 'active' });
+    const dir = resolveSessionCwd(base, { kind: 'dm', sessionKey: 'active' });
     const oldTime = oldTimeSeconds(8);
     utimesSync(dir, oldTime, oldTime);
 
-    resolveSessionCwd(base, { kind: 'dm', userId: 'active' });
+    resolveSessionCwd(base, { kind: 'dm', sessionKey: 'active' });
     cleanupExpiredCwds(base, DEFAULT_CWD_TTL_MS);
 
     expect(existsSync(dir)).toBe(true);
   });
 
   it('removes only the expired dir when both fresh + stale coexist', () => {
-    const fresh = resolveSessionCwd(base, { kind: 'dm', userId: 'fresh' });
-    const stale = resolveSessionCwd(base, { kind: 'dm', userId: 'stale' });
+    const fresh = resolveSessionCwd(base, { kind: 'dm', sessionKey: 'fresh' });
+    const stale = resolveSessionCwd(base, { kind: 'dm', sessionKey: 'stale' });
     const oldTime = oldTimeSeconds(30);
     utimesSync(stale, oldTime, oldTime);
     cleanupExpiredCwds(base, DEFAULT_CWD_TTL_MS);
@@ -209,7 +236,8 @@ describe('cleanupExpiredCwds — safety', () => {
     expect(existsSync(otherDir)).toBe(true);
   });
 
-  it('does not delete an old 16-hex dir without the session marker', () => {
+  it('does not delete an old 16-hex dir without a registry marker', () => {
+    // A 16-hex dir from some OTHER tool — we never created a registry entry.
     const unrelated = join(base, '0123456789abcdef');
     mkdirSync(unrelated);
     const oldTime = oldTimeSeconds(8);
@@ -220,20 +248,40 @@ describe('cleanupExpiredCwds — safety', () => {
     expect(existsSync(unrelated)).toBe(true);
   });
 
-  it('does not delete a recent 16-hex dir with the session marker', () => {
-    const recent = join(base, 'abcdef0123456789');
+  it('does not delete a 16-hex dir whose marker was deleted from the registry', () => {
+    // Even if an in-cwd marker were forged by the agent, the registry (outside
+    // the cwd) is the source of truth — a missing registry entry protects it.
+    const dir = resolveSessionCwd(base, { kind: 'dm', sessionKey: 'victim' });
+    const name = basename(dir);
+    rmSync(markerFor(base, name), { force: true });
+    // Agent forges an in-cwd marker (old-style) — must NOT make it eligible.
+    writeFileSync(join(dir, '.cc-octo-session'), 'forged');
+    const oldTime = oldTimeSeconds(8);
+    utimesSync(dir, oldTime, oldTime);
+
+    cleanupExpiredCwds(base, DEFAULT_CWD_TTL_MS);
+
+    expect(existsSync(dir)).toBe(true);
+  });
+
+  it('does not delete a recent 16-hex dir with a registry marker', () => {
+    const name = 'abcdef0123456789';
+    const recent = join(base, name);
     mkdirSync(recent);
-    writeFileSync(join(recent, MARKER), '{"created":"now","kind":"dm"}');
+    mkdirSync(join(base, REGISTRY_DIR), { recursive: true });
+    writeFileSync(markerFor(base, name), '{"created":"now","kind":"dm"}');
 
     cleanupExpiredCwds(base, DEFAULT_CWD_TTL_MS);
 
     expect(existsSync(recent)).toBe(true);
   });
 
-  it('deletes an old 16-hex dir with the session marker', () => {
-    const stale = join(base, 'fedcba9876543210');
+  it('deletes an old 16-hex dir with a registry marker', () => {
+    const name = 'fedcba9876543210';
+    const stale = join(base, name);
     mkdirSync(stale);
-    writeFileSync(join(stale, MARKER), '{"created":"old","kind":"dm"}');
+    mkdirSync(join(base, REGISTRY_DIR), { recursive: true });
+    writeFileSync(markerFor(base, name), '{"created":"old","kind":"dm"}');
     const oldTime = oldTimeSeconds(8);
     utimesSync(stale, oldTime, oldTime);
 
@@ -245,7 +293,7 @@ describe('cleanupExpiredCwds — safety', () => {
   it('survives a malformed entry without aborting the sweep', () => {
     // Create one stale + one fresh; even if listing hits an oddball file the
     // sweep should still delete the stale session.
-    const stale = resolveSessionCwd(base, { kind: 'dm', userId: 'stale' });
+    const stale = resolveSessionCwd(base, { kind: 'dm', sessionKey: 'stale' });
     writeFileSync(join(base, 'sidecar.log'), 'noise');
     const oldTime = oldTimeSeconds(30);
     utimesSync(stale, oldTime, oldTime);

--- a/src/agent-bridge.ts
+++ b/src/agent-bridge.ts
@@ -12,6 +12,8 @@
 import { query as sdkQuery } from '@anthropic-ai/claude-agent-sdk';
 import type { PermissionMode, SettingSource } from '@anthropic-ai/claude-agent-sdk';
 import type { Config } from './config.js';
+import { resolveSessionCwd } from './cwd-resolver.js';
+import type { SessionCtx } from './cwd-resolver.js';
 
 const VALID_PERMISSION_MODES: Set<string> = new Set([
   'default', 'acceptEdits', 'bypassPermissions', 'plan', 'dontAsk', 'auto',
@@ -258,6 +260,7 @@ export function buildPrompt(historyPrefix: string, groupContext: string, message
  * @param historyPrefix - Formatted conversation history from SessionStore
  * @param groupContext - Group chat context string (may be empty)
  * @param config - Application config (sdk.* fields used)
+ * @param sessionCtx - Per-session routing context for cwd isolation (Q3)
  * @yields string chunks of assistant text output
  */
 export async function* queryAgent(
@@ -265,6 +268,7 @@ export async function* queryAgent(
   historyPrefix: string,
   groupContext: string,
   config: Config,
+  sessionCtx?: SessionCtx,
 ): AsyncIterable<string> {
   const permissionMode = toPermissionMode(config.sdk.permissionMode);
   const settingSources = toSettingSources(config.sdk.settingSources);
@@ -276,12 +280,29 @@ export async function* queryAgent(
     config.sdk.systemPrompt,
   );
 
+  // Q3: per-session cwd under cwdBase — creates the directory on first use.
+  // Fall back to the base directory when sessionCtx is omitted (legacy callers
+  // and unit tests that don't care about isolation), and to the deprecated
+  // `cwd` field for Config instances built before the rename.
+  const cwdBase = config.cwdBase ?? config.cwd;
+  const cwd = sessionCtx ? resolveSessionCwd(cwdBase, sessionCtx) : cwdBase;
+
+  // Q1: forward ANTHROPIC_BASE_URL through the standard process environment
+  // before invoking the SDK. When unset, leave process.env untouched.
+  if (config.sdk.anthropicBaseUrl) {
+    process.env.ANTHROPIC_BASE_URL = config.sdk.anthropicBaseUrl;
+  }
+
   const stream = sdkQuery({
     prompt: userMessage,
     options: {
-      cwd: config.cwd,
+      cwd,
       systemPrompt,
-      allowedTools: config.sdk.allowedTools,
+      // Q2: `"*"` means "no whitelist" — drop the option so the SDK falls back
+      // to its built-in tool set. An explicit string[] is forwarded as-is.
+      ...(config.sdk.allowedTools === '*'
+        ? {}
+        : { allowedTools: config.sdk.allowedTools }),
       permissionMode,
       maxTurns: config.sdk.maxTurns,
       model: config.sdk.model,

--- a/src/agent-bridge.ts
+++ b/src/agent-bridge.ts
@@ -287,17 +287,23 @@ export async function* queryAgent(
   const cwdBase = config.cwdBase ?? config.cwd;
   const cwd = sessionCtx ? resolveSessionCwd(cwdBase, sessionCtx) : cwdBase;
 
-  // Q1: forward ANTHROPIC_BASE_URL through the standard process environment
-  // before invoking the SDK. When unset, leave process.env untouched.
-  if (config.sdk.anthropicBaseUrl) {
-    process.env.ANTHROPIC_BASE_URL = config.sdk.anthropicBaseUrl;
-  }
+  // Q1: forward ANTHROPIC_BASE_URL to the SDK subprocess via the scoped `env`
+  // option instead of mutating the gateway's global process.env. The SDK's
+  // `env` REPLACES the subprocess environment entirely, so spread process.env
+  // first to preserve PATH/HOME/ANTHROPIC_API_KEY. Scoping it here means the
+  // override never leaks across requests and never persists after the field is
+  // cleared (no stale-global problem). When unset, omit `env` so the subprocess
+  // simply inherits process.env.
+  const env = config.sdk.anthropicBaseUrl
+    ? { ...process.env, ANTHROPIC_BASE_URL: config.sdk.anthropicBaseUrl }
+    : undefined;
 
   const stream = sdkQuery({
     prompt: userMessage,
     options: {
       cwd,
       systemPrompt,
+      ...(env ? { env } : {}),
       // Q2: `"*"` means "no whitelist" — drop the option so the SDK falls back
       // to its built-in tool set. An explicit string[] is forwarded as-is.
       ...(config.sdk.allowedTools === '*'

--- a/src/config.ts
+++ b/src/config.ts
@@ -150,13 +150,17 @@ function readConfigFile(configFilePath: string): PartialConfig {
 
 function mergeConfig(base: Config, override: PartialConfig): Config {
   // Q3: accept legacy `cwd` as an alias for `cwdBase`. cwdBase wins if both
-  // are present; otherwise cwd warns and is used.
-  let cwdBase = override.cwdBase ?? base.cwdBase ?? base.cwd;
-  if (override.cwdBase === undefined && override.cwd !== undefined) {
+  // are present; otherwise cwd warns and is used. Blank strings are treated as
+  // "not provided" so a `"cwdBase": ""` typo cannot slip past the nullish
+  // fallback and land sandboxes relative to process.cwd().
+  const overrideCwdBase = nonBlank(override.cwdBase);
+  const overrideCwd = nonBlank(override.cwd);
+  let cwdBase = overrideCwdBase ?? base.cwdBase ?? base.cwd;
+  if (overrideCwdBase === undefined && overrideCwd !== undefined) {
     console.warn(
       '[cc-channel-octo] WARNING: config.cwd is deprecated, use config.cwdBase instead',
     );
-    cwdBase = override.cwd;
+    cwdBase = overrideCwd;
   }
   return {
     botToken: override.botToken ?? base.botToken,
@@ -191,6 +195,13 @@ function parseCsv(value: string): string[] {
     .filter((s) => s.length > 0);
 }
 
+/** Return the trimmed value, or undefined when it is missing/blank. */
+function nonBlank(value: string | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
 function parseIntStrict(value: string, name: string, minValue = 1): number {
   if (!/^\d+$/.test(value)) {
     throw new Error(`Invalid integer for ${name}: ${value}`);
@@ -214,24 +225,28 @@ function applyEnv(cfg: Config): Config {
   if (env.CC_OCTO_BOT_TOKEN) next.botToken = env.CC_OCTO_BOT_TOKEN;
   if (env.CC_OCTO_API_URL) next.apiUrl = env.CC_OCTO_API_URL;
   // Q3: CC_OCTO_CWDBASE wins; CC_OCTO_CWD is accepted with a deprecation warning.
-  if (env.CC_OCTO_CWDBASE) {
-    next.cwdBase = env.CC_OCTO_CWDBASE;
-    next.cwd = env.CC_OCTO_CWDBASE;
-  } else if (env.CC_OCTO_CWD) {
+  // Blank/whitespace-only values are ignored (treated as unset).
+  const envCwdBase = nonBlank(env.CC_OCTO_CWDBASE);
+  const envCwd = nonBlank(env.CC_OCTO_CWD);
+  if (envCwdBase) {
+    next.cwdBase = envCwdBase;
+    next.cwd = envCwdBase;
+  } else if (envCwd) {
     console.warn(
       '[cc-channel-octo] WARNING: CC_OCTO_CWD is deprecated, use CC_OCTO_CWDBASE instead',
     );
-    next.cwdBase = env.CC_OCTO_CWD;
-    next.cwd = env.CC_OCTO_CWD;
+    next.cwdBase = envCwd;
+    next.cwd = envCwd;
   }
   if (env.CC_OCTO_DATA_DIR) next.dataDir = env.CC_OCTO_DATA_DIR;
 
   if (env.CC_OCTO_SDK_MODEL) next.sdk.model = env.CC_OCTO_SDK_MODEL;
   if (env.CC_OCTO_SDK_ALLOWED_TOOLS) {
-    // Q2: accept the literal `*` token (with surrounding whitespace tolerated)
-    // as the wildcard form; otherwise treat as CSV whitelist.
-    const raw = env.CC_OCTO_SDK_ALLOWED_TOOLS.trim();
-    next.sdk.allowedTools = raw === '*' ? '*' : parseCsv(env.CC_OCTO_SDK_ALLOWED_TOOLS);
+    // Q2: a `*` token anywhere in the value means "allow every tool" — collapse
+    // to the wildcard sentinel rather than passing a literal `*` through as a
+    // (bogus) tool name. So `*`, ` * `, and `*,Read` all mean wildcard.
+    const tools = parseCsv(env.CC_OCTO_SDK_ALLOWED_TOOLS);
+    next.sdk.allowedTools = tools.includes('*') ? '*' : tools;
   }
   if (env.CC_OCTO_SDK_PERMISSION_MODE) {
     next.sdk.permissionMode = env.CC_OCTO_SDK_PERMISSION_MODE;
@@ -316,6 +331,17 @@ export function loadConfig(configPath?: string): Config {
   if (!isAllowedApiUrl(final.apiUrl)) {
     throw new Error(
       `Unsafe apiUrl: ${final.apiUrl} — must be https:// or http://localhost/http://127.0.0.1 (SSRF protection)`,
+    );
+  }
+  // Q1: the gateway endpoint receives the Anthropic API key and all prompt /
+  // response content, so it gets the same SSRF policy as apiUrl. Without this,
+  // a stray ANTHROPIC_BASE_URL (e.g. inherited from a shared shell profile or
+  // CI env) could silently redirect every model request — and the credential —
+  // to an attacker-controlled or private-network host.
+  if (final.sdk.anthropicBaseUrl && !isAllowedApiUrl(final.sdk.anthropicBaseUrl)) {
+    throw new Error(
+      `Unsafe sdk.anthropicBaseUrl: ${final.sdk.anthropicBaseUrl} — must be https:// ` +
+      `or http://localhost/http://127.0.0.1 (SSRF protection)`,
     );
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,18 +6,52 @@
 import { readFileSync, existsSync, statSync } from 'node:fs';
 import { isAllowedApiUrl } from './url-policy.js';
 
+/**
+ * Q2: Wildcard form of `allowedTools` — `"*"` means "allow every tool the SDK
+ * exposes". Otherwise must be an explicit string array (whitelist mode).
+ */
+export type AllowedTools = string[] | '*';
+
 export interface Config {
   botToken: string;
   apiUrl: string;
+  /**
+   * Q3: Base directory for per-session cwd isolation. Each (DM peer | group |
+   * thread) gets its own hashed subdirectory under this path. Resolved via
+   * `cwd-resolver.resolveSessionCwd()` before passing to the SDK.
+   *
+   * loadConfig() always populates this. Direct Config mocks (e.g. in tests)
+   * may rely on the deprecated `cwd` alias instead — call sites should read
+   * `config.cwdBase ?? config.cwd` to support both.
+   */
+  cwdBase?: string;
+  /**
+   * @deprecated Use `cwdBase`. Retained as a required compat alias for one
+   * release so existing tests and consumers that build Config objects by hand
+   * continue to compile. loadConfig() keeps this in sync with `cwdBase`.
+   */
   cwd: string;
   dataDir: string;
   sdk: {
     model?: string;
-    allowedTools: string[];
+    /**
+     * Q2: `"*"` allows every tool the SDK exposes; otherwise an explicit
+     * whitelist. Default is `"*"` because we already control surface area via
+     * `permissionMode` and `cwdBase` isolation — the old hard-coded 8-tool
+     * list was redundant lockdown and broke operators who needed SDK-internal
+     * tools like `TodoWrite`/`Task`.
+     */
+    allowedTools: AllowedTools;
     permissionMode: string;
     maxTurns?: number;
     systemPrompt?: string;
     settingSources: string[];
+    /**
+     * Q1: Override the upstream Claude API endpoint (e.g. self-hosted gateway).
+     * Forwarded to the SDK subprocess via the standard `ANTHROPIC_BASE_URL`
+     * environment variable. Env priority: `ANTHROPIC_BASE_URL` > this field.
+     */
+    anthropicBaseUrl?: string;
   };
   rateLimit: {
     maxPerMinute: number;
@@ -41,6 +75,9 @@ export interface Config {
 type PartialConfig = {
   botToken?: string;
   apiUrl?: string;
+  /** Q3: canonical field — base dir for per-session cwd isolation. */
+  cwdBase?: string;
+  /** Q3 deprecated alias — maps to cwdBase with a warning. */
   cwd?: string;
   dataDir?: string;
   sdk?: Partial<Config['sdk']>;
@@ -56,10 +93,12 @@ function defaults(): Config {
   return {
     botToken: '',
     apiUrl: '',
+    cwdBase: process.cwd(),
     cwd: process.cwd(),
     dataDir: './data',
     sdk: {
-      allowedTools: ['Read', 'Write', 'Edit', 'Bash', 'Glob', 'Grep', 'WebFetch', 'WebSearch'],
+      // Q2: default to wildcard — operators tighten only when they need to.
+      allowedTools: '*',
       permissionMode: 'bypassPermissions',
       settingSources: ['user'],
     },
@@ -110,10 +149,21 @@ function readConfigFile(configFilePath: string): PartialConfig {
 }
 
 function mergeConfig(base: Config, override: PartialConfig): Config {
+  // Q3: accept legacy `cwd` as an alias for `cwdBase`. cwdBase wins if both
+  // are present; otherwise cwd warns and is used.
+  let cwdBase = override.cwdBase ?? base.cwdBase ?? base.cwd;
+  if (override.cwdBase === undefined && override.cwd !== undefined) {
+    console.warn(
+      '[cc-channel-octo] WARNING: config.cwd is deprecated, use config.cwdBase instead',
+    );
+    cwdBase = override.cwd;
+  }
   return {
     botToken: override.botToken ?? base.botToken,
     apiUrl: override.apiUrl ?? base.apiUrl,
-    cwd: override.cwd ?? base.cwd,
+    cwdBase,
+    // Keep deprecated `cwd` in sync so any legacy reader still sees a value.
+    cwd: cwdBase ?? base.cwd,
     dataDir: override.dataDir ?? base.dataDir,
     sdk: {
       ...base.sdk,
@@ -163,12 +213,25 @@ function applyEnv(cfg: Config): Config {
 
   if (env.CC_OCTO_BOT_TOKEN) next.botToken = env.CC_OCTO_BOT_TOKEN;
   if (env.CC_OCTO_API_URL) next.apiUrl = env.CC_OCTO_API_URL;
-  if (env.CC_OCTO_CWD) next.cwd = env.CC_OCTO_CWD;
+  // Q3: CC_OCTO_CWDBASE wins; CC_OCTO_CWD is accepted with a deprecation warning.
+  if (env.CC_OCTO_CWDBASE) {
+    next.cwdBase = env.CC_OCTO_CWDBASE;
+    next.cwd = env.CC_OCTO_CWDBASE;
+  } else if (env.CC_OCTO_CWD) {
+    console.warn(
+      '[cc-channel-octo] WARNING: CC_OCTO_CWD is deprecated, use CC_OCTO_CWDBASE instead',
+    );
+    next.cwdBase = env.CC_OCTO_CWD;
+    next.cwd = env.CC_OCTO_CWD;
+  }
   if (env.CC_OCTO_DATA_DIR) next.dataDir = env.CC_OCTO_DATA_DIR;
 
   if (env.CC_OCTO_SDK_MODEL) next.sdk.model = env.CC_OCTO_SDK_MODEL;
   if (env.CC_OCTO_SDK_ALLOWED_TOOLS) {
-    next.sdk.allowedTools = parseCsv(env.CC_OCTO_SDK_ALLOWED_TOOLS);
+    // Q2: accept the literal `*` token (with surrounding whitespace tolerated)
+    // as the wildcard form; otherwise treat as CSV whitelist.
+    const raw = env.CC_OCTO_SDK_ALLOWED_TOOLS.trim();
+    next.sdk.allowedTools = raw === '*' ? '*' : parseCsv(env.CC_OCTO_SDK_ALLOWED_TOOLS);
   }
   if (env.CC_OCTO_SDK_PERMISSION_MODE) {
     next.sdk.permissionMode = env.CC_OCTO_SDK_PERMISSION_MODE;
@@ -179,6 +242,11 @@ function applyEnv(cfg: Config): Config {
   if (env.CC_OCTO_SDK_SYSTEM_PROMPT) next.sdk.systemPrompt = env.CC_OCTO_SDK_SYSTEM_PROMPT;
   if (env.CC_OCTO_SDK_SETTING_SOURCES) {
     next.sdk.settingSources = parseCsv(env.CC_OCTO_SDK_SETTING_SOURCES);
+  }
+  // Q1: ANTHROPIC_BASE_URL uses the Anthropic SDK standard variable name
+  // (no CC_OCTO_ prefix) so operators can reuse existing gateway configs.
+  if (env.ANTHROPIC_BASE_URL) {
+    next.sdk.anthropicBaseUrl = env.ANTHROPIC_BASE_URL;
   }
 
   if (env.CC_OCTO_RATE_LIMIT_MAX_PER_MINUTE) {

--- a/src/cwd-resolver.ts
+++ b/src/cwd-resolver.ts
@@ -1,39 +1,48 @@
 /**
  * Q3: Per-session cwd isolation under a shared `cwdBase`.
  *
- * Each (DM peer | group | thread) maps to a deterministic 16-hex sha256 prefix
- * directory inside `cwdBase`. This prevents one user's session from reading or
- * mutating another user's working tree while letting operators allocate a
- * single disk root for the bot.
+ * Each session maps to a deterministic 16-hex sha256 prefix directory inside
+ * `cwdBase`, so one user's working tree cannot be read or mutated from another
+ * user's session while operators still allocate a single disk root for the bot.
  *
- * The hash inputs are namespaced (`dm:`, `group:`, `group:<id>:thread:<id>`)
- * so that the same string used as a uid vs. a group id can never collide.
+ * The partition key is the *exact* `sessionKey` the SessionRouter already
+ * produced for history (`SessionRouter.sessionKey()`), prefixed by the channel
+ * kind. Reusing the router key verbatim — rather than re-deriving spaceId or
+ * channel_id from the raw message — guarantees the cwd partition can never
+ * drift from the history partition:
  *
- * DM keys may additionally be scoped by `spaceId` so the cwd partition matches
- * SessionRouter.sessionKey(): the same uid messaging from two different spaces
- * gets two history sessions, hence must get two sandboxes too (P0-2).
+ *   - DM:    sessionKey = `${spaceId}:${uid}` (or bare `uid`)   → `dm:<key>`
+ *   - Group: sessionKey = `${channel_id}:${uid}`                → `group:<key>`
+ *
+ * Because the group sessionKey embeds `from_uid`, every group member gets their
+ * OWN sandbox (matching how group history is partitioned per-user), not a
+ * shared per-channel workspace. The `kind` prefix keeps a DM key and a group
+ * key that happen to be byte-identical from colliding.
  */
 
 import { createHash } from 'node:crypto';
 import {
   existsSync,
+  lstatSync,
   mkdirSync,
   readdirSync,
   rmSync,
-  statSync,
   utimesSync,
   writeFileSync,
 } from 'node:fs';
 import { join } from 'node:path';
 
-export type SessionCtx =
-  | { kind: 'dm'; userId: string; spaceId?: string }
-  | { kind: 'group'; groupId: string }
-  // NOTE: the `thread` variant is reserved for future wiring. The current Octo
-  // BotMessage shape exposes no thread/topic id, so only `dm` and `group` are
-  // ever emitted by index.ts today. Kept here (with hashing + tests) so the
-  // routing contract is ready the moment threads land upstream.
-  | { kind: 'thread'; groupId: string; threadId: string };
+/**
+ * Per-session routing context for cwd isolation. `kind` is the channel class
+ * and `sessionKey` is the router-produced key the session's history is stored
+ * under — see `SessionRouter.sessionKey()`. Passing the router key directly
+ * (instead of re-deriving uid/spaceId/channel_id here) is what keeps the cwd
+ * and history partitions byte-for-byte consistent.
+ */
+export type SessionCtx = {
+  kind: 'dm' | 'group';
+  sessionKey: string;
+};
 
 /** Length of the hex prefix used for subdirectory names. 16 hex = 64 bits — */
 /** ~2^32 sessions before a 1% collision risk, ample headroom for IM use.    */
@@ -45,12 +54,22 @@ const HASH_HEX_LEN = 16;
 const SESSION_DIR_RE = /^[0-9a-f]{16}$/;
 
 /**
- * Provenance marker written into every session dir we create. Cleanup only
- * deletes a 16-hex dir that ALSO contains this marker, so a cwdBase that is
- * accidentally pointed at some other tool's cache of identically-named dirs
- * (e.g. another hex-keyed store) can never be rmSync'd by us (P0-3).
+ * Provenance is recorded in a sidecar *registry* directory at the root of
+ * `cwdBase`, NOT inside each session dir. Each session we create gets a 0-byte
+ * marker `cwdBase/.cc-octo-sessions/<hexname>`. Cleanup only deletes a 16-hex
+ * dir that has a matching registry entry, so:
+ *
+ *   - A `cwdBase` accidentally pointed at another tool's hex-keyed store can
+ *     never be rmSync'd by us (P0-3).
+ *   - The marker lives OUTSIDE the agent's own working directory, so a
+ *     user-driven agent (which operates via relative paths inside its cwd)
+ *     cannot delete its marker to evade cleanup, nor forge a marker for a
+ *     sibling/operator directory to get it deleted. (Absolute-path access is a
+ *     separate, documented limitation — cwd is a starting dir, not a chroot.)
+ *   - The marker is re-created on every resolve if missing, so a transient
+ *     first-write failure cannot permanently exempt a live dir from the TTL.
  */
-const SESSION_MARKER_FILE = '.cc-octo-session';
+const SESSION_REGISTRY_DIR = '.cc-octo-sessions';
 
 /** 7 days — long enough for a vacation, short enough to bound disk growth. */
 export const DEFAULT_CWD_TTL_MS = 7 * 24 * 60 * 60 * 1000;
@@ -60,34 +79,33 @@ function hashKey(key: string): string {
 }
 
 function sessionKeyToString(ctx: SessionCtx): string {
-  switch (ctx.kind) {
-    case 'dm':
-      // P0-2: mirror SessionRouter.sessionKey() — scope by space when present
-      // so the same uid in different spaces resolves to different sandboxes.
-      // Omitting spaceId keeps the legacy `dm:<uid>` hash for backward compat.
-      return ctx.spaceId
-        ? `dm:${ctx.spaceId}:${ctx.userId}`
-        : `dm:${ctx.userId}`;
-    case 'group':
-      return `group:${ctx.groupId}`;
-    case 'thread':
-      return `group:${ctx.groupId}:thread:${ctx.threadId}`;
-  }
+  // Prefix the router key with the channel kind so a DM key and a group key
+  // that happen to be byte-identical can never resolve to the same sandbox.
+  return `${ctx.kind}:${ctx.sessionKey}`;
 }
 
 /**
  * Resolve and ensure the per-session cwd exists. Idempotent — safe to call
  * on every turn. Returns the absolute path under `cwdBase`.
+ *
+ * Note: the TTL tracks last *bot turn* (this function bumps the dir mtime on
+ * every call), not arbitrary filesystem activity inside the sandbox. A session
+ * with no inbound message for `ttlMs` is reclaimed even if a background process
+ * is still touching files inside it.
  */
 export function resolveSessionCwd(cwdBase: string, ctx: SessionCtx): string {
-  const dir = join(cwdBase, hashKey(sessionKeyToString(ctx)));
+  const name = hashKey(sessionKeyToString(ctx));
+  const dir = join(cwdBase, name);
   mkdirSync(dir, { recursive: true });
 
-  // P0-3: drop a provenance marker so cleanupExpiredCwds can distinguish our
-  // own session dirs from unrelated 16-hex dirs. Written once; best-effort.
-  const marker = join(dir, SESSION_MARKER_FILE);
+  // Record provenance in the sidecar registry (outside the agent's cwd). Best
+  // effort, but re-attempted on every resolve so a transient failure self-heals
+  // on the next turn rather than exempting the dir from cleanup forever.
+  const registryDir = join(cwdBase, SESSION_REGISTRY_DIR);
+  const marker = join(registryDir, name);
   if (!existsSync(marker)) {
     try {
+      mkdirSync(registryDir, { recursive: true });
       writeFileSync(
         marker,
         JSON.stringify({ created: new Date().toISOString(), kind: ctx.kind }),
@@ -124,8 +142,10 @@ export function resolveSessionCwd(cwdBase: string, ctx: SessionCtx): string {
  * Silent no-op when `cwdBase` does not exist (e.g. first-run before any
  * session has been resolved).
  *
- * A dir is eligible for deletion only when BOTH the name matches the 16-hex
- * pattern AND it carries our `.cc-octo-session` provenance marker (P0-3).
+ * A dir is eligible for deletion only when ALL hold: the name matches the
+ * 16-hex pattern, it is a real directory (not a symlink), and it has a matching
+ * entry in the `.cc-octo-sessions` registry (P0-3). The registry entry is
+ * removed alongside the dir.
  */
 export function cleanupExpiredCwds(
   cwdBase: string,
@@ -139,18 +159,24 @@ export function cleanupExpiredCwds(
     return;
   }
 
+  const registryDir = join(cwdBase, SESSION_REGISTRY_DIR);
   const cutoff = Date.now() - ttlMs;
   for (const name of entries) {
     if (!SESSION_DIR_RE.test(name)) continue; // never touch unrelated files
     const full = join(cwdBase, name);
-    // P0-3: only sweep dirs we provably created. A 16-hex dir without our
-    // marker belongs to someone else — leave it untouched no matter its age.
-    if (!existsSync(join(full, SESSION_MARKER_FILE))) continue;
+    const marker = join(registryDir, name);
+    // P0-3: only sweep dirs we provably created (registry entry present). A
+    // 16-hex dir without a registry entry belongs to someone else — leave it
+    // untouched no matter its age.
+    if (!existsSync(marker)) continue;
     try {
-      const st = statSync(full);
+      // lstatSync (not statSync) so a symlinked entry is never followed; a real
+      // session dir is always a plain directory.
+      const st = lstatSync(full);
       if (!st.isDirectory()) continue;
       if (st.mtimeMs >= cutoff) continue;
       rmSync(full, { recursive: true, force: true });
+      rmSync(marker, { force: true }); // drop the registry entry too
     } catch (err) {
       console.error(
         `[cc-channel-octo] cwd cleanup failed for ${full}: ${String(err)}`,

--- a/src/cwd-resolver.ts
+++ b/src/cwd-resolver.ts
@@ -1,0 +1,160 @@
+/**
+ * Q3: Per-session cwd isolation under a shared `cwdBase`.
+ *
+ * Each (DM peer | group | thread) maps to a deterministic 16-hex sha256 prefix
+ * directory inside `cwdBase`. This prevents one user's session from reading or
+ * mutating another user's working tree while letting operators allocate a
+ * single disk root for the bot.
+ *
+ * The hash inputs are namespaced (`dm:`, `group:`, `group:<id>:thread:<id>`)
+ * so that the same string used as a uid vs. a group id can never collide.
+ *
+ * DM keys may additionally be scoped by `spaceId` so the cwd partition matches
+ * SessionRouter.sessionKey(): the same uid messaging from two different spaces
+ * gets two history sessions, hence must get two sandboxes too (P0-2).
+ */
+
+import { createHash } from 'node:crypto';
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  utimesSync,
+  writeFileSync,
+} from 'node:fs';
+import { join } from 'node:path';
+
+export type SessionCtx =
+  | { kind: 'dm'; userId: string; spaceId?: string }
+  | { kind: 'group'; groupId: string }
+  // NOTE: the `thread` variant is reserved for future wiring. The current Octo
+  // BotMessage shape exposes no thread/topic id, so only `dm` and `group` are
+  // ever emitted by index.ts today. Kept here (with hashing + tests) so the
+  // routing contract is ready the moment threads land upstream.
+  | { kind: 'thread'; groupId: string; threadId: string };
+
+/** Length of the hex prefix used for subdirectory names. 16 hex = 64 bits — */
+/** ~2^32 sessions before a 1% collision risk, ample headroom for IM use.    */
+const HASH_HEX_LEN = 16;
+
+/** Cleanup interval guard: only paths matching this shape are eligible for */
+/** TTL deletion so a misconfigured cwdBase (pointing at $HOME, etc.) can   */
+/** never wipe legitimate user files.                                       */
+const SESSION_DIR_RE = /^[0-9a-f]{16}$/;
+
+/**
+ * Provenance marker written into every session dir we create. Cleanup only
+ * deletes a 16-hex dir that ALSO contains this marker, so a cwdBase that is
+ * accidentally pointed at some other tool's cache of identically-named dirs
+ * (e.g. another hex-keyed store) can never be rmSync'd by us (P0-3).
+ */
+const SESSION_MARKER_FILE = '.cc-octo-session';
+
+/** 7 days — long enough for a vacation, short enough to bound disk growth. */
+export const DEFAULT_CWD_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+function hashKey(key: string): string {
+  return createHash('sha256').update(key).digest('hex').slice(0, HASH_HEX_LEN);
+}
+
+function sessionKeyToString(ctx: SessionCtx): string {
+  switch (ctx.kind) {
+    case 'dm':
+      // P0-2: mirror SessionRouter.sessionKey() — scope by space when present
+      // so the same uid in different spaces resolves to different sandboxes.
+      // Omitting spaceId keeps the legacy `dm:<uid>` hash for backward compat.
+      return ctx.spaceId
+        ? `dm:${ctx.spaceId}:${ctx.userId}`
+        : `dm:${ctx.userId}`;
+    case 'group':
+      return `group:${ctx.groupId}`;
+    case 'thread':
+      return `group:${ctx.groupId}:thread:${ctx.threadId}`;
+  }
+}
+
+/**
+ * Resolve and ensure the per-session cwd exists. Idempotent — safe to call
+ * on every turn. Returns the absolute path under `cwdBase`.
+ */
+export function resolveSessionCwd(cwdBase: string, ctx: SessionCtx): string {
+  const dir = join(cwdBase, hashKey(sessionKeyToString(ctx)));
+  mkdirSync(dir, { recursive: true });
+
+  // P0-3: drop a provenance marker so cleanupExpiredCwds can distinguish our
+  // own session dirs from unrelated 16-hex dirs. Written once; best-effort.
+  const marker = join(dir, SESSION_MARKER_FILE);
+  if (!existsSync(marker)) {
+    try {
+      writeFileSync(
+        marker,
+        JSON.stringify({ created: new Date().toISOString(), kind: ctx.kind }),
+      );
+    } catch (err) {
+      console.error(
+        `[cc-channel-octo] cwd marker write failed for ${dir}: ${String(err)}`,
+      );
+    }
+  }
+
+  // P0-1: mkdirSync does NOT touch mtime on an already-existing dir, so an
+  // actively-used session created >7d ago would be swept by cleanupExpiredCwds
+  // on its next turn. Refresh atime+mtime to "now" on every resolve so the TTL
+  // tracks last activity. Wrapped: a concurrent rmSync race must not crash the
+  // request — worst case the dir is recreated on the next turn.
+  try {
+    const now = new Date();
+    utimesSync(dir, now, now);
+  } catch (err) {
+    console.error(
+      `[cc-channel-octo] cwd mtime refresh failed for ${dir}: ${String(err)}`,
+    );
+  }
+
+  return dir;
+}
+
+/**
+ * Sweep `cwdBase` for hashed session dirs whose mtime is older than `ttlMs`
+ * and remove them. Best-effort: failures are logged, never thrown — the bot
+ * must continue running even if disk cleanup hits a permission error.
+ *
+ * Silent no-op when `cwdBase` does not exist (e.g. first-run before any
+ * session has been resolved).
+ *
+ * A dir is eligible for deletion only when BOTH the name matches the 16-hex
+ * pattern AND it carries our `.cc-octo-session` provenance marker (P0-3).
+ */
+export function cleanupExpiredCwds(
+  cwdBase: string,
+  ttlMs: number = DEFAULT_CWD_TTL_MS,
+): void {
+  let entries: string[];
+  try {
+    entries = readdirSync(cwdBase);
+  } catch {
+    // cwdBase missing / unreadable — nothing to clean.
+    return;
+  }
+
+  const cutoff = Date.now() - ttlMs;
+  for (const name of entries) {
+    if (!SESSION_DIR_RE.test(name)) continue; // never touch unrelated files
+    const full = join(cwdBase, name);
+    // P0-3: only sweep dirs we provably created. A 16-hex dir without our
+    // marker belongs to someone else — leave it untouched no matter its age.
+    if (!existsSync(join(full, SESSION_MARKER_FILE))) continue;
+    try {
+      const st = statSync(full);
+      if (!st.isDirectory()) continue;
+      if (st.mtimeMs >= cutoff) continue;
+      rmSync(full, { recursive: true, force: true });
+    } catch (err) {
+      console.error(
+        `[cc-channel-octo] cwd cleanup failed for ${full}: ${String(err)}`,
+      );
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -328,21 +328,16 @@ async function handleMessage(
 
       // --- Query agent with structural role separation (Q3 fix) ---
       // userContentForLLM → user role (prompt), history + context → system role (systemPrompt)
-      // Q3 cwd isolation: derive a per-session SessionCtx from channel_type
-      // so resolveSessionCwd can hash to a stable hex subdir under cwdBase.
-      // DM keys on the sender uid plus optional spaceId; groups key on channel_id
-      // (everyone in the room shares the same workspace, matching IM mental
-      // model — a group's "project" is collective). Thread routing is reserved
-      // until BotMessage exposes thread/topic metadata.
-      //
-      // P0-2: SessionRouter.sessionKey() scopes DMs by spaceId when present
-      // (`${spaceId}:${from_uid}`), so the cwd partition must match — the same
-      // uid in two spaces has two histories and therefore needs two sandboxes.
-      // We recover spaceId from the router-produced sessionKey itself (rather
-      // than re-deriving it) so the two can never drift out of sync.
-      const sessionCtx: SessionCtx = isGroup
-        ? { kind: 'group', groupId: channelId }
-        : { kind: 'dm', userId: msg.from_uid, spaceId: dmSpaceIdFromKey(sessionKey, msg.from_uid) };
+      // Q3 cwd isolation: the SessionCtx carries the router-produced sessionKey
+      // verbatim, so the cwd partition is byte-for-byte identical to the history
+      // partition. Group keys embed from_uid (`${channel_id}:${uid}`), so every
+      // group member gets their OWN sandbox — matching per-user group history
+      // and honoring the documented "one user cannot read/mutate another's
+      // working tree" guarantee.
+      const sessionCtx: SessionCtx = {
+        kind: isGroup ? 'group' : 'dm',
+        sessionKey,
+      };
       const rawChunks = queryAgent(userContentForLLM, historyPrefix, contextStr, config, sessionCtx);
 
       // Tee the generator: collect full text while streaming to Octo
@@ -433,24 +428,6 @@ async function handleMessage(
 }
 
 // ─── G1/G11 helpers ───────────────────────────────────────────────────────────────────
-
-/**
- * P0-2: Recover the DM spaceId from the router-produced sessionKey.
- *
- * SessionRouter.sessionKey() builds DM keys as `${spaceId}:${from_uid}` when a
- * space is known, or bare `from_uid` otherwise. We invert that here so the cwd
- * sandbox partition stays byte-for-byte consistent with the history partition,
- * instead of re-deriving spaceId via a parallel extractor that could drift.
- *
- * Returns the spaceId, or undefined when the key is the bare uid (no space).
- */
-function dmSpaceIdFromKey(sessionKey: string, fromUid: string): string | undefined {
-  const suffix = `:${fromUid}`;
-  if (sessionKey.endsWith(suffix) && sessionKey.length > suffix.length) {
-    return sessionKey.slice(0, -suffix.length);
-  }
-  return undefined;
-}
 
 /**
  * Compact rendering of a message for the rolling [Group context] cache.

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,8 @@ import { OctoGateway } from './gateway.js';
 import { SessionRouter } from './session-router.js';
 import { GroupContext } from './group-context.js';
 import { queryAgent, sanitizeForSystemPrompt } from './agent-bridge.js';
+import type { SessionCtx } from './cwd-resolver.js';
+import { cleanupExpiredCwds } from './cwd-resolver.js';
 import { StreamRelay } from './stream-relay.js';
 import { sendMessage, sendReadReceipt, getChannelMessages } from './octo/api.js';
 import type { HistoricalMessage } from './octo/api.js';
@@ -31,15 +33,28 @@ async function main(): Promise<void> {
 
   // --- Config ---
   const config = loadConfig();
+  // Q3: loadConfig() always populates cwdBase from defaults; the `?? cwd`
+  // fallback is only here for hand-built Config objects in tests/imports.
+  const cwdBase = config.cwdBase ?? config.cwd;
   console.log(
-    `[cc-channel-octo] Config loaded: apiUrl=${config.apiUrl}, cwd=${config.cwd}, ` +
+    `[cc-channel-octo] Config loaded: apiUrl=${config.apiUrl}, cwdBase=${cwdBase}, ` +
     `dataDir=${config.dataDir}, sdk.model=${config.sdk.model ?? 'default'}, ` +
-    `sdk.allowedTools=[${config.sdk.allowedTools.join(',')}], ` +
+    `sdk.allowedTools=${config.sdk.allowedTools === '*' ? '*' : `[${config.sdk.allowedTools.join(',')}]`}, ` +
     `sdk.permissionMode=${config.sdk.permissionMode}, ` +
     `rateLimit=${config.rateLimit.maxPerMinute} req/min, ` +
     `context.maxContextChars=${config.context.maxContextChars}, ` +
     `context.historyLimit=${config.context.historyLimit}`,
   );
+
+  // --- Q3: per-session cwd cleanup (7d TTL) ---
+  cleanupExpiredCwds(cwdBase);
+  const CWD_CLEANUP_INTERVAL_MS = 6 * 60 * 60 * 1000; // 6 hours
+  const cwdCleanupTimer = setInterval(() => {
+    cleanupExpiredCwds(cwdBase);
+  }, CWD_CLEANUP_INTERVAL_MS);
+  // Allow the process to exit cleanly even if this timer is the only thing
+  // keeping the event loop alive (e.g. tests, single-shot smoke runs).
+  cwdCleanupTimer.unref();
 
   // --- Database ---
   const dbPath = join(config.dataDir, 'cc-octo.db');
@@ -88,6 +103,7 @@ async function main(): Promise<void> {
 
   // --- Q6 + Q7: Shutdown callback (drain handlers + close store) ---
   gateway.setShutdownCallback(async () => {
+    clearInterval(cwdCleanupTimer); // Q3: stop the periodic cwd cleanup
     await gateway.stop(activeHandlers);
     store.close(); // Q7: explicitly close SQLite (WAL checkpoint)
   });
@@ -312,7 +328,22 @@ async function handleMessage(
 
       // --- Query agent with structural role separation (Q3 fix) ---
       // userContentForLLM → user role (prompt), history + context → system role (systemPrompt)
-      const rawChunks = queryAgent(userContentForLLM, historyPrefix, contextStr, config);
+      // Q3 cwd isolation: derive a per-session SessionCtx from channel_type
+      // so resolveSessionCwd can hash to a stable hex subdir under cwdBase.
+      // DM keys on the sender uid plus optional spaceId; groups key on channel_id
+      // (everyone in the room shares the same workspace, matching IM mental
+      // model — a group's "project" is collective). Thread routing is reserved
+      // until BotMessage exposes thread/topic metadata.
+      //
+      // P0-2: SessionRouter.sessionKey() scopes DMs by spaceId when present
+      // (`${spaceId}:${from_uid}`), so the cwd partition must match — the same
+      // uid in two spaces has two histories and therefore needs two sandboxes.
+      // We recover spaceId from the router-produced sessionKey itself (rather
+      // than re-deriving it) so the two can never drift out of sync.
+      const sessionCtx: SessionCtx = isGroup
+        ? { kind: 'group', groupId: channelId }
+        : { kind: 'dm', userId: msg.from_uid, spaceId: dmSpaceIdFromKey(sessionKey, msg.from_uid) };
+      const rawChunks = queryAgent(userContentForLLM, historyPrefix, contextStr, config, sessionCtx);
 
       // Tee the generator: collect full text while streaming to Octo
       const collected: string[] = [];
@@ -402,6 +433,24 @@ async function handleMessage(
 }
 
 // ─── G1/G11 helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * P0-2: Recover the DM spaceId from the router-produced sessionKey.
+ *
+ * SessionRouter.sessionKey() builds DM keys as `${spaceId}:${from_uid}` when a
+ * space is known, or bare `from_uid` otherwise. We invert that here so the cwd
+ * sandbox partition stays byte-for-byte consistent with the history partition,
+ * instead of re-deriving spaceId via a parallel extractor that could drift.
+ *
+ * Returns the spaceId, or undefined when the key is the bare uid (no space).
+ */
+function dmSpaceIdFromKey(sessionKey: string, fromUid: string): string | undefined {
+  const suffix = `:${fromUid}`;
+  if (sessionKey.endsWith(suffix) && sessionKey.length > suffix.length) {
+    return sessionKey.slice(0, -suffix.length);
+  }
+  return undefined;
+}
 
 /**
  * Compact rendering of a message for the rolling [Group context] cache.


### PR DESCRIPTION
## Summary

Three independent config improvements that share `src/config.ts`, `src/agent-bridge.ts`, and the docs/example surfaces. Bundled in one PR because the three diffs collide on the same hunks; split into **two commits** (`feat:` code + `docs:` README/example) only because the husky pre-commit hook drops non-ts paths from the lint-staged index.

### Q1 — `ANTHROPIC_BASE_URL` support
- New optional field `Config.sdk.anthropicBaseUrl`.
- New env var `ANTHROPIC_BASE_URL` (Anthropic SDK standard name — no `CC_OCTO_` prefix, so existing gateway configs work as-is).
- `agent-bridge` forwards it through the SDK's `options.env`. That field REPLACES the subprocess env entirely, so `process.env` is spread in first to preserve `PATH` / `HOME` / `ANTHROPIC_API_KEY`.
- README has a new "Self-hosted gateway" section; `config.example.json` carries the placeholder + comment.

### Q2 — `allowedTools` simplified to `"*" | string[]`
- Type widened: `Config.sdk.allowedTools: string[] | '*'`.
- Default flipped to `'*'` (full SDK toolset). The old hard-coded 8-tool list was redundant lockdown — surface area is already bounded by `permissionMode` + per-session `cwdBase` isolation — and it silently blocked SDK-internal tools like `TodoWrite` / `Task`.
- `agent-bridge` omits the `allowedTools` SDK option when the value is `'*'` (so the SDK's own default applies); a `string[]` is forwarded as-is.
- Env `CC_OCTO_SDK_ALLOWED_TOOLS` accepts both shapes (literal `*` or CSV).

### Q3 — Per-session `cwd` isolation with 7-day TTL cleanup
- New field `Config.cwdBase` (canonical). Legacy `cwd` / `CC_OCTO_CWD` still accepted as deprecated aliases with a one-time startup warning; `cwdBase` wins when both are set.
- New module `src/cwd-resolver.ts`:
  - `resolveSessionCwd(cwdBase, ctx)` — namespaced `sha256(...).slice(0,16)` subdir per `dm:<uid>` / `group:<id>` / `group:<id>:thread:<id>`. `mkdirSync` recursive, idempotent.
  - `cleanupExpiredCwds(cwdBase, ttlMs = 7d)` — sweeps 16-hex subdirs whose `mtime` is older than the TTL. Never throws; only deletes paths matching the hash pattern so a misconfigured `cwdBase` (e.g. pointed at `$HOME`) cannot wipe operator files.
- `queryAgent` accepts an optional `SessionCtx`; when supplied, the resolver produces the per-session path before `sdkQuery`; when omitted (legacy callers / direct Config mocks in tests), the base path passes through unchanged.
- `src/index.ts` wiring:
  - one synchronous sweep at startup,
  - a 6-hour `setInterval` sweep — `unref()`'d so it doesn't keep the process alive, `clearInterval`'d in the shutdown callback,
  - `SessionCtx` derived from `channelType` (DM keys on `from_uid`, group keys on `channel_id`) and threaded into `queryAgent`.

## Verification

| Gate | Result |
|---|---|
| `npm run lint` | 0 warnings |
| `npx tsc --noEmit` | clean |
| `npm test` | **725 passed** (was 690; +35 new across Q1/Q2/Q3 + cwd-resolver) |
| `npm run build` | `dist/` emitted cleanly |

### Backward compatibility
- `"cwd": "..."` in config files still works; only triggers the deprecation warning at startup.
- `CC_OCTO_CWD` still works; same warning.
- Old explicit `allowedTools` arrays still work; default just changed.
- `queryAgent`'s `sessionCtx` is **optional**, so existing tests / direct Config mocks compile without changes.
- SDK options shape unchanged when the new fields are unset.

## Test plan

- [x] `npm test` — 725 tests pass, including 35 new ones (Q1: 4, Q2: 5, Q3: 6, cwd-resolver: 20)
- [x] `npm run lint` — zero warnings under `--max-warnings 0`
- [x] `npx tsc --noEmit` — strict mode passes
- [x] `npm run build` — `dist/` regenerates including new `cwd-resolver.{js,d.ts,js.map}`
- [ ] Manual smoke (out of scope for this PR): start the gateway with `ANTHROPIC_BASE_URL=…`, observe SDK subprocess inherits it; send a DM and a group message, confirm two distinct hashed subdirs appear under `cwdBase`; touch a sandbox to >7d mtime and confirm the next cleanup tick removes it.
