### PR TITLE
docs(CLAUDE.md): document pre-commit hook scope, fix layer count, add commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,8 @@ cc-channel-octo: Independent Node.js gateway bridging Claude Code (Claude Agent 
 - `npm run type-check` — type check without emit
 - `npm run lint` — ESLint
 - `npm test` — run tests
+- `npx vitest run src/__tests__/<file>.test.ts` — run a single test file
+- `npm run dev` — tsc in watch mode
 - `npm start` — start the gateway
 
 ## Code Style
@@ -29,7 +31,7 @@ cc-channel-octo: Independent Node.js gateway bridging Claude Code (Claude Agent 
 
 ## Architecture
 
-Six layers (L0–L7), see ARCHITECTURE.md:
+Layered design (L0–L7), see ARCHITECTURE.md:
 - L0: octo/ — WuKongIM binary protocol (forked from openclaw-channel-octo)
 - L1: gateway.ts — WS lifecycle + token refresh
 - L2: session-router.ts — routing + concurrency + rate limiting
@@ -39,8 +41,22 @@ Six layers (L0–L7), see ARCHITECTURE.md:
 - L6: group-context.ts — group chat context + mentions
 - L7: config.ts — configuration loading
 
+Cross-cutting: url-policy.ts (SSRF/URL validation), cwd-resolver.ts (per-session
+cwd isolation), media-upload.ts / file-inline-wrap.ts (inbound media), db-adapter.ts.
+
 ## Testing
 
 - Test files go in src/__tests__/
 - Use vitest
 - Tests must pass before commit
+
+## Gotchas
+
+- **Pre-commit hook scope** — `.husky/pre-commit` runs `lint-staged` (ESLint on
+  staged `*.ts` only) + `npm run type-check`. Non-`.ts` files (README, *.json)
+  bypass lint-staged; full `npm test` is deferred to CI, so run it locally
+  before pushing.
+- **Commit messages** — Conventional Commits (`feat:`, `fix:`, `chore(scope):`);
+  enforced by a commitlint `commit-msg` hook on `main`.
+- **Lint is zero-tolerance** — `eslint --max-warnings 0`, so an `any` (warn-level
+  rule) fails the build despite being "just a warning".


### PR DESCRIPTION
Closes #54.

## What changed and why

A project-memory audit of `CLAUDE.md` found three small gaps that cost contributors time. This PR fixes all three (documentation only):

1. **New Gotchas section.** Documents the `.husky/pre-commit` behavior (lint-staged runs ESLint on staged `*.ts` only + `npm run type-check`; non-`.ts` files bypass it; full `npm test` is CI-deferred) — the exact behavior that forced PR #51 to split code vs. docs/json into two commits. Also notes the Conventional Commits requirement and that lint is zero-tolerance (`--max-warnings 0`).
2. **Architecture wording fix.** "Six layers (L0–L7)" → "Layered design (L0–L7)" (L0–L7 is eight labels), plus a cross-cutting line surfacing modules that were invisible in the map: `url-policy.ts` (SSRF validation), `cwd-resolver.ts` (per-session cwd isolation), the media modules, and `db-adapter.ts`.
3. **Commands.** Added the single-test-file invocation (`npx vitest run src/__tests__/<file>.test.ts`) and `npm run dev` (watch mode).

## Files modified

- `CLAUDE.md`

## Test results

Documentation-only change; no source modified.

- `npm run type-check` — clean (ran via pre-commit hook)
- `npm test` — not affected (no source/test changes)

## Breaking changes

None.