### PR TITLE
fix(db-adapter): create dataDir with 0700 permissions

### DIFF
--- a/src/__tests__/db-adapter.test.ts
+++ b/src/__tests__/db-adapter.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { createAdapter } from '../db-adapter.js';
-import { mkdtempSync, rmSync, existsSync } from 'node:fs';
+import { mkdtempSync, rmSync, existsSync, statSync, mkdirSync, chmodSync } from 'node:fs';
 import { join } from 'node:path';
-import { tmpdir } from 'node:os';
+import { tmpdir, platform } from 'node:os';
 
 describe('DbAdapter', () => {
   let tmpDir: string;
@@ -75,6 +75,30 @@ describe('DbAdapter', () => {
     const adapter = createAdapter(':memory:');
     const fk = adapter.prepare('PRAGMA foreign_keys').get() as { foreign_keys: number };
     expect(fk.foreign_keys).toBe(1);
+    adapter.close();
+  });
+
+  // dataDir holds chat-history SQLite — README/CONTRIBUTING promise 0700.
+  const itPosix = platform() === 'win32' ? it.skip : it;
+
+  itPosix('creates the data directory with 0700 permissions', () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'db-adapter-perm-'));
+    const dir = join(tmpDir, 'data');
+    const adapter = createAdapter(join(dir, 'cc-octo.db'));
+    const mode = statSync(dir).mode & 0o777;
+    expect(mode).toBe(0o700);
+    adapter.close();
+  });
+
+  itPosix('tightens a pre-existing world-readable data directory to 0700', () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'db-adapter-perm2-'));
+    const dir = join(tmpDir, 'data');
+    // Operator (or a prior umask) left it 0755 — adapter must clamp it down.
+    mkdirSync(dir, { recursive: true });
+    chmodSync(dir, 0o755);
+    const adapter = createAdapter(join(dir, 'cc-octo.db'));
+    const mode = statSync(dir).mode & 0o777;
+    expect(mode).toBe(0o700);
     adapter.close();
   });
 });

--- a/src/db-adapter.ts
+++ b/src/db-adapter.ts
@@ -3,7 +3,7 @@
  * Enables future migration to node:sqlite when it reaches GA.
  */
 
-import { mkdirSync } from 'node:fs';
+import { mkdirSync, chmodSync } from 'node:fs';
 import { dirname } from 'node:path';
 import Database from 'better-sqlite3';
 
@@ -30,8 +30,25 @@ class BetterSqliteAdapter implements DbAdapter {
   private readonly db: Database.Database;
 
   constructor(dbPath: string) {
-    const dir = dirname(dbPath);
-    mkdirSync(dir, { recursive: true });
+    // The data directory holds chat-history SQLite files, so it must be
+    // owner-only (0700) as documented in README / CONTRIBUTING. The in-memory
+    // path has no backing directory — skip all filesystem setup for it (and
+    // never chmod the process cwd that dirname(':memory:') resolves to).
+    if (dbPath !== ':memory:') {
+      const dir = dirname(dbPath);
+      // `mode` on mkdirSync is masked by umask, and a pre-existing directory is
+      // left untouched — so chmod afterwards to enforce 0700 unconditionally.
+      mkdirSync(dir, { recursive: true, mode: 0o700 });
+      try {
+        chmodSync(dir, 0o700);
+      } catch (err) {
+        // Best-effort: a non-POSIX FS (or a dir we don't own) may reject chmod.
+        // Don't crash startup — log so the operator can tighten it manually.
+        console.warn(
+          `[cc-channel-octo] WARNING: could not enforce 0700 on dataDir ${dir}: ${String(err)}`,
+        );
+      }
+    }
     this.db = new Database(dbPath);
     this.db.pragma('journal_mode = WAL');
     this.db.pragma('foreign_keys = ON');


### PR DESCRIPTION
Closes #56.

## What changed and why

The `dataDir` (default `./data`) holds chat-history SQLite files and is documented as created with `0700` perms (README:89, CONTRIBUTING:223). In reality `mkdirSync` used the umask default — a real run produced `0755` (group/other readable), contradicting the documented security posture. Found during end-to-end dogfooding.

`src/db-adapter.ts`:
- Create the directory with `mode: 0o700` **and** `chmod 0700` afterwards, so the guarantee holds regardless of umask or a pre-existing directory.
- Skip all filesystem setup for the `:memory:` path so it never touches/chmods the cwd that `dirname(':memory:')` resolves to.
- `chmod` is best-effort — a non-POSIX FS warns instead of crashing startup.

## Files modified

- `src/db-adapter.ts`
- `src/__tests__/db-adapter.test.ts` (2 new POSIX-only regression tests)

## Test results

- `npm run type-check` — clean
- `npm test` — **742 passed** (was 740; +2)
- `npm run lint` — 0 warnings
- `npm run build` — clean
- Dogfood: real `node dist/index.js` run now produces `700 .../data` (verified).

## Breaking changes

None. In-memory behavior unchanged; existing data dirs are tightened to 0700 on next startup.