### PR TITLE
chore(release): 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,97 @@
+# Changelog
+
+All notable changes to this project are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+While the major version is `0`, minor releases may carry breaking changes.
+
+## [0.2.0] - 2026-06-07
+
+The first feature release after the initial `0.1.0` tag. It adds the full
+inbound/outbound media and group-chat capabilities, per-session working-directory
+isolation, a self-hosted gateway endpoint, and a large batch of security
+hardening across the SSRF, prompt-injection, and protocol-DoS surfaces.
+
+### Added
+
+- **Self-hosted gateway endpoint** — `sdk.anthropicBaseUrl` config field (and the
+  standard `ANTHROPIC_BASE_URL` env var) to route the Claude Agent SDK through a
+  proxy/regional endpoint. SSRF-validated at boot like `apiUrl`.
+- **Per-session `cwd` isolation** — each session (DM peer, or individual group
+  member) gets its own hashed sandbox under `cwdBase`, partitioned by the same
+  key as conversation history; idle sandboxes (>7d) are reclaimed every 6h.
+- **`allowedTools: "*"`** wildcard form to allow every SDK tool; the env var
+  accepts a `*` token or a CSV whitelist.
+- **Inbound message resolution** — image/file/RichText payload handling, text-file
+  inlining (base64-wrapped, budgeted), and group history backfill from the Octo
+  API on cold start (G1, G2, G4, G11, G22).
+- **Outbound capabilities** — media, RichText, and `@mention` send (G24, G5, G6, G7).
+- **Group chat features** — Space isolation, history segmentation, `streamOn`
+  cache filter, reply/quote context, read receipts, mention-free groups, and
+  `@botname` stripping (G3, G8–G13, G9, G10, G21).
+- **Bot/identity controls** — bot-loop prevention, owner identity, per-user rate
+  limiting, robot flags (G14, G18, G19, G20, G23).
+- **Octo API surface** — `fetchBotGroups`, `getGroupInfo`, `searchSpaceMembers`
+  (G15, G16, G17).
+- **CI & repo gates** — GitHub Actions, husky pre-commit/commit-msg/pre-push,
+  coverage, strict `tsc`, commitlint (W0).
+- **Docs** — `ARCHITECTURE.md`, `CONTRIBUTING.md`, self-hosted-gateway and
+  security-model sections in `README.md`.
+
+### Changed
+
+- **Default `allowedTools` flipped to `"*"`** (was a hard-coded 8-tool list). The
+  surface is bounded by `permissionMode` + per-session `cwdBase` isolation; the
+  old list also silently blocked SDK-internal tools.
+- **`cwd` → `cwdBase`** as the canonical config field. Legacy `cwd` / `CC_OCTO_CWD`
+  still accepted with a one-time deprecation warning.
+- **`dataDir` created with `0700`** permissions, enforced via `chmod` regardless of
+  umask or a pre-existing directory (previously used the umask default).
+- Response truncation limit, heartbeat logging, and runtime version now read from
+  `package.json` (Q31, Q32, Q36).
+
+### Fixed
+
+- **Protocol DoS / correctness (D1)** — socket temp-buffer cap, base64 cap, system
+  prompt cap, SDK null guard.
+- **RichText pipeline (C1)** — crash on array payloads, per-payload budgets, G4
+  payload merge, rejection-cache guard, `O(n)` byte-safe truncation.
+- **Media pipeline (C2)** — output + media defects (P0-1, P1-3..6), inline-image
+  safety gate, data-URI MIME-param parsing, legacy `image/svg` MIME rejection.
+- **Byte-safe truncation (S2)** — correct handling of N×4-byte UTF-8 boundaries
+  (no stray U+FFFD).
+- Shutdown resilience — drain in-flight handlers, explicit `store.close()` WAL
+  checkpoint, `unhandledRejection` handler (Q6, Q7, Q8).
+- Rate limiting — peek-then-consume with per-bucket debounce (G20); global
+  per-minute limit (Q13).
+- Heartbeat restored on token-refresh failure; WS listener cleanup; 30s default
+  `postJson` timeout (Q2, Q30, Q33, Q35).
+- **e2e tests now drive the real `handleMessage` pipeline** instead of a
+  hand-copied replica, closing a coverage gap around the per-session cwd wiring.
+
+### Security
+
+- **SSRF defense (S1, S2, S4, S5, S6)** — shared `url-policy.ts`; reject
+  `file://`/non-http(s) schemes, private/loopback/link-local/CGN IPs (incl.
+  v4-mapped IPv6 hex), `https://` to private hosts; per-hop redirect re-validation
+  with cross-host `Authorization` scoping; WHATWG-canonical path-traversal check
+  for encoded dot-segments; `%2F` encoded-slash rejection. **(breaking)**
+- **Prompt-injection defense** — structural role separation with a non-overridable
+  security prefix (Q3, Q9); sanitize reply quotes and group context (S3); inlined
+  file content wrapped in base64 with a total payload cap (S2). **(breaking)**
+- Replace `Math.random` DH seed with `crypto.randomBytes`; fix spread-induced stack
+  overflow (Q4, Q5).
+- Message-length limit, sanitized credential/error logs, config-file permission
+  warning (Q10, Q11, Q12).
+- `anthropicBaseUrl` SSRF-validated at boot so a stray endpoint cannot exfiltrate
+  the API key; forwarded via scoped subprocess env (no global `process.env`
+  mutation, no cross-request leak).
+
+## [0.1.0]
+
+Initial tagged baseline: text messaging, streaming output, SQLite session
+persistence, rate limiting, and the core security model.
+
+[0.2.0]: https://github.com/Mininglamp-OSS/cc-channel-octo/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/Mininglamp-OSS/cc-channel-octo/releases/tag/v0.1.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cc-channel-octo",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cc-channel-octo",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "better-sqlite3": "^12.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-channel-octo",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Bridge Claude Code (via Claude Agent SDK) to Octo IM — independent Node.js gateway",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
Release **v0.2.0** — first feature release after the `v0.1.0` baseline.

## What changed and why

- `package.json` / `package-lock.json`: `0.1.0` → `0.2.0` (SemVer minor — many `feat`s plus two `!` breaking security changes; `0.x` carries breaking changes in minor).
- New `CHANGELOG.md` (Keep a Changelog), backfilling everything since `v0.1.0` under Added / Changed / Fixed / Security.

**No VERSION file** — `package.json` is the single source of truth (read at runtime by `gateway.ts:15`); a separate file would only risk drift.

## Release contents (highlights)

- **Added:** self-hosted `anthropicBaseUrl`, per-session `cwdBase` isolation, `allowedTools: "*"`, full inbound media/RichText/file-inlining, outbound media/@mention, group features (Space isolation, history segmentation, reply context, read receipts), Octo API surface, CI/husky/commitlint gates, ARCHITECTURE/CONTRIBUTING docs.
- **Security (breaking):** shared `url-policy.ts` SSRF defense (S1/S2/S4/S5/S6), structural prompt-injection defense, base64-wrapped file inlining + caps.
- **Fixed:** protocol DoS (D1), RichText/media pipeline (C1/C2), byte-safe truncation (S2), shutdown resilience, dataDir `0700`, e2e now drives the real pipeline.

See `CHANGELOG.md` for the full categorized list.

## Test results

- `npm run type-check` — clean
- `npm test` — **744 passed**
- `npm run lint` — 0 warnings
- `npm run build` — clean
- Dogfood: runtime resolves version `0.2.0`.

## Post-merge

Tag `v0.2.0` will be created on the merge commit on `main` (annotated), so it points at the real release state.

Refs #51 #57 #59