### PR TITLE
docs(readme): mark v0.2 as current; align roadmap with shipped scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,9 +276,9 @@ src/
     └── types.ts        # Protocol type definitions
 ```
 
-## Known Limitations (v0.1)
+## Known Limitations (v0.2)
 
-- **Text only** — Image, file, and voice messages are not processed (the bot replies with a notice).
+- **No slash commands** — `/reset`, `/config` and similar in-chat controls are not yet implemented (planned for v0.3).
 - **Per-session `cwdBase` isolation** — Each session (DM peer, or individual group member) gets its own SHA-256 hex sandbox under `cwdBase`, partitioned by the same key as conversation history; idle sandboxes (>7d) are auto-cleaned every 6h. Note: `cwdBase` separates sessions from each other but does not confine a session to its directory (absolute-path reads via Bash/Read remain possible) — see the Security Model section.
 - **Stateless sessions** — Uses the v1 `query()` API. Workspace state (open files, command history) does not persist across messages. The v2 Session API is planned for v0.3.
 - **Single bot** — One bot per process. Multi-bot support is planned for v0.3.
@@ -287,10 +287,10 @@ src/
 
 | Version | Scope |
 |---------|-------|
-| **v0.1** *(current)* | Text messaging, streaming, session persistence, rate limiting, security model |
-| **v0.2** | Media reception (image/file), `/reset` and `/config` commands |
-| **v0.3** | v2 Session API, multi-bot support, tool progress display |
-| **v1.0** | Media sending, GROUP.md/THREAD.md configuration, webhook mode |
+| **v0.1** | Text messaging, streaming, session persistence, rate limiting, security model |
+| **v0.2** *(current)* | Media reception & sending (image/file/RichText), @mention, group context, per-session `cwdBase` isolation, self-hosted gateway, SSRF/prompt-injection hardening |
+| **v0.3** | v2 Session API, multi-bot support, `/reset` and `/config` commands, tool progress display |
+| **v1.0** | GROUP.md/THREAD.md configuration, webhook mode |
 
 ## Contributing
 


### PR DESCRIPTION
Follow-up to the v0.2.0 release — the README roadmap still said *(current)* on v0.1.

## What changed and why

Updated the **Known Limitations** and **Roadmap** sections to reflect what v0.2.0 actually shipped (verified against `src/`), not the pre-release plan:

- `## Known Limitations (v0.1)` → `(v0.2)`.
- Dropped the stale **"Text only"** limitation — image/file/voice/RichText reception is implemented (`inbound.ts` handles `MessageType.Image/GIF/Voice/Video/File/RichText`). Replaced it with the real gap: **no in-chat slash commands yet**.
- v0.2 row now lists delivered scope: media reception & sending, @mention, group context, per-session `cwdBase` isolation, self-hosted gateway, SSRF / prompt-injection hardening.
- Moved `/reset` + `/config` to **v0.3** (confirmed not implemented).
- Removed **media sending** from v1.0 — it already shipped in v0.2 (`sendMediaMessage` / `sendRichTextMessage`).

## Files modified

- `README.md`

## Test results

Docs-only; no source change. `type-check` clean (pre-commit hook).