### PR TITLE
feat(commands): in-chat /reset, /config, /help (v0.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ While the major version is `0`, minor releases may carry breaking changes.
   history, `/config` shows the active non-sensitive settings, `/help` lists
   commands. Handled before the agent query, scoped per-user (even in groups), so
   a command never reaches the LLM or leaks into another member's group context.
+  `/reset` records a persisted reset barrier (by `message_seq`) so group
+  cold-start backfill cannot resurrect the cleared history, even across a
+  process restart. Commands are subject to the normal per-session rate limit.
 
 ## [0.2.0] - 2026-06-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 While the major version is `0`, minor releases may carry breaking changes.
 
+## [Unreleased]
+
+### Added
+
+- **In-chat slash commands** (v0.3) — `/reset` clears the current session's
+  history, `/config` shows the active non-sensitive settings, `/help` lists
+  commands. Handled before the agent query, scoped per-user (even in groups), so
+  a command never reaches the LLM or leaks into another member's group context.
+
 ## [0.2.0] - 2026-06-07
 
 The first feature release after the initial `0.1.0` tag. It adds the full

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Users talk to a bot in Octo (DM or group @mention). The bot sends messages to Cl
 - **Streaming output** — Real-time response delivery via Octo's stream API with 800 ms throttled flushes, typing indicators, and automatic fallback to plain messages.
 - **Group chat awareness** — Responds only to @mentions. Injects recent group conversation as context so Claude understands the discussion.
 - **Session persistence** — SQLite-backed conversation history (40-message sliding window) with automatic 7-day expiry.
+- **In-chat commands** — `/reset` clears the current conversation, `/config` shows the active settings, `/help` lists commands. Scoped per-user (even in groups).
 - **Rate limiting** — Per-session token bucket (default 5 req/min) with debounced rejection notices.
 - **Security by configuration** — `allowedTools` whitelist + per-session `cwdBase` isolation. No runtime permission prompts (headless mode).
 - **Zero infrastructure** — Single process, single SQLite file, `npm start` and go.
@@ -278,7 +279,6 @@ src/
 
 ## Known Limitations (v0.2)
 
-- **No slash commands** — `/reset`, `/config` and similar in-chat controls are not yet implemented (planned for v0.3).
 - **Per-session `cwdBase` isolation** — Each session (DM peer, or individual group member) gets its own SHA-256 hex sandbox under `cwdBase`, partitioned by the same key as conversation history; idle sandboxes (>7d) are auto-cleaned every 6h. Note: `cwdBase` separates sessions from each other but does not confine a session to its directory (absolute-path reads via Bash/Read remain possible) — see the Security Model section.
 - **Stateless sessions** — Uses the v1 `query()` API. Workspace state (open files, command history) does not persist across messages. The v2 Session API is planned for v0.3.
 - **Single bot** — One bot per process. Multi-bot support is planned for v0.3.
@@ -289,7 +289,7 @@ src/
 |---------|-------|
 | **v0.1** | Text messaging, streaming, session persistence, rate limiting, security model |
 | **v0.2** *(current)* | Media reception & sending (image/file/RichText), @mention, group context, per-session `cwdBase` isolation, self-hosted gateway, SSRF/prompt-injection hardening |
-| **v0.3** | v2 Session API, multi-bot support, `/reset` and `/config` commands, tool progress display |
+| **v0.3** | v2 Session API, multi-bot support, tool progress display |
 | **v1.0** | GROUP.md/THREAD.md configuration, webhook mode |
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Users talk to a bot in Octo (DM or group @mention). The bot sends messages to Cl
 - **Streaming output** — Real-time response delivery via Octo's stream API with 800 ms throttled flushes, typing indicators, and automatic fallback to plain messages.
 - **Group chat awareness** — Responds only to @mentions. Injects recent group conversation as context so Claude understands the discussion.
 - **Session persistence** — SQLite-backed conversation history (40-message sliding window) with automatic 7-day expiry.
-- **In-chat commands** — `/reset` clears the current conversation, `/config` shows the active settings, `/help` lists commands. Scoped per-user (even in groups); subject to the same per-session rate limit as normal messages.
+- **In-chat commands** — `/reset` clears your own session's stored history (not the shared recent-group-context cache), `/config` shows the active settings, `/help` lists commands. Scoped per-user (even in groups); subject to the same per-session rate limit as normal messages.
 - **Rate limiting** — Per-session token bucket (default 5 req/min) with debounced rejection notices.
 - **Security by configuration** — `allowedTools` whitelist + per-session `cwdBase` isolation. No runtime permission prompts (headless mode).
 - **Zero infrastructure** — Single process, single SQLite file, `npm start` and go.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Users talk to a bot in Octo (DM or group @mention). The bot sends messages to Cl
 - **Streaming output** — Real-time response delivery via Octo's stream API with 800 ms throttled flushes, typing indicators, and automatic fallback to plain messages.
 - **Group chat awareness** — Responds only to @mentions. Injects recent group conversation as context so Claude understands the discussion.
 - **Session persistence** — SQLite-backed conversation history (40-message sliding window) with automatic 7-day expiry.
-- **In-chat commands** — `/reset` clears the current conversation, `/config` shows the active settings, `/help` lists commands. Scoped per-user (even in groups).
+- **In-chat commands** — `/reset` clears the current conversation, `/config` shows the active settings, `/help` lists commands. Scoped per-user (even in groups); subject to the same per-session rate limit as normal messages.
 - **Rate limiting** — Per-session token bucket (default 5 req/min) with debounced rejection notices.
 - **Security by configuration** — `allowedTools` whitelist + per-session `cwdBase` isolation. No runtime permission prompts (headless mode).
 - **Zero infrastructure** — Single process, single SQLite file, `npm start` and go.

--- a/src/__tests__/commands.test.ts
+++ b/src/__tests__/commands.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Slash command tests (v0.3): /reset, /config, /help, unknown, and the
+ * "not a command" passthrough.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { parseCommand, handleCommand } from '../commands.js';
+import { SessionStore } from '../session-store.js';
+import { createAdapter, type DbAdapter } from '../db-adapter.js';
+import type { Config } from '../config.js';
+
+function makeConfig(overrides?: Partial<Config['sdk']>): Config {
+  return {
+    botToken: 'bf_test',
+    apiUrl: 'https://octo.example.com',
+    cwdBase: '/tmp/base',
+    cwd: '/tmp/base',
+    dataDir: '/tmp/data',
+    sdk: {
+      allowedTools: '*',
+      permissionMode: 'bypassPermissions',
+      settingSources: ['user'],
+      ...overrides,
+    },
+    rateLimit: { maxPerMinute: 5 },
+    context: { maxContextChars: 6000, historyLimit: 40 },
+    maxResponseChars: 1000,
+  };
+}
+
+describe('parseCommand', () => {
+  it('parses a bare command', () => {
+    expect(parseCommand('/reset')).toEqual({ name: 'reset', args: '' });
+  });
+
+  it('lowercases the command name and trims args', () => {
+    expect(parseCommand('/Config   verbose ')).toEqual({ name: 'config', args: 'verbose' });
+  });
+
+  it('only considers the first line', () => {
+    expect(parseCommand('/reset\nplease')).toEqual({ name: 'reset', args: '' });
+  });
+
+  it('tolerates leading/trailing whitespace on the line', () => {
+    expect(parseCommand('   /help  ')).toEqual({ name: 'help', args: '' });
+  });
+
+  it('returns null when slash is not leading', () => {
+    expect(parseCommand('please /reset')).toBeNull();
+  });
+
+  it('returns null for plain text', () => {
+    expect(parseCommand('hello there')).toBeNull();
+  });
+
+  it('returns null for a lone slash', () => {
+    expect(parseCommand('/')).toBeNull();
+  });
+
+  it('captures hyphenated/underscored command names', () => {
+    expect(parseCommand('/foo-bar_baz x')).toEqual({ name: 'foo-bar_baz', args: 'x' });
+  });
+});
+
+describe('handleCommand', () => {
+  let adapter: DbAdapter;
+  let store: SessionStore;
+  const config = makeConfig();
+  const KEY = 'user-001';
+
+  beforeEach(() => {
+    adapter = createAdapter(':memory:');
+    store = new SessionStore(adapter);
+    store.init();
+  });
+
+  afterEach(() => {
+    store.close();
+  });
+
+  it('passes through non-command text (handled=false)', () => {
+    const r = handleCommand('what is the weather', KEY, store, config);
+    expect(r.handled).toBe(false);
+    expect(r.reply).toBeUndefined();
+  });
+
+  it('/reset clears the session history and confirms', () => {
+    store.getOrCreate(KEY, 'ch', 1);
+    store.appendUser(KEY, 'first message', 1);
+    store.appendAssistant(KEY, 'a reply', 1);
+    expect(store.buildHistoryPrefix(KEY, 40)).not.toBe('');
+
+    const r = handleCommand('/reset', KEY, store, config);
+    expect(r.handled).toBe(true);
+    expect(r.reply).toMatch(/cleared/i);
+    expect(store.buildHistoryPrefix(KEY, 40)).toBe('');
+  });
+
+  it('/reset is scoped to the calling sessionKey only', () => {
+    store.getOrCreate('group:alice', 'ch', 2);
+    store.appendUser('group:alice', 'alice msg', 1);
+    store.getOrCreate('group:bob', 'ch', 2);
+    store.appendUser('group:bob', 'bob msg', 1);
+
+    handleCommand('/reset', 'group:alice', store, config);
+
+    expect(store.buildHistoryPrefix('group:alice', 40)).toBe('');
+    // Bob's history is untouched.
+    expect(store.buildHistoryPrefix('group:bob', 40)).toContain('bob msg');
+  });
+
+  it('/config shows non-sensitive settings without leaking secrets', () => {
+    const r = handleCommand('/config', KEY, store, makeConfig({ allowedTools: ['Read', 'Grep'] }));
+    expect(r.handled).toBe(true);
+    expect(r.reply).toContain('allowedTools: Read, Grep');
+    expect(r.reply).toContain('permissionMode: bypassPermissions');
+    // Never echo the bot token.
+    expect(r.reply).not.toContain('bf_test');
+  });
+
+  it('/config renders the wildcard toolset readably', () => {
+    const r = handleCommand('/config', KEY, store, config);
+    expect(r.reply).toContain('* (all SDK tools)');
+  });
+
+  it('/help lists the commands', () => {
+    const r = handleCommand('/help', KEY, store, config);
+    expect(r.handled).toBe(true);
+    expect(r.reply).toContain('/reset');
+    expect(r.reply).toContain('/config');
+  });
+
+  it('unknown command is reported (handled=true) instead of reaching the agent', () => {
+    const r = handleCommand('/frobnicate', KEY, store, config);
+    expect(r.handled).toBe(true);
+    expect(r.reply).toMatch(/unknown command/i);
+    expect(r.reply).toContain('/frobnicate');
+  });
+
+  it('a path-like message that does not lead with a known slash word is still parsed as a command token', () => {
+    // Documents current behavior: "/etc" leads with a slash, so it is treated
+    // as an (unknown) command rather than forwarded. Acceptable — real prompts
+    // rarely start with a bare "/etc"; users can prefix with text if needed.
+    const r = handleCommand('/etc/passwd please read', KEY, store, config);
+    expect(r.handled).toBe(true);
+    expect(r.reply).toMatch(/unknown command/i);
+  });
+});

--- a/src/__tests__/commands.test.ts
+++ b/src/__tests__/commands.test.ts
@@ -60,6 +60,20 @@ describe('parseCommand', () => {
   it('captures hyphenated/underscored command names', () => {
     expect(parseCommand('/foo-bar_baz x')).toEqual({ name: 'foo-bar_baz', args: 'x' });
   });
+
+  it('requires a token boundary after the command name (no glued suffix)', () => {
+    // Path/route-like text must NOT parse as a command — guards against
+    // accidentally triggering destructive /reset via "/reset/foo".
+    expect(parseCommand('/reset/foo')).toBeNull();
+    expect(parseCommand('/config.json')).toBeNull();
+    expect(parseCommand('/help.md')).toBeNull();
+    expect(parseCommand('/etc/passwd please read')).toBeNull();
+  });
+
+  it('still parses a command with whitespace-separated args', () => {
+    expect(parseCommand('/reset')).toEqual({ name: 'reset', args: '' });
+    expect(parseCommand('/config now')).toEqual({ name: 'config', args: 'now' });
+  });
 });
 
 describe('handleCommand', () => {
@@ -160,12 +174,18 @@ describe('handleCommand', () => {
     expect(r.reply).toContain('/frobnicate');
   });
 
-  it('a path-like message that does not lead with a known slash word is still parsed as a command token', () => {
-    // Documents current behavior: "/etc" leads with a slash, so it is treated
-    // as an (unknown) command rather than forwarded. Acceptable — real prompts
-    // rarely start with a bare "/etc"; users can prefix with text if needed.
-    const r = handleCommand('/etc/passwd please read', KEY, store, config);
-    expect(r.handled).toBe(true);
-    expect(r.reply).toMatch(/unknown command/i);
+  it('path-like text glued to a command name is NOT treated as a command', () => {
+    // "/reset/foo" must fall through to the agent, never trigger /reset.
+    const r = handleCommand('/reset/foo', KEY, store, config);
+    expect(r.handled).toBe(false);
+  });
+
+  it('does not clear history for path-like "/reset/..." text', () => {
+    store.getOrCreate(KEY, 'ch', 1);
+    store.appendUser(KEY, 'keep me', 1);
+    const r = handleCommand('/reset/foo', KEY, store, config, 7);
+    expect(r.handled).toBe(false);
+    expect(store.buildHistoryPrefix(KEY, 40)).toContain('keep me');
+    expect(store.getResetBarrier(KEY)).toBeUndefined();
   });
 });

--- a/src/__tests__/commands.test.ts
+++ b/src/__tests__/commands.test.ts
@@ -109,6 +109,29 @@ describe('handleCommand', () => {
     expect(store.buildHistoryPrefix('group:bob', 40)).toContain('bob msg');
   });
 
+  it('/reset records a persisted reset barrier at the command message_seq', () => {
+    store.getOrCreate(KEY, 'ch', 2);
+    handleCommand('/reset', KEY, store, config, 42);
+    expect(store.getResetBarrier(KEY)).toBe(42);
+  });
+
+  it('/reset barrier is monotonic — a later reset raises it, an older one does not', () => {
+    handleCommand('/reset', KEY, store, config, 10);
+    handleCommand('/reset', KEY, store, config, 25);
+    expect(store.getResetBarrier(KEY)).toBe(25);
+    // Out-of-order/older seq must not lower the barrier.
+    handleCommand('/reset', KEY, store, config, 5);
+    expect(store.getResetBarrier(KEY)).toBe(25);
+  });
+
+  it('/reset without a message_seq still clears history (no barrier set)', () => {
+    store.getOrCreate(KEY, 'ch', 2);
+    store.appendUser(KEY, 'x', 1);
+    handleCommand('/reset', KEY, store, config);
+    expect(store.buildHistoryPrefix(KEY, 40)).toBe('');
+    expect(store.getResetBarrier(KEY)).toBeUndefined();
+  });
+
   it('/config shows non-sensitive settings without leaking secrets', () => {
     const r = handleCommand('/config', KEY, store, makeConfig({ allowedTools: ['Read', 'Grep'] }));
     expect(r.handled).toBe(true);

--- a/src/__tests__/e2e.test.ts
+++ b/src/__tests__/e2e.test.ts
@@ -199,6 +199,32 @@ describe('E2E smoke tests', () => {
     expect(history).toContain('[assistant]: Hello from Claude');
   });
 
+  // --- 1b. v0.3 slash commands through the real pipeline ---
+
+  it('/reset clears history, replies, and does NOT call the agent', async () => {
+    // Seed a prior turn.
+    await simulateMessage(makeDmMsg('first'), config, store, router, groupContext, streamRelay);
+    expect(store.buildHistoryPrefix(USER_UID, 40)).not.toBe('');
+    (queryAgent as ReturnType<typeof vi.fn>).mockClear();
+    (sendMessage as ReturnType<typeof vi.fn>).mockClear();
+
+    await simulateMessage(makeDmMsg('/reset'), config, store, router, groupContext, streamRelay);
+
+    // Command path: agent untouched, a confirmation sent, history cleared.
+    expect(queryAgent).not.toHaveBeenCalled();
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    const reply = (sendMessage as ReturnType<typeof vi.fn>).mock.calls[0][0].content as string;
+    expect(reply).toMatch(/cleared/i);
+    expect(store.buildHistoryPrefix(USER_UID, 40)).toBe('');
+  });
+
+  it('/config replies without invoking the agent', async () => {
+    await simulateMessage(makeDmMsg('/config'), config, store, router, groupContext, streamRelay);
+    expect(queryAgent).not.toHaveBeenCalled();
+    const reply = (sendMessage as ReturnType<typeof vi.fn>).mock.calls[0][0].content as string;
+    expect(reply).toContain('permissionMode');
+  });
+
   // --- 2. Group @mention triggers processing ---
 
   it('Group @mention: triggers agent and stores history', async () => {

--- a/src/__tests__/e2e.test.ts
+++ b/src/__tests__/e2e.test.ts
@@ -57,6 +57,7 @@ import { handleMessage } from '../index.js';
 import {
   sendMessage,
   sendReadReceipt,
+  getChannelMessages,
 } from '../octo/api.js';
 import { ChannelType, MessageType } from '../octo/types.js';
 import type { BotMessage } from '../octo/types.js';
@@ -223,6 +224,39 @@ describe('E2E smoke tests', () => {
     expect(queryAgent).not.toHaveBeenCalled();
     const reply = (sendMessage as ReturnType<typeof vi.fn>).mock.calls[0][0].content as string;
     expect(reply).toContain('permissionMode');
+  });
+
+  it('/reset barrier prevents group backfill from resurrecting pre-reset history', async () => {
+    // Regression for the PR #62 review finding: /reset deletes the local
+    // session, but G4 cold-start backfill could refetch + re-seed the same
+    // history on the next group turn (esp. after a restart). The persisted
+    // reset barrier must filter out messages at/before the reset seq.
+    const CH = 'group-reset-test'; // unique channel → guarantees cold-start backfill
+    const uid = USER_UID;
+    const sessionKey = `${CH}:${uid}`;
+    const g = (content: string, seq: number) =>
+      makeGroupMsg(content, true, { channel_id: CH, message_seq: seq, from_uid: uid });
+
+    // Pre-reset channel history that the sync API would return on cold start.
+    (getChannelMessages as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
+      { from_uid: uid, from_name: 'TestUser', content: 'SECRET pre-reset line', type: 1, message_seq: 5 },
+    ]);
+
+    // User issues /reset at seq 10 (after that historical message).
+    await simulateMessage(g('/reset', 10), config, store, router, groupContext, streamRelay);
+    expect(store.getResetBarrier(sessionKey)).toBe(10);
+
+    // Next group turn at seq 11: local history is empty → G4 backfill fires and
+    // fetches the pre-reset line (seq 5). The barrier must drop it.
+    mockQueryYield('fresh answer');
+    await simulateMessage(g('hello again', 11), config, store, router, groupContext, streamRelay);
+
+    // The agent's systemPrompt/history must NOT contain the pre-reset content.
+    const call = (queryAgent as ReturnType<typeof vi.fn>).mock.calls.at(-1)!;
+    const historyPrefix = call[1] as string;
+    expect(historyPrefix).not.toContain('SECRET pre-reset line');
+    // And the persisted store must not have re-seeded it either.
+    expect(store.buildHistoryPrefix(sessionKey, 40)).not.toContain('SECRET pre-reset line');
   });
 
   // --- 2. Group @mention triggers processing ---

--- a/src/__tests__/e2e.test.ts
+++ b/src/__tests__/e2e.test.ts
@@ -217,6 +217,8 @@ describe('E2E smoke tests', () => {
     const reply = (sendMessage as ReturnType<typeof vi.fn>).mock.calls[0][0].content as string;
     expect(reply).toMatch(/cleared/i);
     expect(store.buildHistoryPrefix(USER_UID, 40)).toBe('');
+    // G8: a handled command still gets a read receipt.
+    expect(sendReadReceipt).toHaveBeenCalled();
   });
 
   it('/config replies without invoking the agent', async () => {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,0 +1,119 @@
+/**
+ * In-chat slash commands (v0.3).
+ *
+ * Users can control their session without leaving the chat:
+ *   /reset            — clear this session's conversation history
+ *   /config           — show the effective per-session settings
+ *   /help             — list available commands
+ *
+ * Commands are matched on the FIRST line of the cleaned message text (after the
+ * router has stripped any leading @bot mention), so `@bot /reset` works in
+ * groups. Matching is case-insensitive and tolerant of surrounding whitespace.
+ *
+ * A command is scoped to the sessionKey of the message — in a group, `/reset`
+ * only clears the calling member's own session (group history is per-user), not
+ * the whole room.
+ */
+
+import type { Config } from './config.js';
+import type { SessionStore } from './session-store.js';
+
+/** Result of attempting to handle a command. */
+export interface CommandResult {
+  /** True when the text was a recognized command and was handled. */
+  handled: boolean;
+  /** Reply to send back to the user (only meaningful when handled). */
+  reply?: string;
+}
+
+/** Not a command at all — let the normal agent pipeline take over. */
+const NOT_A_COMMAND: CommandResult = { handled: false };
+
+/**
+ * Parse the command token from a message body. Returns the lowercased command
+ * name (without the leading slash) and the trimmed argument string, or null
+ * when the text does not start with a slash command.
+ *
+ * Only the first whitespace-delimited token on the first line is considered, so
+ * a message that merely mentions "/reset" mid-sentence is NOT treated as a
+ * command — it must lead.
+ */
+export function parseCommand(
+  body: string,
+): { name: string; args: string } | null {
+  const firstLine = body.split('\n', 1)[0]?.trim() ?? '';
+  // Must start with a single slash followed by a letter (avoid matching paths
+  // like "/etc/passwd" being read as a command — those start with a slash but
+  // we still treat a leading-slash word as a command; the command set is
+  // closed, so an unknown command is reported rather than silently run).
+  const match = firstLine.match(/^\/([a-zA-Z][a-zA-Z0-9_-]*)\s*(.*)$/);
+  if (!match) return null;
+  return { name: match[1].toLowerCase(), args: match[2].trim() };
+}
+
+/** Human-readable list of supported commands. */
+const HELP_TEXT = [
+  'Available commands:',
+  '• `/reset` — clear this conversation’s history (starts fresh)',
+  '• `/config` — show the current session settings',
+  '• `/help` — show this message',
+].join('\n');
+
+/**
+ * Render the effective, non-sensitive per-session configuration. Deliberately
+ * omits secrets (botToken, apiUrl host details beyond scheme) — this reply is
+ * visible to any user who can message the bot.
+ */
+function renderConfig(config: Config): string {
+  const tools =
+    config.sdk.allowedTools === '*'
+      ? '* (all SDK tools)'
+      : config.sdk.allowedTools.join(', ');
+  return [
+    'Current settings:',
+    `• model: ${config.sdk.model ?? '(SDK default)'}`,
+    `• allowedTools: ${tools}`,
+    `• permissionMode: ${config.sdk.permissionMode}`,
+    `• rateLimit: ${config.rateLimit.maxPerMinute} req/min`,
+    `• historyLimit: ${config.context.historyLimit} messages`,
+  ].join('\n');
+}
+
+/**
+ * Try to handle `body` as a slash command for the given session.
+ *
+ * Returns `{ handled: false }` when the text is not a command (caller proceeds
+ * with the normal agent pipeline). When handled, returns the reply to send and
+ * performs any side effect (e.g. clearing history) immediately.
+ */
+export function handleCommand(
+  body: string,
+  sessionKey: string,
+  store: SessionStore,
+  config: Config,
+): CommandResult {
+  const parsed = parseCommand(body);
+  if (!parsed) return NOT_A_COMMAND;
+
+  switch (parsed.name) {
+    case 'reset': {
+      // Scoped to THIS sessionKey only — in a group, clears the caller's own
+      // per-user history, never the whole room.
+      store.deleteSession(sessionKey);
+      return { handled: true, reply: '✓ Conversation history cleared. Starting fresh.' };
+    }
+    case 'config': {
+      return { handled: true, reply: renderConfig(config) };
+    }
+    case 'help': {
+      return { handled: true, reply: HELP_TEXT };
+    }
+    default:
+      // A leading-slash token we don't recognize. Report it rather than
+      // silently forwarding to the agent, so typos are visible.
+      return {
+        handled: true,
+        reply: `Unknown command: /${parsed.name}\n\n${HELP_TEXT}`,
+      };
+  }
+}

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -48,19 +48,22 @@ export function parseCommand(
   body: string,
 ): { name: string; args: string } | null {
   const firstLine = body.split('\n', 1)[0]?.trim() ?? '';
-  // Must start with a single slash followed by a letter (avoid matching paths
-  // like "/etc/passwd" being read as a command — those start with a slash but
-  // we still treat a leading-slash word as a command; the command set is
-  // closed, so an unknown command is reported rather than silently run).
-  const match = firstLine.match(/^\/([a-zA-Z][a-zA-Z0-9_-]*)\s*(.*)$/);
+  // The command name must be followed by a TOKEN BOUNDARY — end-of-line or
+  // whitespace — before any args. Without this, path/route-like text such as
+  // `/reset/foo`, `/config.json`, or `/help.md` would be parsed as the bare
+  // command and could trigger a destructive action (`/reset`). Requiring `\s+`
+  // (or EOL) after the name means only a real command token matches; anything
+  // glued to the name (`/foo.bar`, `/a/b`) is NOT a command and falls through
+  // to the normal agent pipeline.
+  const match = firstLine.match(/^\/([a-zA-Z][a-zA-Z0-9_-]*)(?:\s+(.*))?$/);
   if (!match) return null;
-  return { name: match[1].toLowerCase(), args: match[2].trim() };
+  return { name: match[1].toLowerCase(), args: (match[2] ?? '').trim() };
 }
 
 /** Human-readable list of supported commands. */
 const HELP_TEXT = [
   'Available commands:',
-  '• `/reset` — clear this conversation’s history (starts fresh)',
+  '• `/reset` — clear your own conversation history (does not affect the shared group context)',
   '• `/config` — show the current session settings',
   '• `/help` — show this message',
 ].join('\n');

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -13,6 +13,12 @@
  * A command is scoped to the sessionKey of the message — in a group, `/reset`
  * only clears the calling member's own session (group history is per-user), not
  * the whole room.
+ *
+ * Note: commands are handled inside the router's processing callback, AFTER the
+ * per-session rate limit is applied. A user who has exhausted their token bucket
+ * therefore cannot run `/reset` or `/help` until it refills — control commands
+ * are rate-limited like normal messages. This is intentional (a flooder should
+ * not get a rate-limit bypass via slash commands); documented in the README.
  */
 
 import type { Config } from './config.js';
@@ -85,12 +91,17 @@ function renderConfig(config: Config): string {
  * Returns `{ handled: false }` when the text is not a command (caller proceeds
  * with the normal agent pipeline). When handled, returns the reply to send and
  * performs any side effect (e.g. clearing history) immediately.
+ *
+ * `messageSeq` is the seq of the command message itself; `/reset` records it as
+ * a persisted barrier so cold-start group backfill cannot resurrect pre-reset
+ * history on a later turn.
  */
 export function handleCommand(
   body: string,
   sessionKey: string,
   store: SessionStore,
   config: Config,
+  messageSeq?: number,
 ): CommandResult {
   const parsed = parseCommand(body);
   if (!parsed) return NOT_A_COMMAND;
@@ -100,6 +111,12 @@ export function handleCommand(
       // Scoped to THIS sessionKey only — in a group, clears the caller's own
       // per-user history, never the whole room.
       store.deleteSession(sessionKey);
+      // Persist a barrier at this message_seq so G4 cold-start backfill (which
+      // refetches channel history when the local cache is empty) cannot
+      // re-seed the history we just cleared — even across a process restart.
+      if (messageSeq !== undefined) {
+        store.setResetBarrier(sessionKey, messageSeq);
+      }
       return { handled: true, reply: '✓ Conversation history cleared. Starting fresh.' };
     }
     case 'config': {

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import type { HistoricalMessage } from './octo/api.js';
 import { ChannelType, MessageType } from './octo/types.js';
 import type { BotMessage } from './octo/types.js';
 import { resolveContent, tryResolveFile, resolveHistoricalMessagePlaceholder } from './inbound.js';
+import { handleCommand } from './commands.js';
 import { buildInlinedFileBody, truncateUtf8ByBytes } from './file-inline-wrap.js';
 import { Buffer } from 'node:buffer';
 import { join } from 'node:path';
@@ -141,6 +142,28 @@ export async function handleMessage(
     try {
       // --- Session ---
       store.getOrCreate(sessionKey, channelId, channelType);
+
+      // --- v0.3: in-chat slash commands (/reset, /config, /help) ---
+      // Handled before group-context caching, history append, and the agent
+      // query — so a command never reaches the LLM, is not stored as a turn,
+      // and does not leak into other members' group context. Only text
+      // messages carry cleanContent; non-text payloads skip this entirely.
+      // Scoped to this sessionKey (per-user, even in groups).
+      if (result.cleanContent !== undefined) {
+        const command = handleCommand(result.cleanContent, sessionKey, store, config);
+        if (command.handled) {
+          if (command.reply) {
+            await sendMessage({
+              apiUrl: config.apiUrl,
+              botToken: config.botToken,
+              channelId,
+              channelType,
+              content: command.reply,
+            });
+          }
+          return; // skip context, history, and the agent query entirely
+        }
+      }
 
       // --- Group context: refresh members + build context string ---
       let contextStr = '';

--- a/src/index.ts
+++ b/src/index.ts
@@ -161,6 +161,18 @@ export async function handleMessage(
               content: command.reply,
             });
           }
+          // G8: send a read receipt for command messages too, mirroring the
+          // normal message path (otherwise handled commands would be the only
+          // processed messages that never get marked read).
+          if (msg.message_id && msg.channel_id && msg.channel_type !== undefined) {
+            sendReadReceipt({
+              apiUrl: config.apiUrl,
+              botToken: config.botToken,
+              channelId: msg.channel_id,
+              channelType: msg.channel_type,
+              messageIds: [msg.message_id],
+            }).catch((err) => console.error(`[cc-channel-octo] readReceipt failed: ${String(err)}`));
+          }
           return; // skip context, history, and the agent query entirely
         }
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -150,7 +150,7 @@ export async function handleMessage(
       // messages carry cleanContent; non-text payloads skip this entirely.
       // Scoped to this sessionKey (per-user, even in groups).
       if (result.cleanContent !== undefined) {
-        const command = handleCommand(result.cleanContent, sessionKey, store, config);
+        const command = handleCommand(result.cleanContent, sessionKey, store, config, msg.message_seq);
         if (command.handled) {
           if (command.reply) {
             await sendMessage({
@@ -345,7 +345,11 @@ export async function handleMessage(
             // turns (PR#33 follow-up: previously every backfilled message
             // was stored as user, which made the LLM see its own past words
             // as if the user had said them).
-            seedHistoryFromApi(store, sessionKey, apiMessages, botId);
+            //
+            // v0.3 /reset barrier: skip any historical message at or before the
+            // reset point so a cleared conversation is not resurrected here.
+            const resetBarrier = store.getResetBarrier(sessionKey);
+            seedHistoryFromApi(store, sessionKey, apiMessages, botId, resetBarrier);
             historyPrefix = store.buildSegmentedHistoryPrefix(sessionKey, config.context.historyLimit);
           }
         } catch (err) {
@@ -493,12 +497,19 @@ function seedHistoryFromApi(
   sessionKey: string,
   apiMessages: HistoricalMessage[],
   botId: string,
+  resetBarrier?: number,
 ): void {
   // Older messages first — sync API returns newest-first depending on pull_mode.
   const ordered = apiMessages
     .slice()
     .sort((a, b) => (a.message_seq ?? 0) - (b.message_seq ?? 0));
   for (const m of ordered) {
+    // v0.3 /reset barrier: never resurrect messages at or before the reset
+    // point. Messages with no seq are treated as un-orderable and skipped when a
+    // barrier exists (we cannot prove they post-date the reset).
+    if (resetBarrier !== undefined && (m.message_seq ?? 0) <= resetBarrier) {
+      continue;
+    }
     const placeholder = resolveHistoricalMessagePlaceholder(m.type, m.name);
     const content = m.content && m.content.trim() !== ''
       ? m.content

--- a/src/session-store.ts
+++ b/src/session-store.ts
@@ -53,6 +53,15 @@ CREATE TABLE IF NOT EXISTS group_members (
   PRIMARY KEY(group_id, uid)
 );
 
+-- v0.3 /reset barrier: the message_seq at which a session was intentionally
+-- cleared. Kept in a SEPARATE table (no FK to sessions) so it SURVIVES
+-- deleteSession() and a process restart — G4 cold-start backfill consults it to
+-- avoid resurrecting pre-reset history. One row per session that ever reset.
+CREATE TABLE IF NOT EXISTS reset_barriers (
+  session_id TEXT PRIMARY KEY,
+  reset_seq INTEGER NOT NULL
+);
+
 CREATE INDEX IF NOT EXISTS idx_messages_session_id ON messages(session_id, id);
 `;
 
@@ -78,6 +87,8 @@ export class SessionStore {
   private selectRecentMessages!: PreparedStatement;
   private deleteExpired!: PreparedStatement;
   private deleteSessionStmt!: PreparedStatement;
+  private upsertResetBarrier!: PreparedStatement;
+  private selectResetBarrier!: PreparedStatement;
 
   /** Tracks the last message_seq at which the bot replied, per group session key. */
   private lastBotReplySeq = new Map<string, number>();
@@ -123,6 +134,14 @@ export class SessionStore {
     );
     this.deleteExpired = this.adapter.prepare('DELETE FROM sessions WHERE updated_at < ?');
     this.deleteSessionStmt = this.adapter.prepare('DELETE FROM sessions WHERE id = ?');
+    this.upsertResetBarrier = this.adapter.prepare(
+      'INSERT INTO reset_barriers (session_id, reset_seq) VALUES (?, ?) ' +
+        'ON CONFLICT(session_id) DO UPDATE SET reset_seq = excluded.reset_seq ' +
+        'WHERE excluded.reset_seq > reset_barriers.reset_seq',
+    );
+    this.selectResetBarrier = this.adapter.prepare(
+      'SELECT reset_seq FROM reset_barriers WHERE session_id = ?',
+    );
   }
 
   getOrCreate(id: string, channelId: string, channelType: number): Session {
@@ -176,6 +195,27 @@ export class SessionStore {
 
   deleteSession(sessionId: string): void {
     this.deleteSessionStmt.run(sessionId);
+  }
+
+  /**
+   * v0.3 /reset: record a barrier so cold-start backfill never resurrects
+   * history at or before `resetSeq`. Persisted independently of the session row
+   * (survives deleteSession + restart). Monotonic — a later reset raises the
+   * barrier, an out-of-order/older seq is ignored.
+   *
+   * `resetSeq` is the message_seq of the /reset command itself; everything up to
+   * and including it is considered intentionally discarded.
+   */
+  setResetBarrier(sessionId: string, resetSeq: number): void {
+    this.upsertResetBarrier.run(sessionId, resetSeq);
+  }
+
+  /** Return the reset barrier seq for a session, or undefined if never reset. */
+  getResetBarrier(sessionId: string): number | undefined {
+    const row = this.selectResetBarrier.get(sessionId) as
+      | { reset_seq: number }
+      | undefined;
+    return row?.reset_seq;
   }
 
   close(): void {


### PR DESCRIPTION
First v0.3 roadmap item: in-chat slash commands.

## What changed and why

Users can now control their session without leaving the chat:

- `/reset` — clear this session's conversation history
- `/config` — show the active **non-sensitive** settings (model, allowedTools, permissionMode, rate/history limits; never echoes the bot token)
- `/help` — list commands; an unknown `/command` is reported rather than silently forwarded to the agent

**Design:**
- New `src/commands.ts` — a pure `parseCommand` + `handleCommand` (no I/O beyond the injected `SessionStore`), so it's trivially unit-testable.
- Wired into `handleMessage` right after `getOrCreate` and **before** group-context caching, history append, and the agent query. So a command never reaches the LLM, is not stored as a turn, and does not leak into another member's group context.
- Scoped to the caller's `sessionKey` — `/reset` in a group clears only that member's per-user history, never the whole room.
- Only text messages (which carry `cleanContent`) are considered; non-text payloads skip the check.

## Files modified

- `src/commands.ts` (new), `src/index.ts` (wiring + import)
- `src/__tests__/commands.test.ts` (new, 16 tests), `src/__tests__/e2e.test.ts` (+2 real-pipeline tests)
- `README.md` (features/limitations/roadmap), `CHANGELOG.md` (Unreleased)

## Test results

- `npm run type-check` — clean
- `npm test` — **762 passed** (+18)
- `npm run lint` — 0 warnings
- `npm run build` — clean

## Notes

- A message that leads with an unknown slash token (e.g. `/etc/passwd please read`) is reported as an unknown command rather than forwarded. Documented in tests; acceptable since real prompts rarely lead with a bare slash, and users can prefix with text.

Roadmap: `/reset` & `/config` removed from the v0.3 row (shipped here).