### PR TITLE
feat(agent): tool progress display (v0.3, opt-in)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ While the major version is `0`, minor releases may carry breaking changes.
 
 ### Added
 
+- **Tool progress display** (v0.3, opt-in) — with `sdk.toolProgress`
+  (`CC_OCTO_SDK_TOOL_PROGRESS=true`), the bot posts brief `🔧 Running <tool>…`
+  notices as the agent invokes tools. `queryAgent` gained a non-breaking
+  `onToolUse` callback (guarded so a throwing callback never breaks the stream);
+  `index.ts` dedups consecutive repeats and caps notices per turn.
 - **In-chat slash commands** (v0.3) — `/reset` clears the current session's
   history, `/config` shows the active non-sensitive settings, `/help` lists
   commands. Handled before the agent query, scoped per-user (even in groups), so

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Users talk to a bot in Octo (DM or group @mention). The bot sends messages to Cl
 ## Features
 
 - **Streaming output** — Real-time response delivery via Octo's stream API with 800 ms throttled flushes, typing indicators, and automatic fallback to plain messages.
+- **Tool progress** *(opt-in)* — With `sdk.toolProgress` enabled, the bot posts brief `🔧 Running <tool>…` notices as the agent invokes tools, so users see activity during long tool-heavy turns (deduped + capped per turn).
 - **Group chat awareness** — Responds only to @mentions. Injects recent group conversation as context so Claude understands the discussion.
 - **Session persistence** — SQLite-backed conversation history (40-message sliding window) with automatic 7-day expiry.
 - **In-chat commands** — `/reset` clears your own session's stored history (not the shared recent-group-context cache), `/config` shows the active settings, `/help` lists commands. Scoped per-user (even in groups); subject to the same per-session rate limit as normal messages.
@@ -94,6 +95,7 @@ Three-level priority: **environment variables** > **config.json** > **defaults**
 | `sdk.maxTurns` | `CC_OCTO_SDK_MAX_TURNS` | *(SDK default)* | Max agentic turns per query |
 | `sdk.systemPrompt` | `CC_OCTO_SDK_SYSTEM_PROMPT` | *(built-in)* | Custom system prompt |
 | `sdk.settingSources` | `CC_OCTO_SDK_SETTING_SOURCES` | `user` | Comma-separated setting sources (e.g. `user,project`) |
+| `sdk.toolProgress` | `CC_OCTO_SDK_TOOL_PROGRESS` | `false` | When true, post `🔧 Running <tool>…` notices as the agent invokes tools (deduped, capped per turn) |
 | `sdk.anthropicBaseUrl` | `ANTHROPIC_BASE_URL` | *(unset)* | Override the upstream Claude API endpoint. See [Self-hosted gateway](#self-hosted-gateway) below. |
 | `rateLimit.maxPerMinute` | `CC_OCTO_RATE_LIMIT_MAX_PER_MINUTE` | `5` | Max requests per minute per session |
 | `context.maxContextChars` | `CC_OCTO_CONTEXT_MAX_CHARS` | `6000` | Max characters of group context injected into prompts |
@@ -289,7 +291,7 @@ src/
 |---------|-------|
 | **v0.1** | Text messaging, streaming, session persistence, rate limiting, security model |
 | **v0.2** *(current)* | Media reception & sending (image/file/RichText), @mention, group context, per-session `cwdBase` isolation, self-hosted gateway, SSRF/prompt-injection hardening |
-| **v0.3** | v2 Session API, multi-bot support, tool progress display |
+| **v0.3** | v2 Session API, multi-bot support |
 | **v1.0** | GROUP.md/THREAD.md configuration, webhook mode |
 
 ## Contributing

--- a/src/__tests__/agent-bridge-query.test.ts
+++ b/src/__tests__/agent-bridge-query.test.ts
@@ -239,4 +239,88 @@ describe('queryAgent', () => {
     }
     expect(chunks).toEqual(['actual content']);
   });
+
+  // --- v0.3 tool progress: onToolUse callback ---
+
+  it('fires onToolUse for each tool_use block, in order', async () => {
+    const stream = createMockStream([
+      {
+        type: 'assistant',
+        message: {
+          content: [
+            { type: 'tool_use', name: 'Bash', input: {} },
+            { type: 'text', text: 'thinking' },
+            { type: 'tool_use', name: 'Read', input: {} },
+          ],
+        },
+      },
+    ]);
+    mockQuery.mockReturnValue(stream);
+
+    const tools: string[] = [];
+    const chunks: string[] = [];
+    for await (const chunk of queryAgent('test', '', '', makeConfig(), undefined, (t) => tools.push(t))) {
+      chunks.push(chunk);
+    }
+    expect(tools).toEqual(['Bash', 'Read']);
+    expect(chunks).toEqual(['thinking']);
+  });
+
+  it('uses a fallback name when a tool_use block has no name', async () => {
+    const stream = createMockStream([
+      { type: 'assistant', message: { content: [{ type: 'tool_use', input: {} }] } },
+    ]);
+    mockQuery.mockReturnValue(stream);
+
+    const tools: string[] = [];
+    for await (const _ of queryAgent('t', '', '', makeConfig(), undefined, (t) => tools.push(t))) {
+      void _;
+    }
+    expect(tools).toEqual(['tool']);
+  });
+
+  it('a throwing onToolUse callback never breaks the stream', async () => {
+    const stream = createMockStream([
+      {
+        type: 'assistant',
+        message: {
+          content: [
+            { type: 'tool_use', name: 'Bash', input: {} },
+            { type: 'text', text: 'still here' },
+          ],
+        },
+      },
+    ]);
+    mockQuery.mockReturnValue(stream);
+
+    const chunks: string[] = [];
+    const onToolUse = (): void => {
+      throw new Error('callback boom');
+    };
+    for await (const chunk of queryAgent('t', '', '', makeConfig(), undefined, onToolUse)) {
+      chunks.push(chunk);
+    }
+    expect(chunks).toEqual(['still here']);
+  });
+
+  it('does not require onToolUse (tool_use blocks are simply ignored)', async () => {
+    const stream = createMockStream([
+      {
+        type: 'assistant',
+        message: {
+          content: [
+            { type: 'tool_use', name: 'Bash', input: {} },
+            { type: 'text', text: 'ok' },
+          ],
+        },
+      },
+    ]);
+    mockQuery.mockReturnValue(stream);
+
+    const chunks: string[] = [];
+    for await (const chunk of queryAgent('t', '', '', makeConfig())) {
+      chunks.push(chunk);
+    }
+    expect(chunks).toEqual(['ok']);
+  });
 });

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -28,7 +28,7 @@ const CC_VARS = [
   'CC_OCTO_RATE_LIMIT_MAX_PER_MINUTE', 'CC_OCTO_CONTEXT_MAX_CHARS',
   'CC_OCTO_CONTEXT_HISTORY_LIMIT', 'CC_OCTO_BOT_BLOCKLIST',
   'CC_OCTO_MENTION_FREE_GROUPS', 'CC_OCTO_MAX_RESPONSE_CHARS',
-  'ANTHROPIC_BASE_URL',
+  'ANTHROPIC_BASE_URL', 'CC_OCTO_SDK_TOOL_PROGRESS',
 ];
 
 function setup() {
@@ -608,4 +608,47 @@ describe('Q3: cwdBase + deprecated cwd alias', () => {
     process.env.CC_OCTO_CWDBASE = '  ';
     expect(loadConfig(path).cwdBase).toBe('/explicit/base');
   });
+});
+
+// ─── v0.3: sdk.toolProgress ────────────────────────────────────────────
+
+describe('v0.3: tool progress toggle', () => {
+  beforeEach(setup);
+  afterEach(teardown);
+
+  it('defaults to undefined (off)', () => {
+    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
+    expect(loadConfig(path).sdk.toolProgress).toBeUndefined();
+  });
+
+  it('reads sdk.toolProgress=true from the config file', () => {
+    const path = writeConfig({
+      botToken: 'bf_t',
+      apiUrl: 'https://a',
+      sdk: { toolProgress: true },
+    });
+    expect(loadConfig(path).sdk.toolProgress).toBe(true);
+  });
+
+  it.each(['true', '1', 'yes', 'on', 'TRUE', 'On'])(
+    'CC_OCTO_SDK_TOOL_PROGRESS=%s enables it',
+    (val) => {
+      const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
+      process.env.CC_OCTO_SDK_TOOL_PROGRESS = val;
+      expect(loadConfig(path).sdk.toolProgress).toBe(true);
+    },
+  );
+
+  it.each(['false', '0', 'no', 'off', ''])(
+    'CC_OCTO_SDK_TOOL_PROGRESS=%s disables it',
+    (val) => {
+      const path = writeConfig({
+        botToken: 'bf_t',
+        apiUrl: 'https://a',
+        sdk: { toolProgress: true },
+      });
+      process.env.CC_OCTO_SDK_TOOL_PROGRESS = val;
+      expect(loadConfig(path).sdk.toolProgress).toBe(false);
+    },
+  );
 });

--- a/src/__tests__/e2e.test.ts
+++ b/src/__tests__/e2e.test.ts
@@ -228,6 +228,49 @@ describe('E2E smoke tests', () => {
     expect(reply).toContain('permissionMode');
   });
 
+  // --- v0.3 tool progress display ---
+
+  it('sends 🔧 progress messages when sdk.toolProgress is on, deduped', async () => {
+    // Mock queryAgent to drive the onToolUse callback (6th arg) like the SDK
+    // would, then yield the final answer.
+    (queryAgent as ReturnType<typeof vi.fn>).mockImplementation(
+      async function* (
+        _u: string, _h: string, _c: string, _cfg: Config, _ctx: unknown,
+        onToolUse?: (t: string) => void,
+      ) {
+        onToolUse?.('Bash');
+        onToolUse?.('Bash'); // consecutive repeat → collapsed
+        onToolUse?.('Read');
+        yield 'done';
+      },
+    );
+
+    const cfg = makeConfig({ sdk: { ...config.sdk, toolProgress: true } });
+    await simulateMessage(makeDmMsg('do work'), cfg, store, router, groupContext, streamRelay);
+
+    const sent = (sendMessage as ReturnType<typeof vi.fn>).mock.calls.map((c) => c[0].content as string);
+    const progress = sent.filter((s) => s.startsWith('🔧 Running'));
+    expect(progress).toEqual(['🔧 Running Bash…', '🔧 Running Read…']); // repeat collapsed
+    // The final answer is still delivered.
+    expect(sent.some((s) => s.includes('done'))).toBe(true);
+  });
+
+  it('sends NO progress messages when toolProgress is off (default)', async () => {
+    (queryAgent as ReturnType<typeof vi.fn>).mockImplementation(
+      async function* (
+        _u: string, _h: string, _c: string, _cfg: Config, _ctx: unknown,
+        onToolUse?: (t: string) => void,
+      ) {
+        onToolUse?.('Bash'); // callback should be undefined → no-op
+        yield 'done';
+      },
+    );
+
+    await simulateMessage(makeDmMsg('do work'), config, store, router, groupContext, streamRelay);
+    const sent = (sendMessage as ReturnType<typeof vi.fn>).mock.calls.map((c) => c[0].content as string);
+    expect(sent.some((s) => s.startsWith('🔧 Running'))).toBe(false);
+  });
+
   it('/reset barrier prevents group backfill from resurrecting pre-reset history', async () => {
     // Regression for the PR #62 review finding: /reset deletes the local
     // session, but G4 cold-start backfill could refetch + re-seed the same

--- a/src/agent-bridge.ts
+++ b/src/agent-bridge.ts
@@ -261,6 +261,10 @@ export function buildPrompt(historyPrefix: string, groupContext: string, message
  * @param groupContext - Group chat context string (may be empty)
  * @param config - Application config (sdk.* fields used)
  * @param sessionCtx - Per-session routing context for cwd isolation (Q3)
+ * @param onToolUse - Optional callback fired with each tool name as the agent
+ *   invokes it (v0.3 tool progress). The bridge stays a pure reporter — it does
+ *   not dedup or rate-limit; the caller decides how to surface progress. A
+ *   throwing callback must never break the stream, so calls are guarded.
  * @yields string chunks of assistant text output
  */
 export async function* queryAgent(
@@ -269,6 +273,7 @@ export async function* queryAgent(
   groupContext: string,
   config: Config,
   sessionCtx?: SessionCtx,
+  onToolUse?: (toolName: string) => void,
 ): AsyncIterable<string> {
   const permissionMode = toPermissionMode(config.sdk.permissionMode);
   const settingSources = toSettingSources(config.sdk.settingSources);
@@ -327,6 +332,15 @@ export async function* queryAgent(
         for (const block of content) {
           if (block.type === 'text' && block.text) {
             yield block.text;
+          } else if (block.type === 'tool_use' && onToolUse) {
+            // v0.3 tool progress: report the tool name. Guard the callback so a
+            // throw never propagates into the SDK stream and kills the turn.
+            const name = typeof block.name === 'string' ? block.name : 'tool';
+            try {
+              onToolUse(name);
+            } catch (err) {
+              console.error(`[cc-channel-octo] onToolUse callback threw: ${String(err)}`);
+            }
           }
         }
       } else if (message.type === 'result') {

--- a/src/config.ts
+++ b/src/config.ts
@@ -47,6 +47,13 @@ export interface Config {
     systemPrompt?: string;
     settingSources: string[];
     /**
+     * v0.3: when true, the bot sends brief "🔧 Running <tool>…" progress
+     * messages as the agent invokes tools, so users see activity during long
+     * tool-heavy turns. Default false — it adds extra chat messages, so it is
+     * opt-in. Env: `CC_OCTO_SDK_TOOL_PROGRESS=true`.
+     */
+    toolProgress?: boolean;
+    /**
      * Q1: Override the upstream Claude API endpoint (e.g. self-hosted gateway).
      * Forwarded to the SDK subprocess via the standard `ANTHROPIC_BASE_URL`
      * environment variable. Env priority: `ANTHROPIC_BASE_URL` > this field.
@@ -257,6 +264,10 @@ function applyEnv(cfg: Config): Config {
   if (env.CC_OCTO_SDK_SYSTEM_PROMPT) next.sdk.systemPrompt = env.CC_OCTO_SDK_SYSTEM_PROMPT;
   if (env.CC_OCTO_SDK_SETTING_SOURCES) {
     next.sdk.settingSources = parseCsv(env.CC_OCTO_SDK_SETTING_SOURCES);
+  }
+  // v0.3: tool-progress messages. Accept the usual truthy spellings.
+  if (env.CC_OCTO_SDK_TOOL_PROGRESS !== undefined) {
+    next.sdk.toolProgress = /^(1|true|yes|on)$/i.test(env.CC_OCTO_SDK_TOOL_PROGRESS.trim());
   }
   // Q1: ANTHROPIC_BASE_URL uses the Anthropic SDK standard variable name
   // (no CC_OCTO_ prefix) so operators can reuse existing gateway configs.

--- a/src/index.ts
+++ b/src/index.ts
@@ -383,7 +383,34 @@ export async function handleMessage(
         kind: isGroup ? 'group' : 'dm',
         sessionKey,
       };
-      const rawChunks = queryAgent(userContentForLLM, historyPrefix, contextStr, config, sessionCtx);
+
+      // v0.3 tool progress (opt-in): send a brief "🔧 Running <tool>…" notice as
+      // the agent invokes tools. Dedup consecutive identical tools and cap the
+      // number of notices per turn so a tool-heavy run doesn't spam the channel.
+      let onToolUse: ((toolName: string) => void) | undefined;
+      if (config.sdk.toolProgress) {
+        let lastTool = '';
+        let noticeCount = 0;
+        const MAX_TOOL_NOTICES = 10;
+        onToolUse = (toolName: string): void => {
+          if (toolName === lastTool) return; // collapse repeats (e.g. Read×5)
+          lastTool = toolName;
+          if (noticeCount >= MAX_TOOL_NOTICES) return;
+          noticeCount++;
+          // Fire-and-forget — never block or fail the agent stream on a notice.
+          sendMessage({
+            apiUrl: config.apiUrl,
+            botToken: config.botToken,
+            channelId,
+            channelType,
+            content: `🔧 Running ${toolName}…`,
+          }).catch((err) =>
+            console.error(`[cc-channel-octo] tool-progress send failed: ${String(err)}`),
+          );
+        };
+      }
+
+      const rawChunks = queryAgent(userContentForLLM, historyPrefix, contextStr, config, sessionCtx, onToolUse);
 
       // Tee the generator: collect full text while streaming to Octo
       const collected: string[] = [];


### PR DESCRIPTION
Second v0.3 roadmap item: tool progress display.

## What changed and why

When `sdk.toolProgress` is enabled (config or `CC_OCTO_SDK_TOOL_PROGRESS=true`), the bot posts brief `🔧 Running <tool>…` notices as the agent invokes tools — so users see activity during long tool-heavy turns instead of silence until the final answer.

**Design (non-breaking):**
- `queryAgent` gains an optional `onToolUse(toolName)` callback, fired for each `tool_use` block in the SDK stream. It's **guarded** — a throwing callback is logged and never breaks the stream. Missing name → `"tool"`. Omitting the callback preserves the old behavior (tool_use blocks ignored).
- `index.ts` (when enabled) passes an `onToolUse` that sends fire-and-forget progress messages, **collapsing consecutive identical tools** (e.g. `Read`×5 → one notice) and **capping at 10 notices/turn** so a tool-heavy run can't spam the channel.
- Why a callback, not a typed event stream: `stream-relay.deliver()` *accumulates* text and sends once at the end, so progress can't be interleaved into the text stream — it must be separate immediate messages. The callback keeps the string stream and all existing callers/tests unchanged.

## Files modified

- `src/agent-bridge.ts` (callback), `src/config.ts` (flag + env), `src/index.ts` (wiring + dedup/cap)
- Tests: `agent-bridge-query` (order, fallback, throw-safety, omitted), `config` (file + truthy/falsy env matrix), `e2e` (dedup+cap on; silent off)
- `README.md`, `CHANGELOG.md`

## Test results

- `npm run type-check` — clean
- `npm test` — **788 passed** (+19)
- `npm run lint` — 0 warnings
- `npm run build` — clean

Roadmap: "tool progress display" removed from the v0.3 row (shipped here).