### PR TITLE
feat(config): multi-bot support (v0.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,15 @@ While the major version is `0`, minor releases may carry breaking changes.
   inherits all top-level fields, and may override `apiUrl`/`dataDir`/`cwdBase`/
   `model`/`systemPrompt`/blocklists. Each bot gets a fully independent stack
   (gateway + router + store); `dataDir` and `cwdBase` are namespaced by id by
-  default so bots never share history or sandboxes. `resolveBotConfigs()` expands
-  the config and fails fast on missing/duplicate tokens or duplicate ids. In
-  multi-bot mode the orchestrator owns a single SIGINT/SIGTERM shutdown that
-  drains all bots (gateways skip their own signal handlers via a new
-  `handleSignals` option). Single-bot configs are unchanged.
+  default so bots never share history or sandboxes. Bot ids are validated as
+  conservative slugs (no path separators) to keep that namespacing safe.
+  `resolveBotConfigs()` expands the config and fails fast on missing/duplicate
+  tokens or duplicate/invalid ids. All bot ids are registered into every router
+  so a mention-free group can't trigger bot-to-bot reply loops, and the
+  cold-start backfill sentinel is keyed per bot. In multi-bot mode the
+  orchestrator owns a single SIGINT/SIGTERM shutdown that drains all bots
+  (gateways skip their own signal handlers via a new `handleSignals` option).
+  Single-bot configs are unchanged.
 - **Tool progress display** (v0.3, opt-in) — with `sdk.toolProgress`
   (`CC_OCTO_SDK_TOOL_PROGRESS=true`), the bot posts brief `🔧 Running <tool>…`
   notices as the agent invokes tools. `queryAgent` gained a non-breaking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ While the major version is `0`, minor releases may carry breaking changes.
 
 ### Added
 
+- **Multi-bot support** (v0.3) — run several independent bots in one process via
+  a top-level `bots[]` config array. Each entry needs its own `botToken` + `id`,
+  inherits all top-level fields, and may override `apiUrl`/`dataDir`/`cwdBase`/
+  `model`/`systemPrompt`/blocklists. Each bot gets a fully independent stack
+  (gateway + router + store); `dataDir` and `cwdBase` are namespaced by id by
+  default so bots never share history or sandboxes. `resolveBotConfigs()` expands
+  the config and fails fast on missing/duplicate tokens or duplicate ids. In
+  multi-bot mode the orchestrator owns a single SIGINT/SIGTERM shutdown that
+  drains all bots (gateways skip their own signal handlers via a new
+  `handleSignals` option). Single-bot configs are unchanged.
 - **Tool progress display** (v0.3, opt-in) — with `sdk.toolProgress`
   (`CC_OCTO_SDK_TOOL_PROGRESS=true`), the bot posts brief `🔧 Running <tool>…`
   notices as the agent invokes tools. `queryAgent` gained a non-breaking

--- a/README.md
+++ b/README.md
@@ -139,9 +139,11 @@ Leave the field unset to talk to Anthropic's public endpoint directly.
 
 To run several bots from one process, add a `bots` array instead of (or in
 addition to) the single top-level `botToken`. Each entry needs its own
-`botToken` and an `id`, inherits every top-level field, and may override
-`apiUrl`, `dataDir`, `cwdBase`, `model`, `systemPrompt`, `botBlocklist`, and the
-mention lists:
+`botToken` and should set a stable `id` (slug: letters, digits, `.`, `_`, `-`).
+If `id` is omitted it falls back to the positional `bot0`, `bot1`, … — which
+works but produces index-dependent directory names, so prefer an explicit id.
+Each entry inherits every top-level field and may override `apiUrl`, `dataDir`,
+`cwdBase`, `model`, `systemPrompt`, `botBlocklist`, and the mention lists:
 
 ```jsonc
 {

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Users talk to a bot in Octo (DM or group @mention). The bot sends messages to Cl
 - **In-chat commands** — `/reset` clears your own session's stored history (not the shared recent-group-context cache), `/config` shows the active settings, `/help` lists commands. Scoped per-user (even in groups); subject to the same per-session rate limit as normal messages.
 - **Rate limiting** — Per-session token bucket (default 5 req/min) with debounced rejection notices.
 - **Security by configuration** — `allowedTools` whitelist + per-session `cwdBase` isolation. No runtime permission prompts (headless mode).
+- **Multi-bot** — Run several independent bots in one process via a `bots[]` config array; each gets its own token, data directory, and sandbox root (no shared history).
 - **Zero infrastructure** — Single process, single SQLite file, `npm start` and go.
 
 ## Quick Start
@@ -133,6 +134,33 @@ ANTHROPIC_BASE_URL=https://claude-gw.internal.example.com npm start
 ```
 
 Leave the field unset to talk to Anthropic's public endpoint directly.
+
+### Multi-bot
+
+To run several bots from one process, add a `bots` array instead of (or in
+addition to) the single top-level `botToken`. Each entry needs its own
+`botToken` and an `id`, inherits every top-level field, and may override
+`apiUrl`, `dataDir`, `cwdBase`, `model`, `systemPrompt`, `botBlocklist`, and the
+mention lists:
+
+```jsonc
+{
+  "apiUrl": "https://your-octo-instance.com",
+  "dataDir": "./data",
+  "cwdBase": "/home/deploy/cc-octo-sandboxes",
+  "bots": [
+    { "id": "support", "botToken": "bf_AAA" },
+    { "id": "ops", "botToken": "bf_BBB", "model": "claude-opus-4-8" }
+  ]
+}
+```
+
+Each bot runs a fully independent stack (gateway, router, store). By default its
+`dataDir` and `cwdBase` are namespaced by `id` (`./data/support`,
+`/home/deploy/cc-octo-sandboxes/support`, …), so **bots never share
+conversation history or working directories**. Set `dataDir`/`cwdBase` on an
+entry to override that. When `bots` is absent, the process runs a single bot
+from the top-level fields exactly as before.
 
 ## Security Model
 
@@ -283,7 +311,6 @@ src/
 
 - **Per-session `cwdBase` isolation** — Each session (DM peer, or individual group member) gets its own SHA-256 hex sandbox under `cwdBase`, partitioned by the same key as conversation history; idle sandboxes (>7d) are auto-cleaned every 6h. Note: `cwdBase` separates sessions from each other but does not confine a session to its directory (absolute-path reads via Bash/Read remain possible) — see the Security Model section.
 - **Stateless sessions** — Uses the v1 `query()` API. Workspace state (open files, command history) does not persist across messages. The v2 Session API is planned for v0.3.
-- **Single bot** — One bot per process. Multi-bot support is planned for v0.3.
 
 ## Roadmap
 
@@ -291,7 +318,7 @@ src/
 |---------|-------|
 | **v0.1** | Text messaging, streaming, session persistence, rate limiting, security model |
 | **v0.2** *(current)* | Media reception & sending (image/file/RichText), @mention, group context, per-session `cwdBase` isolation, self-hosted gateway, SSRF/prompt-injection hardening |
-| **v0.3** | v2 Session API, multi-bot support |
+| **v0.3** | v2 Session API |
 | **v1.0** | GROUP.md/THREAD.md configuration, webhook mode |
 
 ## Contributing

--- a/config.example.json
+++ b/config.example.json
@@ -12,6 +12,7 @@
     "_comment_allowed_tools": "Q2: either '*' (allow every tool the SDK exposes) or an explicit string[] whitelist, e.g. ['Read', 'Write', 'Edit', 'Bash', 'Glob', 'Grep', 'WebFetch', 'WebSearch']. Env override CC_OCTO_SDK_ALLOWED_TOOLS accepts the same two shapes (a value containing '*' means wildcard; otherwise CSV).",
     "allowedTools": "*",
     "permissionMode": "bypassPermissions",
+    "_comment_tool_progress": "v0.3: set toolProgress=true to post '🔧 Running <tool>…' notices as the agent invokes tools (deduped, capped per turn). Env override: CC_OCTO_SDK_TOOL_PROGRESS=true. Off by default.",
     "settingSources": ["user"]
   },
 
@@ -25,6 +26,8 @@
   },
 
   "botBlocklist": [],
+
+  "_comment_multi_bot": "v0.3 multi-bot: to run several bots in one process, add a top-level \"bots\" array instead of (or alongside) the single botToken above. Each entry needs its own botToken and an id; it inherits all top-level fields and may override apiUrl/dataDir/cwdBase/model/systemPrompt/botBlocklist/etc. By default each bot's dataDir and cwdBase are namespaced by id so bots never share history or sandboxes. Example: \"bots\": [{ \"id\": \"support\", \"botToken\": \"bf_AAA\" }, { \"id\": \"ops\", \"botToken\": \"bf_BBB\", \"model\": \"claude-opus-4-8\" }]",
 
   "_comment_mention_free": "G12: group_ids listed here process every text message without requiring an @bot mention. Use group channel IDs as strings. Env override: CC_OCTO_MENTION_FREE_GROUPS (csv).",
   "mentionFreeGroups": []

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -14,7 +14,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { join } from 'node:path';
 import { mkdtempSync, writeFileSync, rmSync, chmodSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { loadConfig } from '../config.js';
+import { loadConfig, resolveBotConfigs } from '../config.js';
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
@@ -651,4 +651,118 @@ describe('v0.3: tool progress toggle', () => {
       expect(loadConfig(path).sdk.toolProgress).toBe(false);
     },
   );
+});
+
+// ─── v0.3: multi-bot (resolveBotConfigs) ───────────────────────────────
+
+describe('v0.3: resolveBotConfigs', () => {
+  beforeEach(setup);
+  afterEach(teardown);
+
+  it('single-bot config resolves to one entry with botId "default"', () => {
+    const cfg = loadConfig(writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' }));
+    const bots = resolveBotConfigs(cfg);
+    expect(bots).toHaveLength(1);
+    expect(bots[0].botId).toBe('default');
+    expect(bots[0].botToken).toBe('bf_t');
+  });
+
+  it('expands a bots[] array into one config per entry', () => {
+    const cfg = loadConfig(writeConfig({
+      apiUrl: 'https://a',
+      dataDir: '/data',
+      cwdBase: '/sand',
+      bots: [
+        { id: 'support', botToken: 'bf_1' },
+        { id: 'ops', botToken: 'bf_2' },
+      ],
+    }));
+    const bots = resolveBotConfigs(cfg);
+    expect(bots.map((b) => b.botId)).toEqual(['support', 'ops']);
+    expect(bots.map((b) => b.botToken)).toEqual(['bf_1', 'bf_2']);
+  });
+
+  it('namespaces dataDir + cwdBase per bot id by default (isolation)', () => {
+    const cfg = loadConfig(writeConfig({
+      apiUrl: 'https://a',
+      dataDir: '/data',
+      cwdBase: '/sand',
+      bots: [{ id: 'support', botToken: 'bf_1' }],
+    }));
+    const [bot] = resolveBotConfigs(cfg);
+    expect(bot.dataDir).toBe('/data/support');
+    expect(bot.cwdBase).toBe('/sand/support');
+  });
+
+  it('honors explicit per-bot dataDir/cwdBase overrides', () => {
+    const cfg = loadConfig(writeConfig({
+      apiUrl: 'https://a',
+      bots: [{ id: 'x', botToken: 'bf_1', dataDir: '/custom/d', cwdBase: '/custom/c' }],
+    }));
+    const [bot] = resolveBotConfigs(cfg);
+    expect(bot.dataDir).toBe('/custom/d');
+    expect(bot.cwdBase).toBe('/custom/c');
+  });
+
+  it('applies per-bot model/systemPrompt overrides onto sdk', () => {
+    const cfg = loadConfig(writeConfig({
+      apiUrl: 'https://a',
+      sdk: { model: 'base-model' },
+      bots: [
+        { id: 'a', botToken: 'bf_1', model: 'opus' },
+        { id: 'b', botToken: 'bf_2' }, // inherits base model
+      ],
+    }));
+    const bots = resolveBotConfigs(cfg);
+    expect(bots[0].sdk.model).toBe('opus');
+    expect(bots[1].sdk.model).toBe('base-model');
+  });
+
+  it('per-bot config carries no nested bots field', () => {
+    const cfg = loadConfig(writeConfig({
+      apiUrl: 'https://a',
+      bots: [{ id: 'a', botToken: 'bf_1' }],
+    }));
+    expect(resolveBotConfigs(cfg)[0].bots).toBeUndefined();
+  });
+
+  it('throws on a missing per-bot token', () => {
+    const cfg = loadConfig(writeConfig({
+      apiUrl: 'https://a',
+      bots: [{ id: 'a', botToken: '' }],
+    }));
+    expect(() => resolveBotConfigs(cfg)).toThrow(/missing required botToken/i);
+  });
+
+  it('throws on duplicate bot ids', () => {
+    const cfg = loadConfig(writeConfig({
+      apiUrl: 'https://a',
+      bots: [{ id: 'x', botToken: 'bf_1' }, { id: 'x', botToken: 'bf_2' }],
+    }));
+    expect(() => resolveBotConfigs(cfg)).toThrow(/duplicate bot id/i);
+  });
+
+  it('throws on duplicate bot tokens', () => {
+    const cfg = loadConfig(writeConfig({
+      apiUrl: 'https://a',
+      bots: [{ id: 'a', botToken: 'bf_same' }, { id: 'b', botToken: 'bf_same' }],
+    }));
+    expect(() => resolveBotConfigs(cfg)).toThrow(/duplicate botToken/i);
+  });
+
+  it('loadConfig allows a missing top-level botToken when bots[] is present', () => {
+    // No top-level botToken, but bots provide their own.
+    expect(() => loadConfig(writeConfig({
+      apiUrl: 'https://a',
+      bots: [{ id: 'a', botToken: 'bf_1' }],
+    }))).not.toThrow();
+  });
+
+  it('rejects an unsafe per-bot apiUrl override', () => {
+    const cfg = loadConfig(writeConfig({
+      apiUrl: 'https://a',
+      bots: [{ id: 'a', botToken: 'bf_1', apiUrl: 'http://169.254.169.254' }],
+    }));
+    expect(() => resolveBotConfigs(cfg)).toThrow(/unsafe apiUrl/i);
+  });
 });

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -765,4 +765,23 @@ describe('v0.3: resolveBotConfigs', () => {
     }));
     expect(() => resolveBotConfigs(cfg)).toThrow(/unsafe apiUrl/i);
   });
+
+  it.each(['../ops', 'a/b', '.', '..', 'a\\b', 'with space'])(
+    'rejects path-traversal/invalid bot id %j',
+    (badId) => {
+      const cfg = loadConfig(writeConfig({
+        apiUrl: 'https://a',
+        bots: [{ id: badId, botToken: 'bf_1' }],
+      }));
+      expect(() => resolveBotConfigs(cfg)).toThrow(/invalid bot id/i);
+    },
+  );
+
+  it('accepts conservative slug ids', () => {
+    const cfg = loadConfig(writeConfig({
+      apiUrl: 'https://a',
+      bots: [{ id: 'support-bot.1_v2', botToken: 'bf_1' }],
+    }));
+    expect(resolveBotConfigs(cfg)[0].botId).toBe('support-bot.1_v2');
+  });
 });

--- a/src/__tests__/gateway.test.ts
+++ b/src/__tests__/gateway.test.ts
@@ -341,3 +341,51 @@ describe('Heartbeat consecutive failures', () => {
     await gw.stop();
   });
 });
+
+// ─── 5. Two-phase startup (v0.3 multi-bot lifecycle) ────────────────────
+
+describe('Two-phase startup: register() then connect()', () => {
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'cc-octo-gw-2p-'));
+    vi.clearAllMocks();
+    setupMocks();
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('register() populates botId WITHOUT opening the socket', async () => {
+    const gw = new OctoGateway(makeConfig());
+    await gw.register();
+    expect(gw.botId).toBe('bot-123');
+    expect(gw.ownerUid).toBe('owner-1');
+    // No socket constructed yet — the WS only opens in connect().
+    expect(vi.mocked(WKSocket)).not.toHaveBeenCalled();
+    await gw.stop();
+  });
+
+  it('a message handler can be installed between register() and connect()', async () => {
+    const gw = new OctoGateway(makeConfig());
+    await gw.register();
+    // Wiring the handler before connect() is the whole point — no throw, no socket.
+    expect(() => gw.setMessageHandler(() => {})).not.toThrow();
+    expect(vi.mocked(WKSocket)).not.toHaveBeenCalled();
+    gw.connect();
+    expect(vi.mocked(WKSocket)).toHaveBeenCalledTimes(1);
+    await gw.stop();
+  });
+
+  it('connect() before register() throws (lifecycle guard)', () => {
+    const gw = new OctoGateway(makeConfig());
+    expect(() => gw.connect()).toThrow(/before register/i);
+  });
+
+  it('start() still does register + connect in one call (back-compat)', async () => {
+    const gw = new OctoGateway(makeConfig());
+    await gw.start();
+    expect(gw.botId).toBe('bot-123');
+    expect(vi.mocked(WKSocket)).toHaveBeenCalledTimes(1);
+    await gw.stop();
+  });
+});

--- a/src/__tests__/session-router.test.ts
+++ b/src/__tests__/session-router.test.ts
@@ -629,3 +629,58 @@ describe('G20: per-user cross-channel rate limit', () => {
     expect(replyCalls.length).toBeLessThanOrEqual(2);
   });
 });
+
+// ─── v0.3 multi-bot: mention-free group bot-loop guard ─────────────────
+
+describe('multi-bot loop guard in mention-free groups', () => {
+  const GROUP = 'mf-group';
+
+  function mfConfig(): Config {
+    return makeConfig({ mentionFreeGroups: [GROUP] });
+  }
+  function mfMsg(fromUid: string): BotMessage {
+    return makeMsg({
+      from_uid: fromUid,
+      channel_id: GROUP,
+      channel_type: ChannelType.Group,
+      payload: { type: MessageType.Text, content: 'auto reply' },
+    });
+  }
+
+  it('processes a human message in a mention-free group (baseline)', async () => {
+    const r = new SessionRouter(mfConfig(), ROBOT_ID);
+    const result = await r.route(mfMsg('human-1'));
+    expect(result?.shouldProcess).toBe(true);
+  });
+
+  it('drops a _bot-suffixed sender in a mention-free group (no mention)', async () => {
+    const r = new SessionRouter(mfConfig(), ROBOT_ID);
+    const result = await r.route(mfMsg('helper_bot'));
+    expect(result).toBeNull();
+  });
+
+  it('drops a registered sibling bot in a mention-free group', async () => {
+    const r = new SessionRouter(mfConfig(), ROBOT_ID);
+    r.registerKnownBot('bot-002'); // sibling bot id (no _bot suffix)
+    const result = await r.route(mfMsg('bot-002'));
+    expect(result).toBeNull();
+  });
+
+  it('still answers a sibling bot that explicitly @-mentions us', async () => {
+    const r = new SessionRouter(mfConfig(), ROBOT_ID);
+    r.registerKnownBot('bot-002');
+    const msg = mfMsg('bot-002');
+    msg.payload.mention = { uids: [ROBOT_ID] };
+    const result = await r.route(msg);
+    expect(result?.shouldProcess).toBe(true);
+  });
+
+  it('honors allowedBotUids whitelist in mention-free groups', async () => {
+    const r = new SessionRouter(
+      makeConfig({ mentionFreeGroups: [GROUP], allowedBotUids: ['trusted_bot'] }),
+      ROBOT_ID,
+    );
+    const result = await r.route(mfMsg('trusted_bot'));
+    expect(result?.shouldProcess).toBe(true);
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -77,6 +77,43 @@ export interface Config {
   allowedBotUids?: string[];
   /** Group IDs where the bot responds without being @mentioned (G12). */
   mentionFreeGroups?: string[];
+  /**
+   * v0.3 multi-bot: optional per-bot overrides. When present and non-empty, the
+   * process runs ONE independent bot per entry, each with its own gateway,
+   * router, store, and (by default) data directory — so bots never share history
+   * or working dirs. Each entry inherits every top-level field and overrides the
+   * listed ones; `botToken` is required per entry. When absent, the process runs
+   * a single bot from the top-level fields exactly as before.
+   *
+   * Resolved into concrete per-bot Config objects by `resolveBotConfigs()`.
+   */
+  bots?: BotOverride[];
+  /**
+   * v0.3 multi-bot: stable identifier for THIS bot, used to namespace its data
+   * directory and logs when running multiple bots. Defaults to `default` for the
+   * single-bot case. Populated by `resolveBotConfigs()`.
+   */
+  botId?: string;
+}
+
+/**
+ * v0.3 multi-bot: one bot's overrides layered on the base config. Every field is
+ * optional except `botToken` (each bot needs its own identity). An omitted field
+ * inherits the top-level value.
+ */
+export interface BotOverride {
+  /** Stable id used to namespace this bot's data dir (e.g. `support`, `ops`). */
+  id?: string;
+  /** Required — this bot's Octo bot token. */
+  botToken: string;
+  apiUrl?: string;
+  dataDir?: string;
+  cwdBase?: string;
+  model?: string;
+  systemPrompt?: string;
+  botBlocklist?: string[];
+  allowedBotUids?: string[];
+  mentionFreeGroups?: string[];
 }
 
 type PartialConfig = {
@@ -94,6 +131,7 @@ type PartialConfig = {
   botBlocklist?: string[];
   allowedBotUids?: string[];
   mentionFreeGroups?: string[];
+  bots?: BotOverride[];
 };
 
 function defaults(): Config {
@@ -192,6 +230,7 @@ function mergeConfig(base: Config, override: PartialConfig): Config {
     botBlocklist: override.botBlocklist ?? base.botBlocklist,
     allowedBotUids: override.allowedBotUids ?? base.allowedBotUids,
     mentionFreeGroups: override.mentionFreeGroups ?? base.mentionFreeGroups,
+    bots: override.bots ?? base.bots,
   };
 }
 
@@ -333,7 +372,11 @@ export function loadConfig(configPath?: string): Config {
   const merged = mergeConfig(defaults(), fileCfg);
   const final = applyEnv(merged);
 
-  if (!final.botToken) {
+  const hasBots = Array.isArray(final.bots) && final.bots.length > 0;
+
+  // In multi-bot mode the per-bot tokens live in `bots[]`, so the top-level
+  // botToken is optional; resolveBotConfigs() validates each entry's token.
+  if (!final.botToken && !hasBots) {
     throw new Error('Missing required config: botToken (set CC_OCTO_BOT_TOKEN or config.json)');
   }
   if (!final.apiUrl) {
@@ -357,4 +400,73 @@ export function loadConfig(configPath?: string): Config {
   }
 
   return final;
+}
+
+/**
+ * v0.3 multi-bot: expand a loaded Config into one concrete Config per bot.
+ *
+ * - Single-bot (no `bots`): returns `[config]` with `botId` defaulted to
+ *   `default`, unchanged otherwise — fully backward compatible.
+ * - Multi-bot: returns one Config per `bots[]` entry. Each inherits the base
+ *   config and applies its overrides. To guarantee bots never share history,
+ *   cwd, or lock files, each bot's `dataDir` and `cwdBase` are namespaced by its
+ *   id UNLESS the entry sets them explicitly.
+ *
+ * Throws on missing/duplicate bot tokens or duplicate ids (fail fast at boot).
+ */
+export function resolveBotConfigs(config: Config): Config[] {
+  const bots = config.bots;
+  if (!bots || bots.length === 0) {
+    return [{ ...config, botId: config.botId ?? 'default' }];
+  }
+
+  const seenIds = new Set<string>();
+  const seenTokens = new Set<string>();
+  return bots.map((bot, i) => {
+    if (!bot.botToken) {
+      throw new Error(`Multi-bot: bots[${i}] is missing required botToken`);
+    }
+    const id = bot.id ?? `bot${i}`;
+    if (seenIds.has(id)) {
+      throw new Error(`Multi-bot: duplicate bot id "${id}" — ids must be unique`);
+    }
+    seenIds.add(id);
+    if (seenTokens.has(bot.botToken)) {
+      throw new Error(`Multi-bot: duplicate botToken across bots — each bot needs a distinct token`);
+    }
+    seenTokens.add(bot.botToken);
+
+    // Namespace data dir + cwd base by id so bots are isolated by default.
+    const baseDataDir = config.dataDir;
+    const baseCwd = config.cwdBase ?? config.cwd;
+    const resolved: Config = {
+      ...config,
+      bots: undefined, // a per-bot config is single-bot
+      botId: id,
+      botToken: bot.botToken,
+      apiUrl: bot.apiUrl ?? config.apiUrl,
+      dataDir: bot.dataDir ?? joinPath(baseDataDir, id),
+      cwdBase: bot.cwdBase ?? joinPath(baseCwd, id),
+      cwd: bot.cwdBase ?? joinPath(baseCwd, id),
+      botBlocklist: bot.botBlocklist ?? config.botBlocklist,
+      allowedBotUids: bot.allowedBotUids ?? config.allowedBotUids,
+      mentionFreeGroups: bot.mentionFreeGroups ?? config.mentionFreeGroups,
+      sdk: {
+        ...config.sdk,
+        ...(bot.model !== undefined ? { model: bot.model } : {}),
+        ...(bot.systemPrompt !== undefined ? { systemPrompt: bot.systemPrompt } : {}),
+      },
+    };
+    if (!isAllowedApiUrl(resolved.apiUrl)) {
+      throw new Error(
+        `Multi-bot: unsafe apiUrl for bot "${id}": ${resolved.apiUrl} (SSRF protection)`,
+      );
+    }
+    return resolved;
+  });
+}
+
+/** Join two path segments without importing node:path into the type surface. */
+function joinPath(a: string, b: string): string {
+  return a.replace(/\/+$/, '') + '/' + b;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -427,6 +427,15 @@ export function resolveBotConfigs(config: Config): Config[] {
       throw new Error(`Multi-bot: bots[${i}] is missing required botToken`);
     }
     const id = bot.id ?? `bot${i}`;
+    // The id becomes a path segment for the default dataDir/cwdBase namespace,
+    // so restrict it to a conservative slug — otherwise ids like "../ops" or
+    // "a/b" could escape or alias the intended per-bot directory, defeating the
+    // isolation the feature promises.
+    if (!/^[a-zA-Z0-9._-]+$/.test(id) || id === '.' || id === '..') {
+      throw new Error(
+        `Multi-bot: invalid bot id "${id}" — use only letters, digits, dot, underscore, hyphen (no path separators)`,
+      );
+    }
     if (seenIds.has(id)) {
       throw new Error(`Multi-bot: duplicate bot id "${id}" — ids must be unique`);
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -102,7 +102,13 @@ export interface Config {
  * inherits the top-level value.
  */
 export interface BotOverride {
-  /** Stable id used to namespace this bot's data dir (e.g. `support`, `ops`). */
+  /**
+   * Stable id used to namespace this bot's data dir / sandbox (e.g. `support`,
+   * `ops`). RECOMMENDED — when omitted it defaults to the positional `bot<N>`
+   * (bot0, bot1, …), which works but produces less stable, index-dependent
+   * directory names (reordering the array changes them). Must be a conservative
+   * slug: letters, digits, dot, underscore, hyphen — no path separators.
+   */
   id?: string;
   /** Required — this bot's Octo bot token. */
   botToken: string;

--- a/src/gateway.ts
+++ b/src/gateway.ts
@@ -37,7 +37,10 @@ export class OctoGateway {
   private heartbeatFailCount = 0;
   private readonly MAX_HEARTBEAT_FAILURES = 3;
 
-  constructor(private readonly config: Config) {
+  constructor(
+    private readonly config: Config,
+    private readonly options: { handleSignals?: boolean } = {},
+  ) {
     this.lockFilePath = join(config.dataDir, 'gateway.lock');
   }
 
@@ -60,7 +63,12 @@ export class OctoGateway {
     this.acquireLock();
     await this.registerAndConnect();
     this.startHeartbeat();
-    this.setupShutdownHandlers();
+    // Multi-bot: the orchestrator owns a single combined SIGINT/SIGTERM handler,
+    // so individual gateways skip registering their own (default true keeps the
+    // single-bot behavior unchanged).
+    if (this.options.handleSignals !== false) {
+      this.setupShutdownHandlers();
+    }
   }
 
   /** Whether the gateway is draining (rejecting new messages). */

--- a/src/gateway.ts
+++ b/src/gateway.ts
@@ -19,6 +19,8 @@ export type MessageHandler = (msg: BotMessage) => void;
 export class OctoGateway {
   private socket: WKSocket | null = null;
   private robotId = '';
+  // Stored registration result from register(); consumed by connect().
+  private registration: Awaited<ReturnType<typeof registerBot>> | null = null;
   // G18: owner_uid from registerBot; used by SessionRouter for future permission model.
   private _ownerUid = '';
   private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
@@ -58,10 +60,48 @@ export class OctoGateway {
     this.onMessage = handler;
   }
 
-  /** Start the gateway: acquire lock → register bot → connect WS → start heartbeat */
+  /**
+   * Start the gateway: register → connect WS → heartbeat. Convenience wrapper
+   * that does registration and connection in one call (single-bot path + tests).
+   * Multi-bot startup calls register() and connect() separately so no socket
+   * begins ACKing messages before its message handler is installed.
+   */
   async start(): Promise<void> {
+    await this.register();
+    this.connect();
+  }
+
+  /**
+   * Phase 1 of startup: acquire the lock and register the bot over REST. This
+   * populates botId/ownerUid but does NOT open the WebSocket, so no messages can
+   * arrive yet. Safe to call before the message handler is wired.
+   */
+  async register(): Promise<void> {
     this.acquireLock();
-    await this.registerAndConnect();
+    const reg = await registerBot({
+      apiUrl: this.config.apiUrl,
+      botToken: this.config.botToken,
+      agentPlatform: 'cc-channel-octo',
+      agentVersion: PKG_VERSION,
+    });
+    this.robotId = reg.robot_id;
+    this._ownerUid = reg.owner_uid;
+    this.registration = reg;
+    console.log(`Bot registered: robot_id=${reg.robot_id}`);
+  }
+
+  /**
+   * Phase 2 of startup: open the WebSocket and start the heartbeat. Call only
+   * AFTER setMessageHandler() so inbound messages are dispatched, not ACK'd and
+   * dropped. Registers signal handlers unless handleSignals is false.
+   */
+  connect(): void {
+    if (!this.registration) {
+      throw new Error('OctoGateway.connect() called before register()');
+    }
+    const reg = this.registration;
+    this.socket = this.createSocket(reg.ws_url, reg.robot_id, reg.im_token);
+    this.socket.connect();
     this.startHeartbeat();
     // Multi-bot: the orchestrator owns a single combined SIGINT/SIGTERM handler,
     // so individual gateways skip registering their own (default true keeps the
@@ -181,22 +221,7 @@ export class OctoGateway {
   }
 
   // --- Bot registration + WS connection ---
-
-  private async registerAndConnect(): Promise<void> {
-    const reg = await registerBot({
-      apiUrl: this.config.apiUrl,
-      botToken: this.config.botToken,
-      agentPlatform: 'cc-channel-octo',
-      agentVersion: PKG_VERSION,
-    });
-
-    this.robotId = reg.robot_id;
-    this._ownerUid = reg.owner_uid;
-    console.log(`Bot registered: robot_id=${reg.robot_id}`);
-
-    this.socket = this.createSocket(reg.ws_url, reg.robot_id, reg.im_token);
-    this.socket.connect();
-  }
+  // (register() + connect() above split the two phases; see start().)
 
   private handleMessage(msg: BotMessage): void {
     if (this._draining) return; // Q6: reject new messages during shutdown

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,19 @@ async function main(): Promise<void> {
   // so per-user history and sandboxes never cross between bots.
   const stacks = await Promise.all(botConfigs.map((c) => startBot(c, multi)));
 
+  // Multi-bot loop guard: make every router aware of ALL bot ids in this
+  // process, so a mention-free group can't let one bot reply to another's
+  // messages (knownBotUids → looksLikeBot → dropped). Done after all gateways
+  // started, since botIds are only known post-registration.
+  if (multi) {
+    const allBotIds = stacks.map((s) => s.botId);
+    for (const s of stacks) {
+      for (const id of allBotIds) {
+        if (id !== s.botId) s.router.registerKnownBot(id);
+      }
+    }
+  }
+
   // Wire a single process-wide shutdown that drains every bot, so N gateways
   // don't each call process.exit. The per-gateway signal handlers are disabled
   // in multi-bot mode (handleSignals=false); we own the signals here.
@@ -66,6 +79,7 @@ async function main(): Promise<void> {
 
 interface BotStack {
   botId: string;
+  router: SessionRouter;
   shutdown: () => Promise<void>;
 }
 
@@ -142,7 +156,7 @@ async function startBot(config: ReturnType<typeof loadConfig>, multi: boolean): 
   // Single-bot: the gateway's own SIGINT/SIGTERM handler invokes this.
   gateway.setShutdownCallback(shutdown);
 
-  return { botId: gateway.botId, shutdown };
+  return { botId: gateway.botId, router, shutdown };
 }
 
 
@@ -366,15 +380,19 @@ export async function handleMessage(
       // G4: Backfill history from API when local cache is empty for groups.
       // Only triggered on first interaction with a group (cold start) to avoid
       // duplicate API calls; checked via a sentinel marker stored in-memory.
+      // Multi-bot: the sentinel set is process-global but each bot has its own
+      // store, so key it by botId+sessionKey — otherwise bot A marking a session
+      // backfilled would make bot B skip backfill against its own empty DB.
+      const backfillKey = `${botId} ${sessionKey}`;
       let historyPrefix = store.buildSegmentedHistoryPrefix(sessionKey, config.context.historyLimit);
       if (
         isGroup &&
         !historyPrefix &&
-        !backfilledSessions.has(sessionKey) &&
+        !backfilledSessions.has(backfillKey) &&
         msg.channel_id &&
         msg.channel_type !== undefined
       ) {
-        backfilledSessions.add(sessionKey);
+        backfilledSessions.add(backfillKey);
         try {
           const apiMessages = await getChannelMessages({
             apiUrl: config.apiUrl,

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,14 +46,17 @@ async function main(): Promise<void> {
   // Each bot runs a fully independent stack (gateway + router + store + cwd
   // cleanup), isolated by its own dataDir/cwdBase. They share nothing stateful,
   // so per-user history and sandboxes never cross between bots.
+  //
+  // Two-phase startup so no WebSocket ACKs a message before its handler is
+  // ready: startBot() registers over REST (gets botId) and installs the message
+  // handler, but does NOT open the socket. We then cross-register sibling bot
+  // ids, and only AFTER that connect every socket.
   const stacks = await Promise.all(botConfigs.map((c) => startBot(c, multi)));
 
   // Multi-bot loop guard: make every router aware of ALL bot ids in this
   // process, so a mention-free group can't let one bot reply to another's
-  // messages (knownBotUids → looksLikeBot → dropped). Done after all gateways
-  // started (botIds are only known post-registration) but BEFORE any router
-  // begins handling messages, so there is no window where a sibling bot's
-  // message could slip through unrecognized.
+  // messages (knownBotUids → looksLikeBot → dropped). botIds are known after
+  // register() (REST), before any socket is open.
   if (multi) {
     const allBotIds = stacks.map((s) => s.botId);
     for (const s of stacks) {
@@ -63,8 +66,9 @@ async function main(): Promise<void> {
     }
   }
 
-  // Now that cross-registration is done, let every bot start handling messages.
-  for (const s of stacks) s.beginHandling();
+  // Handlers are wired and siblings registered — now open every socket. From
+  // this point inbound messages are dispatched, never ACK'd-and-dropped.
+  for (const s of stacks) s.connect();
 
   // Wire a single process-wide shutdown that drains every bot, so N gateways
   // don't each call process.exit. The per-gateway signal handlers are disabled
@@ -85,7 +89,7 @@ async function main(): Promise<void> {
 interface BotStack {
   botId: string;
   router: SessionRouter;
-  beginHandling: () => void;
+  connect: () => void;
   shutdown: () => Promise<void>;
 }
 
@@ -133,8 +137,10 @@ async function startBot(config: ReturnType<typeof loadConfig>, multi: boolean): 
   // --- Gateway. In multi-bot mode main() owns shutdown signals, so the gateway
   // must NOT register its own (N gateways racing process.exit). ---
   const gateway = new OctoGateway(config, { handleSignals: !multi });
-  await gateway.start();
-  console.log(`[cc-channel-octo] ${label}Bot started: id=${gateway.botId}`);
+  // Phase 1: register over REST (gets botId) — does NOT open the socket yet, so
+  // no message can arrive before the handler below is installed.
+  await gateway.register();
+  console.log(`[cc-channel-octo] ${label}Bot registered: id=${gateway.botId}`);
 
   // --- Session router ---
   const router = new SessionRouter(config, gateway.botId, gateway.ownerUid);
@@ -142,22 +148,26 @@ async function startBot(config: ReturnType<typeof loadConfig>, multi: boolean): 
   // --- Active handler tracking (Q6: in-flight drain on shutdown) ---
   const activeHandlers = new Set<Promise<void>>();
 
-  // Wiring the message handler is deferred to beginHandling() so the orchestrator
-  // can register all sibling bot ids into this router FIRST — otherwise there is
-  // a startup window where a mention-free group could deliver a sibling bot's
-  // message before this router knows it's a bot.
-  const beginHandling = (): void => {
-    gateway.setMessageHandler((msg: BotMessage) => {
-      if (gateway.draining) return;
-      const p = handleMessage(msg, config, store, router, groupContext, streamRelay, gateway.botId)
-        .catch((err) => {
-          console.error(`[cc-channel-octo] ${label}Unhandled message handler error:`, err instanceof Error ? err.message : err);
-        })
-        .finally(() => {
-          activeHandlers.delete(p);
-        });
-      activeHandlers.add(p);
-    });
+  // Install the message handler NOW (before the socket opens). The socket is
+  // opened later via connect(), after main() has cross-registered sibling bot
+  // ids — so there is no window where a message is ACK'd and dropped, nor one
+  // where a sibling bot's message slips through unrecognized.
+  gateway.setMessageHandler((msg: BotMessage) => {
+    if (gateway.draining) return;
+    const p = handleMessage(msg, config, store, router, groupContext, streamRelay, gateway.botId)
+      .catch((err) => {
+        console.error(`[cc-channel-octo] ${label}Unhandled message handler error:`, err instanceof Error ? err.message : err);
+      })
+      .finally(() => {
+        activeHandlers.delete(p);
+      });
+    activeHandlers.add(p);
+  });
+
+  // Phase 2 (called by main() after cross-registration): open the socket.
+  const connect = (): void => {
+    gateway.connect();
+    console.log(`[cc-channel-octo] ${label}Bot connected: id=${gateway.botId}`);
   };
 
   const shutdown = async (): Promise<void> => {
@@ -168,7 +178,7 @@ async function startBot(config: ReturnType<typeof loadConfig>, multi: boolean): 
   // Single-bot: the gateway's own SIGINT/SIGTERM handler invokes this.
   gateway.setShutdownCallback(shutdown);
 
-  return { botId: gateway.botId, router, beginHandling, shutdown };
+  return { botId: gateway.botId, router, connect, shutdown };
 }
 
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@
  * OctoGateway.start → setMessageHandler wiring the full pipeline.
  */
 
-import { loadConfig } from './config.js';
+import { loadConfig, resolveBotConfigs } from './config.js';
 import { createAdapter } from './db-adapter.js';
 import { SessionStore } from './session-store.js';
 import { OctoGateway } from './gateway.js';
@@ -35,17 +35,54 @@ async function main(): Promise<void> {
 
   // --- Config ---
   const config = loadConfig();
-  // Q3: loadConfig() always populates cwdBase from defaults; the `?? cwd`
-  // fallback is only here for hand-built Config objects in tests/imports.
+  // v0.3 multi-bot: expand into one concrete Config per bot. Single-bot configs
+  // resolve to a 1-element array, so the loop below is the same code path.
+  const botConfigs = resolveBotConfigs(config);
+  const multi = botConfigs.length > 1;
+  if (multi) {
+    console.log(`[cc-channel-octo] Multi-bot mode: starting ${botConfigs.length} bots`);
+  }
+
+  // Each bot runs a fully independent stack (gateway + router + store + cwd
+  // cleanup), isolated by its own dataDir/cwdBase. They share nothing stateful,
+  // so per-user history and sandboxes never cross between bots.
+  const stacks = await Promise.all(botConfigs.map((c) => startBot(c, multi)));
+
+  // Wire a single process-wide shutdown that drains every bot, so N gateways
+  // don't each call process.exit. The per-gateway signal handlers are disabled
+  // in multi-bot mode (handleSignals=false); we own the signals here.
+  if (multi) {
+    const shutdownAll = async (signal: string): Promise<void> => {
+      console.log(`[cc-channel-octo] Received ${signal}, shutting down ${stacks.length} bots...`);
+      await Promise.allSettled(stacks.map((s) => s.shutdown()));
+      process.exit(0);
+    };
+    process.once('SIGINT', () => void shutdownAll('SIGINT'));
+    process.once('SIGTERM', () => void shutdownAll('SIGTERM'));
+  }
+
+  console.log('[cc-channel-octo] Ready — listening for messages');
+}
+
+interface BotStack {
+  botId: string;
+  shutdown: () => Promise<void>;
+}
+
+/**
+ * Start one bot's full pipeline. `ownSignals` is true for the single-bot case
+ * (the gateway registers its own SIGINT/SIGTERM handlers); false in multi-bot
+ * mode where main() owns a single combined shutdown.
+ */
+async function startBot(config: ReturnType<typeof loadConfig>, multi: boolean): Promise<BotStack> {
+  const label = multi ? `[${config.botId}] ` : '';
   const cwdBase = config.cwdBase ?? config.cwd;
   console.log(
-    `[cc-channel-octo] Config loaded: apiUrl=${config.apiUrl}, cwdBase=${cwdBase}, ` +
+    `[cc-channel-octo] ${label}Config loaded: apiUrl=${config.apiUrl}, cwdBase=${cwdBase}, ` +
     `dataDir=${config.dataDir}, sdk.model=${config.sdk.model ?? 'default'}, ` +
     `sdk.allowedTools=${config.sdk.allowedTools === '*' ? '*' : `[${config.sdk.allowedTools.join(',')}]`}, ` +
     `sdk.permissionMode=${config.sdk.permissionMode}, ` +
-    `rateLimit=${config.rateLimit.maxPerMinute} req/min, ` +
-    `context.maxContextChars=${config.context.maxContextChars}, ` +
-    `context.historyLimit=${config.context.historyLimit}`,
+    `rateLimit=${config.rateLimit.maxPerMinute} req/min`,
   );
 
   // --- Q3: per-session cwd cleanup (7d TTL) ---
@@ -54,20 +91,16 @@ async function main(): Promise<void> {
   const cwdCleanupTimer = setInterval(() => {
     cleanupExpiredCwds(cwdBase);
   }, CWD_CLEANUP_INTERVAL_MS);
-  // Allow the process to exit cleanly even if this timer is the only thing
-  // keeping the event loop alive (e.g. tests, single-shot smoke runs).
   cwdCleanupTimer.unref();
 
-  // --- Database ---
+  // --- Database (per-bot dataDir → no cross-bot history) ---
   const dbPath = join(config.dataDir, 'cc-octo.db');
   const adapter = createAdapter(dbPath);
   const store = new SessionStore(adapter);
   store.init();
-
-  // Clean expired sessions on startup
   const cleaned = store.cleanExpired();
   if (cleaned > 0) {
-    console.log(`[cc-channel-octo] Cleaned ${cleaned} expired session(s)`);
+    console.log(`[cc-channel-octo] ${label}Cleaned ${cleaned} expired session(s)`);
   }
 
   // --- Group context ---
@@ -77,11 +110,11 @@ async function main(): Promise<void> {
   // --- Stream relay ---
   const streamRelay = new StreamRelay();
 
-  // --- Gateway ---
-  const gateway = new OctoGateway(config);
+  // --- Gateway. In multi-bot mode main() owns shutdown signals, so the gateway
+  // must NOT register its own (N gateways racing process.exit). ---
+  const gateway = new OctoGateway(config, { handleSignals: !multi });
   await gateway.start();
-
-  console.log(`[cc-channel-octo] Bot started: id=${gateway.botId}`);
+  console.log(`[cc-channel-octo] ${label}Bot started: id=${gateway.botId}`);
 
   // --- Session router ---
   const router = new SessionRouter(config, gateway.botId, gateway.ownerUid);
@@ -89,13 +122,11 @@ async function main(): Promise<void> {
   // --- Active handler tracking (Q6: in-flight drain on shutdown) ---
   const activeHandlers = new Set<Promise<void>>();
 
-  // --- Message handler ---
   gateway.setMessageHandler((msg: BotMessage) => {
-    if (gateway.draining) return; // Extra guard: drop during shutdown
+    if (gateway.draining) return;
     const p = handleMessage(msg, config, store, router, groupContext, streamRelay, gateway.botId)
       .catch((err) => {
-        // Q8: catch unhandled rejections from fire-and-forget handlers
-        console.error('[cc-channel-octo] Unhandled message handler error:', err instanceof Error ? err.message : err);
+        console.error(`[cc-channel-octo] ${label}Unhandled message handler error:`, err instanceof Error ? err.message : err);
       })
       .finally(() => {
         activeHandlers.delete(p);
@@ -103,15 +134,17 @@ async function main(): Promise<void> {
     activeHandlers.add(p);
   });
 
-  // --- Q6 + Q7: Shutdown callback (drain handlers + close store) ---
-  gateway.setShutdownCallback(async () => {
-    clearInterval(cwdCleanupTimer); // Q3: stop the periodic cwd cleanup
+  const shutdown = async (): Promise<void> => {
+    clearInterval(cwdCleanupTimer);
     await gateway.stop(activeHandlers);
-    store.close(); // Q7: explicitly close SQLite (WAL checkpoint)
-  });
+    store.close();
+  };
+  // Single-bot: the gateway's own SIGINT/SIGTERM handler invokes this.
+  gateway.setShutdownCallback(shutdown);
 
-  console.log('[cc-channel-octo] Ready — listening for messages');
+  return { botId: gateway.botId, shutdown };
 }
+
 
 /**
  * Process a single inbound message through the full pipeline: route → context →

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,9 @@ async function main(): Promise<void> {
   // Multi-bot loop guard: make every router aware of ALL bot ids in this
   // process, so a mention-free group can't let one bot reply to another's
   // messages (knownBotUids → looksLikeBot → dropped). Done after all gateways
-  // started, since botIds are only known post-registration.
+  // started (botIds are only known post-registration) but BEFORE any router
+  // begins handling messages, so there is no window where a sibling bot's
+  // message could slip through unrecognized.
   if (multi) {
     const allBotIds = stacks.map((s) => s.botId);
     for (const s of stacks) {
@@ -60,6 +62,9 @@ async function main(): Promise<void> {
       }
     }
   }
+
+  // Now that cross-registration is done, let every bot start handling messages.
+  for (const s of stacks) s.beginHandling();
 
   // Wire a single process-wide shutdown that drains every bot, so N gateways
   // don't each call process.exit. The per-gateway signal handlers are disabled
@@ -80,6 +85,7 @@ async function main(): Promise<void> {
 interface BotStack {
   botId: string;
   router: SessionRouter;
+  beginHandling: () => void;
   shutdown: () => Promise<void>;
 }
 
@@ -136,17 +142,23 @@ async function startBot(config: ReturnType<typeof loadConfig>, multi: boolean): 
   // --- Active handler tracking (Q6: in-flight drain on shutdown) ---
   const activeHandlers = new Set<Promise<void>>();
 
-  gateway.setMessageHandler((msg: BotMessage) => {
-    if (gateway.draining) return;
-    const p = handleMessage(msg, config, store, router, groupContext, streamRelay, gateway.botId)
-      .catch((err) => {
-        console.error(`[cc-channel-octo] ${label}Unhandled message handler error:`, err instanceof Error ? err.message : err);
-      })
-      .finally(() => {
-        activeHandlers.delete(p);
-      });
-    activeHandlers.add(p);
-  });
+  // Wiring the message handler is deferred to beginHandling() so the orchestrator
+  // can register all sibling bot ids into this router FIRST — otherwise there is
+  // a startup window where a mention-free group could deliver a sibling bot's
+  // message before this router knows it's a bot.
+  const beginHandling = (): void => {
+    gateway.setMessageHandler((msg: BotMessage) => {
+      if (gateway.draining) return;
+      const p = handleMessage(msg, config, store, router, groupContext, streamRelay, gateway.botId)
+        .catch((err) => {
+          console.error(`[cc-channel-octo] ${label}Unhandled message handler error:`, err instanceof Error ? err.message : err);
+        })
+        .finally(() => {
+          activeHandlers.delete(p);
+        });
+      activeHandlers.add(p);
+    });
+  };
 
   const shutdown = async (): Promise<void> => {
     clearInterval(cwdCleanupTimer);
@@ -156,7 +168,7 @@ async function startBot(config: ReturnType<typeof loadConfig>, multi: boolean): 
   // Single-bot: the gateway's own SIGINT/SIGTERM handler invokes this.
   gateway.setShutdownCallback(shutdown);
 
-  return { botId: gateway.botId, router, shutdown };
+  return { botId: gateway.botId, router, beginHandling, shutdown };
 }
 
 
@@ -383,7 +395,7 @@ export async function handleMessage(
       // Multi-bot: the sentinel set is process-global but each bot has its own
       // store, so key it by botId+sessionKey — otherwise bot A marking a session
       // backfilled would make bot B skip backfill against its own empty DB.
-      const backfillKey = `${botId} ${sessionKey}`;
+      const backfillKey = `${botId}\u0000${sessionKey}`;
       let historyPrefix = store.buildSegmentedHistoryPrefix(sessionKey, config.context.historyLimit);
       if (
         isGroup &&

--- a/src/session-router.ts
+++ b/src/session-router.ts
@@ -251,6 +251,14 @@ export class SessionRouter {
       if (!isMentionFree) {
         return null;
       }
+      // Multi-bot loop guard: in a mention-free group there is no @-mention gate
+      // to stop one bot from replying to another bot's plain-text message. Drop
+      // messages from known/bot-looking uids (unless explicitly whitelisted) so
+      // two bots in the same mention-free room cannot enter an unbounded reply
+      // loop. An @-mention still goes through (handled by the branch above).
+      if (this.looksLikeBot(msg.from_uid) && !this.isAllowedBot(msg.from_uid)) {
+        return null;
+      }
     }
 
     // Skip system events (group join/leave, etc.) — no user-facing reply needed.


### PR DESCRIPTION
Third v0.3 roadmap item: multi-bot support.

## What changed and why

Run several independent bots from one process via a top-level `bots[]` array. Single-bot configs are completely unchanged.

**Design — per-bot isolation:**
- `resolveBotConfigs(config)` expands a loaded Config into one concrete Config per bot. No `bots` → `[config]` (backward compatible). Each entry inherits the base config and overrides `apiUrl`/`dataDir`/`cwdBase`/`model`/`systemPrompt`/blocklists.
- **`dataDir` and `cwdBase` are namespaced by bot `id` by default** (`./data/support`, …) so bots never share conversation history, sandboxes, or lock files. This also sidesteps the `sessionKey` collision risk — `SessionRouter.sessionKey()` has no botId, so a shared store would cross-contaminate per-user history; separate stores avoid that entirely.
- Fails fast on missing/duplicate tokens or duplicate ids, and SSRF-validates per-bot `apiUrl` overrides. Top-level `botToken` becomes optional when `bots[]` is present.
- `main()` starts one independent stack per bot (`startBot`). In multi-bot mode the orchestrator owns a single SIGINT/SIGTERM shutdown draining all bots; gateways skip their own signal handlers via a new `OctoGateway(config, { handleSignals })` option (default true → single-bot unchanged).

## Files modified

- `src/config.ts` (`BotOverride`, `bots`, `resolveBotConfigs`), `src/index.ts` (`startBot` + multi-bot main), `src/gateway.ts` (`handleSignals` option)
- `src/__tests__/config.test.ts` (+11), `README.md`, `CHANGELOG.md`, `config.example.json`

## Test results

- `npm run type-check` / `lint` / `build` — clean
- `npm test` — **799 passed** (+11)
- Dogfood: a 2-bot config boots two namespaced stacks (`data/support`, `data/ops`) each to the network boundary.

Roadmap: "multi-bot support" removed from the v0.3 row (shipped here).