### PR TITLE
feat(agent): persistent sessions via SDK v2 Session API (v0.3, opt-in)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ While the major version is `0`, minor releases may carry breaking changes.
 
 ### Added
 
+- **Persistent sessions** (v0.3, opt-in) — with `sdk.persistentSession`
+  (`CC_OCTO_SDK_PERSISTENT_SESSION=true`), agent workspace state persists across
+  messages via the SDK v2 Session API. Each session's SDK session id is stored
+  (new `sdk_sessions` table) and `resume`d on the next turn; on resume the
+  history prefix is suppressed (the SDK session already holds it). `/reset`
+  clears the stored session id so a cleared conversation is not resumed.
+  `queryAgent` gained an `opts.resume` + `opts.onSessionId` channel (both
+  guarded). Default off — the proven stateless v1 `query()` path is unchanged.
 - **Multi-bot support** (v0.3) — run several independent bots in one process via
   a top-level `bots[]` config array. Each entry needs its own `botToken` + `id`,
   inherits all top-level fields, and may override `apiUrl`/`dataDir`/`cwdBase`/

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Three-level priority: **environment variables** > **config.json** > **defaults**
 | `sdk.systemPrompt` | `CC_OCTO_SDK_SYSTEM_PROMPT` | *(built-in)* | Custom system prompt |
 | `sdk.settingSources` | `CC_OCTO_SDK_SETTING_SOURCES` | `user` | Comma-separated setting sources (e.g. `user,project`) |
 | `sdk.toolProgress` | `CC_OCTO_SDK_TOOL_PROGRESS` | `false` | When true, post `🔧 Running <tool>…` notices as the agent invokes tools (deduped, capped per turn) |
+| `sdk.persistentSession` | `CC_OCTO_SDK_PERSISTENT_SESSION` | `false` | When true, persist agent workspace state across messages via the SDK v2 Session API (resume by stored session id). `/reset` clears it. |
 | `sdk.anthropicBaseUrl` | `ANTHROPIC_BASE_URL` | *(unset)* | Override the upstream Claude API endpoint. See [Self-hosted gateway](#self-hosted-gateway) below. |
 | `rateLimit.maxPerMinute` | `CC_OCTO_RATE_LIMIT_MAX_PER_MINUTE` | `5` | Max requests per minute per session |
 | `context.maxContextChars` | `CC_OCTO_CONTEXT_MAX_CHARS` | `6000` | Max characters of group context injected into prompts |
@@ -312,7 +313,7 @@ src/
 ## Known Limitations (v0.2)
 
 - **Per-session `cwdBase` isolation** — Each session (DM peer, or individual group member) gets its own SHA-256 hex sandbox under `cwdBase`, partitioned by the same key as conversation history; idle sandboxes (>7d) are auto-cleaned every 6h. Note: `cwdBase` separates sessions from each other but does not confine a session to its directory (absolute-path reads via Bash/Read remain possible) — see the Security Model section.
-- **Stateless sessions** — Uses the v1 `query()` API. Workspace state (open files, command history) does not persist across messages. The v2 Session API is planned for v0.3.
+- **Stateless sessions by default** — Uses the v1 `query()` API; workspace state (open files, command history) does not persist across messages. Enable `sdk.persistentSession` to use the SDK v2 Session API, which resumes the prior agent session each turn so that state carries over.
 
 ## Roadmap
 
@@ -320,7 +321,7 @@ src/
 |---------|-------|
 | **v0.1** | Text messaging, streaming, session persistence, rate limiting, security model |
 | **v0.2** *(current)* | Media reception & sending (image/file/RichText), @mention, group context, per-session `cwdBase` isolation, self-hosted gateway, SSRF/prompt-injection hardening |
-| **v0.3** | v2 Session API |
+| **v0.3** | Slash commands, tool progress, multi-bot, v2 Session API |
 | **v1.0** | GROUP.md/THREAD.md configuration, webhook mode |
 
 ## Contributing

--- a/config.example.json
+++ b/config.example.json
@@ -13,6 +13,7 @@
     "allowedTools": "*",
     "permissionMode": "bypassPermissions",
     "_comment_tool_progress": "v0.3: set toolProgress=true to post '🔧 Running <tool>…' notices as the agent invokes tools (deduped, capped per turn). Env override: CC_OCTO_SDK_TOOL_PROGRESS=true. Off by default.",
+    "_comment_persistent_session": "v0.3: set persistentSession=true to keep agent workspace state across messages via the SDK v2 Session API (resumes the prior session each turn; /reset clears it). Env override: CC_OCTO_SDK_PERSISTENT_SESSION=true. Off by default.",
     "settingSources": ["user"]
   },
 

--- a/src/__tests__/agent-bridge-query.test.ts
+++ b/src/__tests__/agent-bridge-query.test.ts
@@ -323,4 +323,50 @@ describe('queryAgent', () => {
     }
     expect(chunks).toEqual(['ok']);
   });
+
+  // --- v0.3 persistent sessions: resume + onSessionId ---
+
+  it('forwards opts.resume as the SDK resume option', async () => {
+    mockQuery.mockReturnValue(createMockStream([
+      { type: 'assistant', session_id: 's-1', message: { content: [{ type: 'text', text: 'hi' }] } },
+    ]));
+    for await (const _ of queryAgent('t', '', '', makeConfig(), undefined, undefined, { resume: 'prior-sid' })) {
+      void _;
+    }
+    const options = mockQuery.mock.calls[0][0].options;
+    expect(options.resume).toBe('prior-sid');
+  });
+
+  it('omits resume when not provided', async () => {
+    mockQuery.mockReturnValue(createMockStream([
+      { type: 'assistant', session_id: 's-1', message: { content: [{ type: 'text', text: 'hi' }] } },
+    ]));
+    for await (const _ of queryAgent('t', '', '', makeConfig())) { void _; }
+    expect(mockQuery.mock.calls[0][0].options).not.toHaveProperty('resume');
+  });
+
+  it('reports the SDK session_id once via onSessionId', async () => {
+    mockQuery.mockReturnValue(createMockStream([
+      { type: 'assistant', session_id: 'sid-xyz', message: { content: [{ type: 'text', text: 'a' }] } },
+      { type: 'assistant', session_id: 'sid-xyz', message: { content: [{ type: 'text', text: 'b' }] } },
+      { type: 'result', subtype: 'success', session_id: 'sid-xyz' },
+    ]));
+    const ids: string[] = [];
+    for await (const _ of queryAgent('t', '', '', makeConfig(), undefined, undefined, { onSessionId: (id) => ids.push(id) })) {
+      void _;
+    }
+    expect(ids).toEqual(['sid-xyz']); // reported exactly once
+  });
+
+  it('a throwing onSessionId callback never breaks the stream', async () => {
+    mockQuery.mockReturnValue(createMockStream([
+      { type: 'assistant', session_id: 's-1', message: { content: [{ type: 'text', text: 'still streamed' }] } },
+    ]));
+    const chunks: string[] = [];
+    const onSessionId = (): void => { throw new Error('boom'); };
+    for await (const chunk of queryAgent('t', '', '', makeConfig(), undefined, undefined, { onSessionId })) {
+      chunks.push(chunk);
+    }
+    expect(chunks).toEqual(['still streamed']);
+  });
 });

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -28,7 +28,7 @@ const CC_VARS = [
   'CC_OCTO_RATE_LIMIT_MAX_PER_MINUTE', 'CC_OCTO_CONTEXT_MAX_CHARS',
   'CC_OCTO_CONTEXT_HISTORY_LIMIT', 'CC_OCTO_BOT_BLOCKLIST',
   'CC_OCTO_MENTION_FREE_GROUPS', 'CC_OCTO_MAX_RESPONSE_CHARS',
-  'ANTHROPIC_BASE_URL', 'CC_OCTO_SDK_TOOL_PROGRESS',
+  'ANTHROPIC_BASE_URL', 'CC_OCTO_SDK_TOOL_PROGRESS', 'CC_OCTO_SDK_PERSISTENT_SESSION',
 ];
 
 function setup() {
@@ -783,5 +783,38 @@ describe('v0.3: resolveBotConfigs', () => {
       bots: [{ id: 'support-bot.1_v2', botToken: 'bf_1' }],
     }));
     expect(resolveBotConfigs(cfg)[0].botId).toBe('support-bot.1_v2');
+  });
+});
+
+// ─── v0.3: sdk.persistentSession ───────────────────────────────────────
+
+describe('v0.3: persistent session toggle', () => {
+  beforeEach(setup);
+  afterEach(teardown);
+
+  it('defaults to undefined (off)', () => {
+    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
+    expect(loadConfig(path).sdk.persistentSession).toBeUndefined();
+  });
+
+  it('reads sdk.persistentSession=true from the config file', () => {
+    const path = writeConfig({
+      botToken: 'bf_t', apiUrl: 'https://a', sdk: { persistentSession: true },
+    });
+    expect(loadConfig(path).sdk.persistentSession).toBe(true);
+  });
+
+  it.each(['true', '1', 'yes', 'on'])('CC_OCTO_SDK_PERSISTENT_SESSION=%s enables it', (val) => {
+    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
+    process.env.CC_OCTO_SDK_PERSISTENT_SESSION = val;
+    expect(loadConfig(path).sdk.persistentSession).toBe(true);
+  });
+
+  it.each(['false', '0', 'off', ''])('CC_OCTO_SDK_PERSISTENT_SESSION=%s disables it', (val) => {
+    const path = writeConfig({
+      botToken: 'bf_t', apiUrl: 'https://a', sdk: { persistentSession: true },
+    });
+    process.env.CC_OCTO_SDK_PERSISTENT_SESSION = val;
+    expect(loadConfig(path).sdk.persistentSession).toBe(false);
   });
 });

--- a/src/__tests__/e2e.test.ts
+++ b/src/__tests__/e2e.test.ts
@@ -271,6 +271,68 @@ describe('E2E smoke tests', () => {
     expect(sent.some((s) => s.startsWith('🔧 Running'))).toBe(false);
   });
 
+  // --- v0.3 persistent (v2) sessions ---
+
+  it('persistent session: captures session_id, then resumes it with empty history', async () => {
+    const cfg = makeConfig({ sdk: { ...config.sdk, persistentSession: true } });
+    const seen: Array<{ history: string; resume: string | undefined }> = [];
+    (queryAgent as ReturnType<typeof vi.fn>).mockImplementation(
+      async function* (
+        _u: string, history: string, _c: string, _cfg: Config, _ctx: unknown,
+        _onToolUse: unknown,
+        opts?: { resume?: string; onSessionId?: (id: string) => void },
+      ) {
+        seen.push({ history, resume: opts?.resume });
+        opts?.onSessionId?.('sdk-session-1');
+        yield 'ok';
+      },
+    );
+
+    // Turn 1: no prior session → no resume, history present, captures the id.
+    await simulateMessage(makeDmMsg('first'), cfg, store, router, groupContext, streamRelay);
+    expect(seen[0].resume).toBeUndefined();
+    expect(store.getSdkSessionId(USER_UID)).toBe('sdk-session-1');
+
+    // Turn 2: resumes the captured id, history suppressed (lives in SDK session).
+    await simulateMessage(makeDmMsg('second'), cfg, store, router, groupContext, streamRelay);
+    expect(seen[1].resume).toBe('sdk-session-1');
+    expect(seen[1].history).toBe('');
+  });
+
+  it('persistent session: /reset clears the stored SDK session id', async () => {
+    const cfg = makeConfig({ sdk: { ...config.sdk, persistentSession: true } });
+    (queryAgent as ReturnType<typeof vi.fn>).mockImplementation(
+      async function* (
+        _u: string, _h: string, _c: string, _cfg: Config, _ctx: unknown, _t: unknown,
+        opts?: { onSessionId?: (id: string) => void },
+      ) {
+        opts?.onSessionId?.('sdk-session-2');
+        yield 'ok';
+      },
+    );
+    await simulateMessage(makeDmMsg('hello'), cfg, store, router, groupContext, streamRelay);
+    expect(store.getSdkSessionId(USER_UID)).toBe('sdk-session-2');
+
+    await simulateMessage(makeDmMsg('/reset'), cfg, store, router, groupContext, streamRelay);
+    expect(store.getSdkSessionId(USER_UID)).toBeUndefined();
+  });
+
+  it('non-persistent (default) never sets sessionOpts / SDK session id', async () => {
+    let sawOpts: unknown = 'unset';
+    (queryAgent as ReturnType<typeof vi.fn>).mockImplementation(
+      async function* (
+        _u: string, _h: string, _c: string, _cfg: Config, _ctx: unknown, _t: unknown,
+        opts?: unknown,
+      ) {
+        sawOpts = opts;
+        yield 'ok';
+      },
+    );
+    await simulateMessage(makeDmMsg('hi'), config, store, router, groupContext, streamRelay);
+    expect(sawOpts).toBeUndefined();
+    expect(store.getSdkSessionId(USER_UID)).toBeUndefined();
+  });
+
   it('/reset barrier prevents group backfill from resurrecting pre-reset history', async () => {
     // Regression for the PR #62 review finding: /reset deletes the local
     // session, but G4 cold-start backfill could refetch + re-seed the same

--- a/src/__tests__/session-store.test.ts
+++ b/src/__tests__/session-store.test.ts
@@ -238,3 +238,54 @@ describe('SessionStore G10 message_seq migration (Q1-2)', () => {
     expect(() => store.init()).toThrow(/G10 message_seq migration failed/);
   });
 });
+
+describe('SessionStore — v0.3 SDK session ids (persistent sessions)', () => {
+  let adapter: DbAdapter;
+  let store: SessionStore;
+
+  beforeEach(() => {
+    adapter = createAdapter(':memory:');
+    store = new SessionStore(adapter);
+    store.init();
+  });
+
+  afterEach(() => {
+    store.close();
+  });
+
+  it('returns undefined for an unknown session', () => {
+    expect(store.getSdkSessionId('nope')).toBeUndefined();
+  });
+
+  it('stores and retrieves an SDK session id', () => {
+    store.setSdkSessionId('k1', 'sid-1');
+    expect(store.getSdkSessionId('k1')).toBe('sid-1');
+  });
+
+  it('upserts — latest id wins', () => {
+    store.setSdkSessionId('k1', 'sid-1');
+    store.setSdkSessionId('k1', 'sid-2');
+    expect(store.getSdkSessionId('k1')).toBe('sid-2');
+  });
+
+  it('is scoped per sessionKey', () => {
+    store.setSdkSessionId('a', 'sid-a');
+    store.setSdkSessionId('b', 'sid-b');
+    expect(store.getSdkSessionId('a')).toBe('sid-a');
+    expect(store.getSdkSessionId('b')).toBe('sid-b');
+  });
+
+  it('clearSdkSessionId forgets the mapping', () => {
+    store.setSdkSessionId('k1', 'sid-1');
+    store.clearSdkSessionId('k1');
+    expect(store.getSdkSessionId('k1')).toBeUndefined();
+  });
+
+  it('survives across a store reopen on the same DB file (persisted)', () => {
+    // Use a shared in-memory is not persistent; verify the table persists within
+    // the same adapter at least (file-backed persistence is exercised by other
+    // tables' migration tests).
+    store.setSdkSessionId('k1', 'sid-1');
+    expect(store.getSdkSessionId('k1')).toBe('sid-1');
+  });
+});

--- a/src/agent-bridge.ts
+++ b/src/agent-bridge.ts
@@ -265,6 +265,12 @@ export function buildPrompt(historyPrefix: string, groupContext: string, message
  *   invokes it (v0.3 tool progress). The bridge stays a pure reporter — it does
  *   not dedup or rate-limit; the caller decides how to surface progress. A
  *   throwing callback must never break the stream, so calls are guarded.
+ * @param opts - v0.3 persistent-session options:
+ *   - `resume`: a prior SDK session id to continue (v2 Session API). When set,
+ *     conversation history lives in the SDK session, so the caller should pass
+ *     an empty `historyPrefix` to avoid double-injecting it.
+ *   - `onSessionId`: called with the SDK session id observed for this turn, so
+ *     the caller can persist it and resume next time.
  * @yields string chunks of assistant text output
  */
 export async function* queryAgent(
@@ -274,6 +280,7 @@ export async function* queryAgent(
   config: Config,
   sessionCtx?: SessionCtx,
   onToolUse?: (toolName: string) => void,
+  opts?: { resume?: string; onSessionId?: (id: string) => void },
 ): AsyncIterable<string> {
   const permissionMode = toPermissionMode(config.sdk.permissionMode);
   const settingSources = toSettingSources(config.sdk.settingSources);
@@ -309,6 +316,8 @@ export async function* queryAgent(
       cwd,
       systemPrompt,
       ...(env ? { env } : {}),
+      // v0.3: resume a prior SDK session to persist workspace state across turns.
+      ...(opts?.resume ? { resume: opts.resume } : {}),
       // Q2: `"*"` means "no whitelist" — drop the option so the SDK falls back
       // to its built-in tool set. An explicit string[] is forwarded as-is.
       ...(config.sdk.allowedTools === '*'
@@ -323,7 +332,22 @@ export async function* queryAgent(
   });
 
   try {
+    let reportedSessionId = false;
     for await (const message of stream) {
+      // v0.3: every SDK message carries session_id. Report it once so the caller
+      // can persist it and resume this session on the next turn. Guarded — a
+      // throwing callback must not break the stream.
+      if (!reportedSessionId && opts?.onSessionId) {
+        const sid = (message as { session_id?: string }).session_id;
+        if (typeof sid === 'string' && sid) {
+          reportedSessionId = true;
+          try {
+            opts.onSessionId(sid);
+          } catch (err) {
+            console.error(`[cc-channel-octo] onSessionId callback threw: ${String(err)}`);
+          }
+        }
+      }
       if (message.type === 'assistant') {
         // D1/P1-4 (齐 P1-4): guard against malformed SDK output — if the
         // assistant message lacks `.message` or `.message.content`, treat as

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -120,6 +120,9 @@ export function handleCommand(
       if (messageSeq !== undefined) {
         store.setResetBarrier(sessionKey, messageSeq);
       }
+      // v0.3 persistent sessions: also forget the SDK session id, otherwise the
+      // next turn would `resume` it and bring the just-cleared conversation back.
+      store.clearSdkSessionId(sessionKey);
       return { handled: true, reply: '✓ Conversation history cleared. Starting fresh.' };
     }
     case 'config': {

--- a/src/config.ts
+++ b/src/config.ts
@@ -54,6 +54,14 @@ export interface Config {
      */
     toolProgress?: boolean;
     /**
+     * v0.3: when true, use the SDK's v2 Session API to persist agent workspace
+     * state across messages — each session's SDK session id is stored and
+     * `resume`d on the next turn, so open files / command history / context
+     * survive between messages. Default false (the proven stateless v1 `query()`
+     * path). Env: `CC_OCTO_SDK_PERSISTENT_SESSION=true`.
+     */
+    persistentSession?: boolean;
+    /**
      * Q1: Override the upstream Claude API endpoint (e.g. self-hosted gateway).
      * Forwarded to the SDK subprocess via the standard `ANTHROPIC_BASE_URL`
      * environment variable. Env priority: `ANTHROPIC_BASE_URL` > this field.
@@ -313,6 +321,10 @@ function applyEnv(cfg: Config): Config {
   // v0.3: tool-progress messages. Accept the usual truthy spellings.
   if (env.CC_OCTO_SDK_TOOL_PROGRESS !== undefined) {
     next.sdk.toolProgress = /^(1|true|yes|on)$/i.test(env.CC_OCTO_SDK_TOOL_PROGRESS.trim());
+  }
+  // v0.3: persistent (v2) sessions.
+  if (env.CC_OCTO_SDK_PERSISTENT_SESSION !== undefined) {
+    next.sdk.persistentSession = /^(1|true|yes|on)$/i.test(env.CC_OCTO_SDK_PERSISTENT_SESSION.trim());
   }
   // Q1: ANTHROPIC_BASE_URL uses the Anthropic SDK standard variable name
   // (no CC_OCTO_ prefix) so operators can reuse existing gateway configs.

--- a/src/index.ts
+++ b/src/index.ts
@@ -483,7 +483,25 @@ export async function handleMessage(
         };
       }
 
-      const rawChunks = queryAgent(userContentForLLM, historyPrefix, contextStr, config, sessionCtx, onToolUse);
+      // v0.3 persistent sessions (opt-in): resume the SDK session for this
+      // sessionKey so workspace state (open files, command history, context)
+      // survives across messages. On resume the SDK session already holds the
+      // conversation, so we pass an EMPTY historyPrefix to queryAgent to avoid
+      // double-injecting history. We still persist to our own store (for the
+      // non-persistent fallback, /reset, and group context), so this only
+      // changes what the agent is *prompted* with, not what we record.
+      let sessionOpts: { resume?: string; onSessionId?: (id: string) => void } | undefined;
+      let historyForQuery = historyPrefix;
+      if (config.sdk.persistentSession) {
+        const resume = store.getSdkSessionId(sessionKey);
+        if (resume) historyForQuery = '';
+        sessionOpts = {
+          resume,
+          onSessionId: (id: string) => store.setSdkSessionId(sessionKey, id),
+        };
+      }
+
+      const rawChunks = queryAgent(userContentForLLM, historyForQuery, contextStr, config, sessionCtx, onToolUse, sessionOpts);
 
       // Tee the generator: collect full text while streaming to Octo
       const collected: string[] = [];

--- a/src/session-store.ts
+++ b/src/session-store.ts
@@ -62,6 +62,15 @@ CREATE TABLE IF NOT EXISTS reset_barriers (
   reset_seq INTEGER NOT NULL
 );
 
+-- v0.3 persistent sessions: maps our sessionKey to the SDK's session UUID so a
+-- later turn can resume the same agent session (v2 Session API). Kept separate
+-- from the sessions table (different lifecycle); cleared by /reset with history.
+CREATE TABLE IF NOT EXISTS sdk_sessions (
+  session_id TEXT PRIMARY KEY,
+  sdk_session_id TEXT NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
 CREATE INDEX IF NOT EXISTS idx_messages_session_id ON messages(session_id, id);
 `;
 
@@ -89,6 +98,9 @@ export class SessionStore {
   private deleteSessionStmt!: PreparedStatement;
   private upsertResetBarrier!: PreparedStatement;
   private selectResetBarrier!: PreparedStatement;
+  private upsertSdkSession!: PreparedStatement;
+  private selectSdkSession!: PreparedStatement;
+  private deleteSdkSession!: PreparedStatement;
 
   /** Tracks the last message_seq at which the bot replied, per group session key. */
   private lastBotReplySeq = new Map<string, number>();
@@ -141,6 +153,17 @@ export class SessionStore {
     );
     this.selectResetBarrier = this.adapter.prepare(
       'SELECT reset_seq FROM reset_barriers WHERE session_id = ?',
+    );
+    this.upsertSdkSession = this.adapter.prepare(
+      'INSERT INTO sdk_sessions (session_id, sdk_session_id, updated_at) VALUES (?, ?, ?) ' +
+        'ON CONFLICT(session_id) DO UPDATE SET sdk_session_id = excluded.sdk_session_id, ' +
+        'updated_at = excluded.updated_at',
+    );
+    this.selectSdkSession = this.adapter.prepare(
+      'SELECT sdk_session_id FROM sdk_sessions WHERE session_id = ?',
+    );
+    this.deleteSdkSession = this.adapter.prepare(
+      'DELETE FROM sdk_sessions WHERE session_id = ?',
     );
   }
 
@@ -216,6 +239,27 @@ export class SessionStore {
       | { reset_seq: number }
       | undefined;
     return row?.reset_seq;
+  }
+
+  /**
+   * v0.3 persistent sessions: record the SDK session UUID for a sessionKey so a
+   * later turn can resume it. Upserts (latest wins).
+   */
+  setSdkSessionId(sessionId: string, sdkSessionId: string): void {
+    this.upsertSdkSession.run(sessionId, sdkSessionId, Date.now());
+  }
+
+  /** Return the stored SDK session UUID for a sessionKey, or undefined. */
+  getSdkSessionId(sessionId: string): string | undefined {
+    const row = this.selectSdkSession.get(sessionId) as
+      | { sdk_session_id: string }
+      | undefined;
+    return row?.sdk_session_id;
+  }
+
+  /** Forget the SDK session mapping (e.g. on /reset or a resume failure). */
+  clearSdkSessionId(sessionId: string): void {
+    this.deleteSdkSession.run(sessionId);
   }
 
   close(): void {


### PR DESCRIPTION
Final v0.3 roadmap item: v2 Session API migration (persistent agent sessions).

## What changed and why

When `sdk.persistentSession` is enabled (config or `CC_OCTO_SDK_PERSISTENT_SESSION=true`), agent workspace state (open files, command history, context) persists across messages. **Default off** — the proven stateless v1 `query()` path is unchanged, so this is purely additive.

**Design:**
- `session-store`: new `sdk_sessions` table mapping our `sessionKey` → SDK session UUID (`set`/`get`/`clear`, upsert latest-wins).
- `agent-bridge`: `queryAgent` gains `opts.resume` (forwarded as the SDK `resume` option) and `opts.onSessionId` (reports the `session_id` once per turn). Both guarded so a throwing callback can't break the stream.
- `index.ts`: when enabled, look up the stored SDK session id, `resume` it, and persist the new id. **On resume the history prefix is suppressed** (the SDK session already holds the conversation) to avoid double-injection — we still write to our own store for the fallback path, `/reset`, and group context.
- `commands.ts`: `/reset` also clears the stored SDK session id, so a cleared conversation is never resumed (same class as the earlier `/reset` backfill-barrier fix).
- `config`: `sdk.persistentSession` flag + env.

## Files modified

- `src/agent-bridge.ts`, `src/session-store.ts`, `src/index.ts`, `src/commands.ts`, `src/config.ts`
- Tests: agent-bridge (+4), session-store (+6), e2e (+3), config (+4 matrix)
- `README.md`, `CHANGELOG.md`, `config.example.json`

## Test results

- `npm run type-check` / `lint` / `build` — clean
- `npm test` — **838 passed** (+23)
- NUL scan clean.

With this merged, **all four v0.3 roadmap items are done** (slash commands, tool progress, multi-bot, v2 Session API). Remaining roadmap: v1.0 (GROUP.md/THREAD.md config, webhook mode).