### PR TITLE
feat(config): per-group instructions via GROUP.md (v1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ While the major version is `0`, minor releases may carry breaking changes.
 
 ### Added
 
+- **Per-group instructions** (v1.0, GROUP.md) — set `groupConfigDir`
+  (`CC_OCTO_GROUP_CONFIG_DIR`) to a directory of `<groupId>.md` files; a matching
+  file's contents are injected into that group's system prompt as a trusted
+  `[Group instructions]` block, so a group can have its own persona/rules without
+  code changes. Operator-controlled (must live outside the agent-writable
+  `cwdBase`); id is filename-pinned to a safe slug (no traversal), content capped
+  at 16 KiB. Groups only. New `src/group-config.ts`.
 - **Persistent sessions** (v0.3, opt-in) — with `sdk.persistentSession`
   (`CC_OCTO_SDK_PERSISTENT_SESSION=true`), agent workspace state persists across
   messages via the SDK v2 Session API. Each session's SDK session id is stored

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,14 @@ While the major version is `0`, minor releases may carry breaking changes.
   (`CC_OCTO_GROUP_CONFIG_DIR`) to a directory of `<groupId>.md` files; a matching
   file's contents are injected into that group's system prompt as a trusted
   `[Group instructions]` block, so a group can have its own persona/rules without
-  code changes. Operator-controlled (must live outside the agent-writable
-  `cwdBase`); id is filename-pinned to a safe slug (no traversal), content capped
-  at 16 KiB. Groups only. New `src/group-config.ts`.
+  code changes. Operator-controlled; id is filename-pinned to a safe slug (no
+  traversal), content capped at 16 KiB, groups only. Boot-time check (re-run
+  per-bot) rejects a `groupConfigDir` equal to or nested under the agent-writable
+  `cwdBase`, using realpath canonicalization. Because the agent can still write
+  absolute paths under default Bash/bypassPermissions, the block is a trusted
+  prompt-injection sink whose safety requires OS-level file permissions + a
+  hardened deployment — documented prominently, with a defense-in-depth refusal
+  to inject a group/world-writable file. New `src/group-config.ts`.
 - **Persistent sessions** (v0.3, opt-in) — with `sdk.persistentSession`
   (`CC_OCTO_SDK_PERSISTENT_SESSION=true`), agent workspace state persists across
   messages via the SDK v2 Session API. Each session's SDK session id is stored

--- a/README.md
+++ b/README.md
@@ -142,7 +142,9 @@ Leave the field unset to talk to Anthropic's public endpoint directly.
 Give a specific group its own persona or rules without code changes: set
 `groupConfigDir` to a directory you control, and drop a `<groupId>.md` file in
 it (the group's channel id, e.g. `s12_345.md`). Its contents are injected into
-that group's system prompt as a trusted `[Group instructions]` block.
+that group's system prompt as a trusted, **unsanitized** `[Group instructions]`
+block. Only groups use this; DMs key on the peer uid. The key is the channel id,
+so all topics under one `CommunityTopic` channel id share the same file.
 
 ```bash
 CC_OCTO_GROUP_CONFIG_DIR=/home/deploy/cc-octo-groups npm start
@@ -150,10 +152,23 @@ CC_OCTO_GROUP_CONFIG_DIR=/home/deploy/cc-octo-groups npm start
 #   Always answer in formal English and cite sources.
 ```
 
-These files are **operator-controlled** — they must live outside the per-session
-`cwdBase` sandbox (which the agent can write), since they shape the system
-prompt. Files larger than 16 KiB are truncated; an unsafe group id (path
-separators, `..`) is ignored. Only groups use this; DMs key on the peer uid.
+> ⚠️ **Security — this is a trusted, unsanitized prompt-injection sink.** Its
+> safety depends entirely on the files being writable **only** by the operator.
+> Putting `groupConfigDir` outside `cwdBase` is required (the gateway refuses
+> otherwise) but **not sufficient**: under the shipped defaults (`allowedTools:
+> "*"` + `bypassPermissions`) the agent has `Bash`/`Write` and can write
+> **absolute** paths outside `cwdBase` — `cwdBase` is a starting dir, not a
+> chroot (see [Security Model](#security-model)). A malicious user could then
+> have the agent write `<groupConfigDir>/<otherGroup>.md` and inject persistent,
+> trusted instructions into another group. So you **must**:
+> - make `groupConfigDir` and its files **non-writable by the gateway process
+>   user** (e.g. root-owned, mode `0755`/`0644`), and/or
+> - harden the deployment (drop `Bash` from `allowedTools`, run unprivileged,
+>   sandbox the filesystem).
+>
+> As defense-in-depth the gateway refuses to inject a group/world-writable file,
+> but that is a backstop, not the guarantee. Files larger than 16 KiB are
+> truncated; an unsafe group id (path separators, `..`) is ignored.
 
 ### Multi-bot
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Three-level priority: **environment variables** > **config.json** > **defaults**
 | `sdk.settingSources` | `CC_OCTO_SDK_SETTING_SOURCES` | `user` | Comma-separated setting sources (e.g. `user,project`) |
 | `sdk.toolProgress` | `CC_OCTO_SDK_TOOL_PROGRESS` | `false` | When true, post `🔧 Running <tool>…` notices as the agent invokes tools (deduped, capped per turn) |
 | `sdk.persistentSession` | `CC_OCTO_SDK_PERSISTENT_SESSION` | `false` | When true, persist agent workspace state across messages via the SDK v2 Session API (resume by stored session id). `/reset` clears it. |
+| `groupConfigDir` | `CC_OCTO_GROUP_CONFIG_DIR` | *(unset)* | Directory of per-group instruction files (`<groupId>.md`). A match is injected into the system prompt as trusted custom instructions for that group. See [Per-group instructions](#per-group-instructions). |
 | `sdk.anthropicBaseUrl` | `ANTHROPIC_BASE_URL` | *(unset)* | Override the upstream Claude API endpoint. See [Self-hosted gateway](#self-hosted-gateway) below. |
 | `rateLimit.maxPerMinute` | `CC_OCTO_RATE_LIMIT_MAX_PER_MINUTE` | `5` | Max requests per minute per session |
 | `context.maxContextChars` | `CC_OCTO_CONTEXT_MAX_CHARS` | `6000` | Max characters of group context injected into prompts |
@@ -135,6 +136,24 @@ ANTHROPIC_BASE_URL=https://claude-gw.internal.example.com npm start
 ```
 
 Leave the field unset to talk to Anthropic's public endpoint directly.
+
+### Per-group instructions
+
+Give a specific group its own persona or rules without code changes: set
+`groupConfigDir` to a directory you control, and drop a `<groupId>.md` file in
+it (the group's channel id, e.g. `s12_345.md`). Its contents are injected into
+that group's system prompt as a trusted `[Group instructions]` block.
+
+```bash
+CC_OCTO_GROUP_CONFIG_DIR=/home/deploy/cc-octo-groups npm start
+# /home/deploy/cc-octo-groups/s12_345.md:
+#   Always answer in formal English and cite sources.
+```
+
+These files are **operator-controlled** — they must live outside the per-session
+`cwdBase` sandbox (which the agent can write), since they shape the system
+prompt. Files larger than 16 KiB are truncated; an unsafe group id (path
+separators, `..`) is ignored. Only groups use this; DMs key on the peer uid.
 
 ### Multi-bot
 
@@ -322,7 +341,7 @@ src/
 | **v0.1** | Text messaging, streaming, session persistence, rate limiting, security model |
 | **v0.2** *(current)* | Media reception & sending (image/file/RichText), @mention, group context, per-session `cwdBase` isolation, self-hosted gateway, SSRF/prompt-injection hardening |
 | **v0.3** | Slash commands, tool progress, multi-bot, v2 Session API |
-| **v1.0** | GROUP.md/THREAD.md configuration, webhook mode |
+| **v1.0** | webhook mode |
 
 ## Contributing
 

--- a/config.example.json
+++ b/config.example.json
@@ -6,6 +6,7 @@
   "_comment_cwd_base": "Q3: base directory for per-session cwd isolation. Each session gets a 16-hex SHA-256 subdirectory under this path; subdirs idle for >7d are auto-cleaned every 6h. Env override: CC_OCTO_CWDBASE (legacy CC_OCTO_CWD still accepted with a deprecation warning).",
   "cwdBase": "/path/to/isolated/sandbox-root",
   "dataDir": "./data",
+  "_comment_group_config_dir": "v1.0: optional directory of per-group instruction files (<groupId>.md). A matching file's contents are injected into that group's system prompt as trusted custom instructions. Operator-controlled — keep it OUTSIDE cwdBase (the agent can write there). Env override: CC_OCTO_GROUP_CONFIG_DIR. Omit to disable.",
 
   "sdk": {
     "_comment_anthropic_base_url": "Q1: Optional self-hosted Claude API gateway base URL. Forwarded to the SDK subprocess (scoped, not via global process.env). Must be https:// (or http://localhost for dev) — it is SSRF-validated at boot like apiUrl. To enable, add a real \"anthropicBaseUrl\": \"https://your-gateway.example.com\" key here, or set the ANTHROPIC_BASE_URL env var (highest priority, Anthropic SDK standard name, no CC_OCTO_ prefix). Leave it out entirely to use Anthropic's public endpoint.",

--- a/src/__tests__/agent-bridge.test.ts
+++ b/src/__tests__/agent-bridge.test.ts
@@ -85,6 +85,27 @@ describe('buildSystemPrompt', () => {
     expect(result).toContain('decline and explain why');
   });
 
+  it('includes a [Group instructions] section when groupInstructions provided (v1.0)', () => {
+    const result = buildSystemPrompt('', '', undefined, 'Always answer in French.');
+    expect(result).toContain('[Group instructions]');
+    expect(result).toContain('Always answer in French.');
+    // Ordered after the security prefix.
+    expect(result.indexOf('untrusted IM users')).toBeLessThan(result.indexOf('[Group instructions]'));
+  });
+
+  it('omits the [Group instructions] section when not provided', () => {
+    const result = buildSystemPrompt('', '', 'custom');
+    expect(result).not.toContain('[Group instructions]');
+  });
+
+  it('orders group instructions before group context and history content', () => {
+    const result = buildSystemPrompt('[user]: HISTLINE', 'CTXLINE', 'custom', 'GROUPRULES');
+    // Compare against unique content tokens (the security prefix itself mentions
+    // the [Group context]/[Conversation history] marker words, so match content).
+    expect(result.indexOf('GROUPRULES')).toBeLessThan(result.indexOf('CTXLINE'));
+    expect(result.indexOf('CTXLINE')).toBeLessThan(result.indexOf('HISTLINE'));
+  });
+
   it('includes group context section when provided', () => {
     const result = buildSystemPrompt('', 'Alice: hello\nBob: world');
     expect(result).toContain('[Group context]');

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -29,6 +29,7 @@ const CC_VARS = [
   'CC_OCTO_CONTEXT_HISTORY_LIMIT', 'CC_OCTO_BOT_BLOCKLIST',
   'CC_OCTO_MENTION_FREE_GROUPS', 'CC_OCTO_MAX_RESPONSE_CHARS',
   'ANTHROPIC_BASE_URL', 'CC_OCTO_SDK_TOOL_PROGRESS', 'CC_OCTO_SDK_PERSISTENT_SESSION',
+  'CC_OCTO_GROUP_CONFIG_DIR',
 ];
 
 function setup() {
@@ -816,5 +817,61 @@ describe('v0.3: persistent session toggle', () => {
     });
     process.env.CC_OCTO_SDK_PERSISTENT_SESSION = val;
     expect(loadConfig(path).sdk.persistentSession).toBe(false);
+  });
+});
+
+// ─── v1.0: groupConfigDir trust-boundary validation ────────────────────
+
+describe('v1.0: groupConfigDir must be outside cwdBase', () => {
+  beforeEach(setup);
+  afterEach(teardown);
+
+  it('accepts a groupConfigDir outside cwdBase', () => {
+    const path = writeConfig({
+      botToken: 'bf_t', apiUrl: 'https://a',
+      cwdBase: '/srv/octo/sandboxes', groupConfigDir: '/srv/octo/groups',
+    });
+    expect(loadConfig(path).groupConfigDir).toBe('/srv/octo/groups');
+  });
+
+  it('rejects groupConfigDir equal to cwdBase', () => {
+    const path = writeConfig({
+      botToken: 'bf_t', apiUrl: 'https://a',
+      cwdBase: '/srv/octo', groupConfigDir: '/srv/octo',
+    });
+    expect(() => loadConfig(path)).toThrow(/Unsafe groupConfigDir/);
+  });
+
+  it('rejects groupConfigDir nested under cwdBase (file config)', () => {
+    const path = writeConfig({
+      botToken: 'bf_t', apiUrl: 'https://a',
+      cwdBase: '/srv/octo', groupConfigDir: '/srv/octo/groups',
+    });
+    expect(() => loadConfig(path)).toThrow(/Unsafe groupConfigDir/);
+  });
+
+  it('rejects nested groupConfigDir expressed with .. (resolved-path check)', () => {
+    const path = writeConfig({
+      botToken: 'bf_t', apiUrl: 'https://a',
+      cwdBase: '/srv/octo', groupConfigDir: '/srv/octo/x/../groups',
+    });
+    expect(() => loadConfig(path)).toThrow(/Unsafe groupConfigDir/);
+  });
+
+  it('rejects nested groupConfigDir set via env (CC_OCTO_GROUP_CONFIG_DIR)', () => {
+    const path = writeConfig({
+      botToken: 'bf_t', apiUrl: 'https://a', cwdBase: '/srv/octo',
+    });
+    process.env.CC_OCTO_GROUP_CONFIG_DIR = '/srv/octo/groups';
+    expect(() => loadConfig(path)).toThrow(/Unsafe groupConfigDir/);
+  });
+
+  it('does not reject a sibling dir that shares a name prefix with cwdBase', () => {
+    // /srv/octo-groups is NOT inside /srv/octo — guard against naive prefix match.
+    const path = writeConfig({
+      botToken: 'bf_t', apiUrl: 'https://a',
+      cwdBase: '/srv/octo', groupConfigDir: '/srv/octo-groups',
+    });
+    expect(loadConfig(path).groupConfigDir).toBe('/srv/octo-groups');
   });
 });

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -767,6 +767,28 @@ describe('v0.3: resolveBotConfigs', () => {
     expect(() => resolveBotConfigs(cfg)).toThrow(/unsafe apiUrl/i);
   });
 
+  it('re-checks the GROUP.md boundary against a per-bot cwdBase override', () => {
+    // Top-level passes (groups dir is outside top-level cwdBase), but the bot's
+    // own cwdBase override would swallow groupConfigDir — must be rejected.
+    const cfg = loadConfig(writeConfig({
+      apiUrl: 'https://a',
+      cwdBase: '/srv/sandboxes',
+      groupConfigDir: '/srv/octo/groups',
+      bots: [{ id: 'a', botToken: 'bf_1', cwdBase: '/srv/octo' }],
+    }));
+    expect(() => resolveBotConfigs(cfg)).toThrow(/Unsafe groupConfigDir/);
+  });
+
+  it('allows a per-bot cwdBase that stays clear of groupConfigDir', () => {
+    const cfg = loadConfig(writeConfig({
+      apiUrl: 'https://a',
+      cwdBase: '/srv/sandboxes',
+      groupConfigDir: '/srv/octo/groups',
+      bots: [{ id: 'a', botToken: 'bf_1', cwdBase: '/srv/other' }],
+    }));
+    expect(() => resolveBotConfigs(cfg)).not.toThrow();
+  });
+
   it.each(['../ops', 'a/b', '.', '..', 'a\\b', 'with space'])(
     'rejects path-traversal/invalid bot id %j',
     (badId) => {

--- a/src/__tests__/e2e.test.ts
+++ b/src/__tests__/e2e.test.ts
@@ -4,6 +4,9 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 // --- Mocks (hoisted before imports) ---
 
@@ -331,6 +334,51 @@ describe('E2E smoke tests', () => {
     await simulateMessage(makeDmMsg('hi'), config, store, router, groupContext, streamRelay);
     expect(sawOpts).toBeUndefined();
     expect(store.getSdkSessionId(USER_UID)).toBeUndefined();
+  });
+
+  // --- v1.0 GROUP.md per-group instructions ---
+
+  it('injects GROUP.md instructions into queryAgent opts for a group', async () => {
+    const cfgDir = mkdtempSync(join(tmpdir(), 'e2e-groupcfg-'));
+    writeFileSync(join(cfgDir, `${GROUP_CHANNEL}.md`), 'Always answer in haiku.');
+    const cfg = makeConfig({ groupConfigDir: cfgDir });
+
+    let sawInstructions: string | undefined;
+    (queryAgent as ReturnType<typeof vi.fn>).mockImplementation(
+      async function* (
+        _u: string, _h: string, _c: string, _cfg: Config, _ctx: unknown, _t: unknown,
+        opts?: { groupInstructions?: string },
+      ) {
+        sawInstructions = opts?.groupInstructions;
+        yield 'ok';
+      },
+    );
+
+    await simulateMessage(makeGroupMsg('hi', true), cfg, store, router, groupContext, streamRelay);
+    expect(sawInstructions).toBe('Always answer in haiku.');
+    rmSync(cfgDir, { recursive: true, force: true });
+  });
+
+  it('does not inject group instructions for a DM', async () => {
+    const cfgDir = mkdtempSync(join(tmpdir(), 'e2e-groupcfg-dm-'));
+    // A file named after the DM peer must NOT be picked up (DMs aren't groups).
+    writeFileSync(join(cfgDir, `${USER_UID}.md`), 'leak');
+    const cfg = makeConfig({ groupConfigDir: cfgDir });
+
+    let sawOpts: unknown = 'unset';
+    (queryAgent as ReturnType<typeof vi.fn>).mockImplementation(
+      async function* (
+        _u: string, _h: string, _c: string, _cfg: Config, _ctx: unknown, _t: unknown,
+        opts?: unknown,
+      ) {
+        sawOpts = opts;
+        yield 'ok';
+      },
+    );
+
+    await simulateMessage(makeDmMsg('hi'), cfg, store, router, groupContext, streamRelay);
+    expect(sawOpts).toBeUndefined();
+    rmSync(cfgDir, { recursive: true, force: true });
   });
 
   it('/reset barrier prevents group backfill from resurrecting pre-reset history', async () => {

--- a/src/__tests__/group-config.test.ts
+++ b/src/__tests__/group-config.test.ts
@@ -3,8 +3,8 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, chmodSync } from 'node:fs';
+import { tmpdir, platform } from 'node:os';
 import { join } from 'node:path';
 import { loadGroupConfig, MAX_GROUP_CONFIG_BYTES } from '../group-config.js';
 
@@ -67,5 +67,28 @@ describe('loadGroupConfig', () => {
   it('does not throw when groupConfigDir does not exist', () => {
     expect(() => loadGroupConfig(join(dir, 'missing'), 'g1')).not.toThrow();
     expect(loadGroupConfig(join(dir, 'missing'), 'g1')).toBeUndefined();
+  });
+
+  const itPosix = platform() === 'win32' ? it.skip : it;
+
+  itPosix('refuses a world-writable file (defense-in-depth)', () => {
+    const p = join(dir, 'g1.md');
+    writeFileSync(p, 'instructions');
+    chmodSync(p, 0o646); // world-writable
+    expect(loadGroupConfig(dir, 'g1')).toBeUndefined();
+  });
+
+  itPosix('refuses a group-writable file', () => {
+    const p = join(dir, 'g1.md');
+    writeFileSync(p, 'instructions');
+    chmodSync(p, 0o664); // group-writable
+    expect(loadGroupConfig(dir, 'g1')).toBeUndefined();
+  });
+
+  itPosix('accepts an owner-only / non-group-writable file', () => {
+    const p = join(dir, 'g1.md');
+    writeFileSync(p, 'instructions');
+    chmodSync(p, 0o644); // owner-write, others read-only
+    expect(loadGroupConfig(dir, 'g1')).toBe('instructions');
   });
 });

--- a/src/__tests__/group-config.test.ts
+++ b/src/__tests__/group-config.test.ts
@@ -1,0 +1,71 @@
+/**
+ * group-config tests (v1.0 GROUP.md/THREAD.md).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { loadGroupConfig, MAX_GROUP_CONFIG_BYTES } from '../group-config.js';
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'group-config-test-'));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe('loadGroupConfig', () => {
+  it('returns undefined when groupConfigDir is unset', () => {
+    expect(loadGroupConfig(undefined, 'g1')).toBeUndefined();
+  });
+
+  it('returns undefined when no file matches', () => {
+    expect(loadGroupConfig(dir, 'g1')).toBeUndefined();
+  });
+
+  it('loads <groupId>.md contents (trimmed)', () => {
+    writeFileSync(join(dir, 'g1.md'), '\n  Be terse and formal.\n');
+    expect(loadGroupConfig(dir, 'g1')).toBe('Be terse and formal.');
+  });
+
+  it('is keyed per group id', () => {
+    writeFileSync(join(dir, 'g1.md'), 'one');
+    writeFileSync(join(dir, 'g2.md'), 'two');
+    expect(loadGroupConfig(dir, 'g1')).toBe('one');
+    expect(loadGroupConfig(dir, 'g2')).toBe('two');
+  });
+
+  it('returns undefined for an empty / whitespace-only file', () => {
+    writeFileSync(join(dir, 'g1.md'), '   \n  ');
+    expect(loadGroupConfig(dir, 'g1')).toBeUndefined();
+  });
+
+  it('truncates an oversized file to the byte cap', () => {
+    writeFileSync(join(dir, 'big.md'), 'x'.repeat(MAX_GROUP_CONFIG_BYTES + 5000));
+    const out = loadGroupConfig(dir, 'big')!;
+    expect(out).toContain('[… group config truncated]');
+    expect(Buffer.byteLength(out, 'utf-8')).toBeLessThan(MAX_GROUP_CONFIG_BYTES + 100);
+  });
+
+  it.each(['../etc', 'a/b', '.', '..', 'a\\b', 'with space', ''])(
+    'rejects unsafe/empty group id %j (no traversal)',
+    (badId) => {
+      // Even if a file with that literal name somehow existed, the id is rejected.
+      expect(loadGroupConfig(dir, badId)).toBeUndefined();
+    },
+  );
+
+  it('does not follow a directory named like the file', () => {
+    mkdirSync(join(dir, 'g1.md'));
+    expect(loadGroupConfig(dir, 'g1')).toBeUndefined();
+  });
+
+  it('does not throw when groupConfigDir does not exist', () => {
+    expect(() => loadGroupConfig(join(dir, 'missing'), 'g1')).not.toThrow();
+    expect(loadGroupConfig(join(dir, 'missing'), 'g1')).toBeUndefined();
+  });
+});

--- a/src/agent-bridge.ts
+++ b/src/agent-bridge.ts
@@ -117,10 +117,17 @@ export function buildSystemPrompt(
   historyPrefix: string,
   groupContext: string,
   customPrompt?: string,
+  groupInstructions?: string,
 ): string {
   const parts: string[] = [SECURITY_PROMPT_PREFIX];
   if (customPrompt) {
     parts.push(customPrompt);
+  }
+  if (groupInstructions) {
+    // v1.0 GROUP.md: operator-provided, trusted per-group instructions. Placed
+    // after the global custom prompt so a group can specialize behavior. NOT
+    // sanitized like group context — this is a trusted operator file, not chat.
+    parts.push(`[Group instructions]\n${groupInstructions}`);
   }
   if (groupContext) {
     // S3/PM-P1-B fix: group context lines are user-authored chat messages.
@@ -280,16 +287,18 @@ export async function* queryAgent(
   config: Config,
   sessionCtx?: SessionCtx,
   onToolUse?: (toolName: string) => void,
-  opts?: { resume?: string; onSessionId?: (id: string) => void },
+  opts?: { resume?: string; onSessionId?: (id: string) => void; groupInstructions?: string },
 ): AsyncIterable<string> {
   const permissionMode = toPermissionMode(config.sdk.permissionMode);
   const settingSources = toSettingSources(config.sdk.settingSources);
 
-  // Build system prompt: non-overridable security prefix + custom + context + history
+  // Build system prompt: non-overridable security prefix + custom + group
+  // instructions (v1.0 GROUP.md) + context + history
   const systemPrompt = buildSystemPrompt(
     historyPrefix,
     groupContext,
     config.sdk.systemPrompt,
+    opts?.groupInstructions,
   );
 
   // Q3: per-session cwd under cwdBase — creates the directory on first use.

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,7 +3,7 @@
  * Three-level priority: env > config.json > defaults.
  */
 
-import { readFileSync, existsSync, statSync } from 'node:fs';
+import { readFileSync, existsSync, statSync, realpathSync } from 'node:fs';
 import { resolve as resolvePath, sep } from 'node:path';
 import { isAllowedApiUrl } from './url-policy.js';
 
@@ -428,24 +428,44 @@ export function loadConfig(configPath?: string): Config {
     );
   }
 
-  // v1.0 GROUP.md trust boundary: groupConfigDir contents are injected UNSANITIZED
-  // into the system prompt, so it must be operator-controlled — NOT the same as,
-  // nor nested under, the agent-writable cwdBase. Otherwise a user-driven agent
-  // could write its own future system-prompt instructions. Enforce with resolved
-  // paths so `.`/`..`/symlink-free traversal can't slip a nested dir past us.
-  if (final.groupConfigDir) {
-    const cwdBaseResolved = resolvePath(final.cwdBase ?? final.cwd);
-    const groupDirResolved = resolvePath(final.groupConfigDir);
-    if (groupDirResolved === cwdBaseResolved || isPathInside(groupDirResolved, cwdBaseResolved)) {
-      throw new Error(
-        `Unsafe groupConfigDir: ${final.groupConfigDir} is the same as or nested under ` +
-        `cwdBase (${final.cwdBase ?? final.cwd}). It must be operator-controlled and ` +
-        `outside the agent-writable sandbox, since its files are injected into the system prompt.`,
-      );
-    }
-  }
+  // v1.0 GROUP.md trust boundary — checked here for the single-bot/top-level
+  // case; resolveBotConfigs() re-checks each bot AFTER applying per-bot cwdBase
+  // overrides (a per-bot cwdBase could otherwise swallow groupConfigDir).
+  assertGroupConfigDirOutsideCwd(final);
 
   return final;
+}
+
+/**
+ * Enforce that `groupConfigDir` (whose files are injected UNSANITIZED into the
+ * system prompt) is not the same as, nor nested under, the agent-writable
+ * `cwdBase`. Otherwise a user-driven agent could write its own future
+ * system-prompt instructions.
+ *
+ * Uses realpathSync.native for paths that exist (so symlinks can't dodge the
+ * boundary) and falls back to lexical resolve() for not-yet-created dirs.
+ */
+function assertGroupConfigDirOutsideCwd(cfg: Config): void {
+  if (!cfg.groupConfigDir) return;
+  const cwdBase = cfg.cwdBase ?? cfg.cwd;
+  const cwdBaseResolved = canonicalize(cwdBase);
+  const groupDirResolved = canonicalize(cfg.groupConfigDir);
+  if (groupDirResolved === cwdBaseResolved || isPathInside(groupDirResolved, cwdBaseResolved)) {
+    throw new Error(
+      `Unsafe groupConfigDir: ${cfg.groupConfigDir} is the same as or nested under ` +
+      `cwdBase (${cwdBase}). It must be operator-controlled and outside the ` +
+      `agent-writable sandbox, since its files are injected into the system prompt.`,
+    );
+  }
+}
+
+/** Resolve to a real path when it exists (defeats symlink dodges), else lexical. */
+function canonicalize(p: string): string {
+  try {
+    return realpathSync.native(p);
+  } catch {
+    return resolvePath(p);
+  }
 }
 
 /** True when `child` is strictly inside `parent` (both already resolved). */
@@ -523,6 +543,10 @@ export function resolveBotConfigs(config: Config): Config[] {
         `Multi-bot: unsafe apiUrl for bot "${id}": ${resolved.apiUrl} (SSRF protection)`,
       );
     }
+    // Re-check the GROUP.md trust boundary against THIS bot's resolved cwdBase
+    // (a per-bot cwdBase override could place groupConfigDir inside the bot's
+    // own writable sandbox, which the top-level check in loadConfig can't see).
+    assertGroupConfigDirOutsideCwd(resolved);
     return resolved;
   });
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,6 +4,7 @@
  */
 
 import { readFileSync, existsSync, statSync } from 'node:fs';
+import { resolve as resolvePath, sep } from 'node:path';
 import { isAllowedApiUrl } from './url-policy.js';
 
 /**
@@ -427,7 +428,30 @@ export function loadConfig(configPath?: string): Config {
     );
   }
 
+  // v1.0 GROUP.md trust boundary: groupConfigDir contents are injected UNSANITIZED
+  // into the system prompt, so it must be operator-controlled — NOT the same as,
+  // nor nested under, the agent-writable cwdBase. Otherwise a user-driven agent
+  // could write its own future system-prompt instructions. Enforce with resolved
+  // paths so `.`/`..`/symlink-free traversal can't slip a nested dir past us.
+  if (final.groupConfigDir) {
+    const cwdBaseResolved = resolvePath(final.cwdBase ?? final.cwd);
+    const groupDirResolved = resolvePath(final.groupConfigDir);
+    if (groupDirResolved === cwdBaseResolved || isPathInside(groupDirResolved, cwdBaseResolved)) {
+      throw new Error(
+        `Unsafe groupConfigDir: ${final.groupConfigDir} is the same as or nested under ` +
+        `cwdBase (${final.cwdBase ?? final.cwd}). It must be operator-controlled and ` +
+        `outside the agent-writable sandbox, since its files are injected into the system prompt.`,
+      );
+    }
+  }
+
   return final;
+}
+
+/** True when `child` is strictly inside `parent` (both already resolved). */
+function isPathInside(child: string, parent: string): boolean {
+  const parentWithSep = parent.endsWith(sep) ? parent : parent + sep;
+  return child.startsWith(parentWithSep);
 }
 
 /**

--- a/src/config.ts
+++ b/src/config.ts
@@ -32,6 +32,13 @@ export interface Config {
    */
   cwd: string;
   dataDir: string;
+  /**
+   * v1.0: directory of per-group instruction files (`<groupId>.md`). When set,
+   * a matching file's contents are injected into the system prompt as trusted
+   * custom instructions for that group. Operator-controlled — must NOT be the
+   * per-session cwd sandbox (which the agent can write). Unset = feature off.
+   */
+  groupConfigDir?: string;
   sdk: {
     model?: string;
     /**
@@ -138,6 +145,7 @@ type PartialConfig = {
   /** Q3 deprecated alias — maps to cwdBase with a warning. */
   cwd?: string;
   dataDir?: string;
+  groupConfigDir?: string;
   sdk?: Partial<Config['sdk']>;
   rateLimit?: Partial<Config['rateLimit']>;
   context?: Partial<Config['context']>;
@@ -228,6 +236,7 @@ function mergeConfig(base: Config, override: PartialConfig): Config {
     // Keep deprecated `cwd` in sync so any legacy reader still sees a value.
     cwd: cwdBase ?? base.cwd,
     dataDir: override.dataDir ?? base.dataDir,
+    groupConfigDir: override.groupConfigDir ?? base.groupConfigDir,
     sdk: {
       ...base.sdk,
       ...(override.sdk ?? {}),
@@ -299,6 +308,7 @@ function applyEnv(cfg: Config): Config {
     next.cwd = envCwd;
   }
   if (env.CC_OCTO_DATA_DIR) next.dataDir = env.CC_OCTO_DATA_DIR;
+  if (env.CC_OCTO_GROUP_CONFIG_DIR) next.groupConfigDir = env.CC_OCTO_GROUP_CONFIG_DIR;
 
   if (env.CC_OCTO_SDK_MODEL) next.sdk.model = env.CC_OCTO_SDK_MODEL;
   if (env.CC_OCTO_SDK_ALLOWED_TOOLS) {

--- a/src/group-config.ts
+++ b/src/group-config.ts
@@ -6,12 +6,23 @@
  * injected into the agent's system prompt as a trusted instruction block, so a
  * group can have its own persona / rules without code changes.
  *
- * SECURITY: these files are OPERATOR-controlled, NOT agent- or user-writable.
- * They live in `config.groupConfigDir` (a path the operator manages), never in
- * the per-session cwd sandbox (which the agent can write). That's the whole
- * point — system-prompt-level instructions must come from a trusted source.
- * The lookup is filename-pinned to a sanitized id so a crafted group/thread id
- * can't traverse out of the config dir.
+ * SECURITY — read carefully. The `[Group instructions]` block is injected into
+ * the system prompt UNSANITIZED, so its contents are trusted. That trust holds
+ * ONLY if the file is writable solely by the operator (the gateway process user).
+ *
+ * Placing `groupConfigDir` outside `cwdBase` is necessary but NOT sufficient:
+ * under the shipped defaults (`allowedTools: '*'`, `bypassPermissions`) the agent
+ * has `Bash`/`Write` and can write ABSOLUTE paths anywhere the gateway user can
+ * write — `cwdBase` is a starting dir, not a chroot. So a malicious user in one
+ * group could drive the agent to write `<groupConfigDir>/<otherGroup>.md` and
+ * inject persistent, trusted instructions into a different group.
+ *
+ * The real protection is OS-level: `groupConfigDir` and its files MUST be made
+ * non-writable by the gateway process user (e.g. root-owned, mode 0755/0644),
+ * and/or the deployment hardened (drop `Bash`, sandboxed FS, unprivileged user).
+ * As cheap defense-in-depth, loadGroupConfig() refuses to inject a file that is
+ * group- or world-writable. The group id is filename-pinned to a safe slug so a
+ * crafted id can't traverse out of the config dir.
  */
 
 import { closeSync, existsSync, openSync, readSync, statSync } from 'node:fs';
@@ -51,7 +62,21 @@ export function loadGroupConfig(
   const path = join(groupConfigDir, `${groupId}.md`);
   try {
     if (!existsSync(path)) return undefined;
-    if (!statSync(path).isFile()) return undefined;
+    const st = statSync(path);
+    if (!st.isFile()) return undefined;
+    // Defense-in-depth: refuse a group/world-writable file. Its contents are
+    // injected UNSANITIZED into the system prompt, so a file anyone-but-the-
+    // operator can write is an untrusted injection sink. This catches the most
+    // common misconfiguration; it is NOT a substitute for proper OS perms +
+    // a hardened deployment (the agent can still write operator-owned paths
+    // under default Bash/bypassPermissions — see the module header).
+    if ((st.mode & 0o022) !== 0) {
+      console.error(
+        `[cc-channel-octo] refusing group config ${path}: file is group/world-writable ` +
+        `(mode ${(st.mode & 0o777).toString(8)}). Make it writable only by the gateway user.`,
+      );
+      return undefined;
+    }
     // Read at most MAX+1 bytes so a mistakenly huge file can't block the event
     // loop or allocate unbounded memory on every group turn. Reading one extra
     // byte lets us detect (and mark) truncation.

--- a/src/group-config.ts
+++ b/src/group-config.ts
@@ -14,7 +14,7 @@
  * can't traverse out of the config dir.
  */
 
-import { existsSync, readFileSync, statSync } from 'node:fs';
+import { closeSync, existsSync, openSync, readSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 
 /** Max bytes of an instruction file we will inject (keeps the prompt bounded). */
@@ -52,13 +52,25 @@ export function loadGroupConfig(
   try {
     if (!existsSync(path)) return undefined;
     if (!statSync(path).isFile()) return undefined;
-    let content = readFileSync(path, 'utf-8');
-    if (Buffer.byteLength(content, 'utf-8') > MAX_GROUP_CONFIG_BYTES) {
-      // Byte-safe truncation to a valid UTF-8 boundary.
-      content = content.slice(0, MAX_GROUP_CONFIG_BYTES);
-      while (Buffer.byteLength(content, 'utf-8') > MAX_GROUP_CONFIG_BYTES) {
-        content = content.slice(0, -1);
-      }
+    // Read at most MAX+1 bytes so a mistakenly huge file can't block the event
+    // loop or allocate unbounded memory on every group turn. Reading one extra
+    // byte lets us detect (and mark) truncation.
+    const fd = openSync(path, 'r');
+    let content: string;
+    let wasTruncated = false;
+    try {
+      const buf = Buffer.allocUnsafe(MAX_GROUP_CONFIG_BYTES + 1);
+      const bytesRead = readSync(fd, buf, 0, MAX_GROUP_CONFIG_BYTES + 1, 0);
+      wasTruncated = bytesRead > MAX_GROUP_CONFIG_BYTES;
+      const slice = buf.subarray(0, Math.min(bytesRead, MAX_GROUP_CONFIG_BYTES));
+      content = slice.toString('utf-8');
+    } finally {
+      closeSync(fd);
+    }
+    if (wasTruncated) {
+      // The slice may end mid-codepoint; trim back to a valid UTF-8 boundary by
+      // dropping any trailing replacement char produced by a split sequence.
+      content = content.replace(/�+$/, '');
       content += '\n[… group config truncated]';
     }
     const trimmed = content.trim();

--- a/src/group-config.ts
+++ b/src/group-config.ts
@@ -1,0 +1,70 @@
+/**
+ * v1.0: GROUP.md / THREAD.md per-conversation instruction files.
+ *
+ * Operators can drop a markdown file with custom instructions for a specific
+ * group (or, later, thread) into a configured directory. Its contents are
+ * injected into the agent's system prompt as a trusted instruction block, so a
+ * group can have its own persona / rules without code changes.
+ *
+ * SECURITY: these files are OPERATOR-controlled, NOT agent- or user-writable.
+ * They live in `config.groupConfigDir` (a path the operator manages), never in
+ * the per-session cwd sandbox (which the agent can write). That's the whole
+ * point — system-prompt-level instructions must come from a trusted source.
+ * The lookup is filename-pinned to a sanitized id so a crafted group/thread id
+ * can't traverse out of the config dir.
+ */
+
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+/** Max bytes of an instruction file we will inject (keeps the prompt bounded). */
+export const MAX_GROUP_CONFIG_BYTES = 16_384; // 16 KiB
+
+/**
+ * Only allow ids that are safe as a single path segment — letters, digits, and
+ * a few separators. Anything else (slashes, dots-only, `..`) is rejected so a
+ * channel/thread id cannot escape `groupConfigDir`.
+ */
+function isSafeId(id: string): boolean {
+  return /^[a-zA-Z0-9._-]+$/.test(id) && id !== '.' && id !== '..';
+}
+
+/**
+ * Load the instruction file for a group, or undefined when none applies.
+ *
+ * Looks for `<groupConfigDir>/<groupId>.md`. Returns the trimmed contents,
+ * truncated to MAX_GROUP_CONFIG_BYTES. Returns undefined when:
+ *   - groupConfigDir is not configured,
+ *   - groupId is empty or unsafe as a path segment,
+ *   - the file does not exist or is unreadable.
+ *
+ * Never throws — a misconfigured dir or unreadable file degrades to "no custom
+ * instructions" rather than failing the turn.
+ */
+export function loadGroupConfig(
+  groupConfigDir: string | undefined,
+  groupId: string,
+): string | undefined {
+  if (!groupConfigDir) return undefined;
+  if (!groupId || !isSafeId(groupId)) return undefined;
+
+  const path = join(groupConfigDir, `${groupId}.md`);
+  try {
+    if (!existsSync(path)) return undefined;
+    if (!statSync(path).isFile()) return undefined;
+    let content = readFileSync(path, 'utf-8');
+    if (Buffer.byteLength(content, 'utf-8') > MAX_GROUP_CONFIG_BYTES) {
+      // Byte-safe truncation to a valid UTF-8 boundary.
+      content = content.slice(0, MAX_GROUP_CONFIG_BYTES);
+      while (Buffer.byteLength(content, 'utf-8') > MAX_GROUP_CONFIG_BYTES) {
+        content = content.slice(0, -1);
+      }
+      content += '\n[… group config truncated]';
+    }
+    const trimmed = content.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  } catch (err) {
+    console.error(`[cc-channel-octo] group config read failed for ${path}: ${String(err)}`);
+    return undefined;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ import { ChannelType, MessageType } from './octo/types.js';
 import type { BotMessage } from './octo/types.js';
 import { resolveContent, tryResolveFile, resolveHistoricalMessagePlaceholder } from './inbound.js';
 import { handleCommand } from './commands.js';
+import { loadGroupConfig } from './group-config.js';
 import { buildInlinedFileBody, truncateUtf8ByBytes } from './file-inline-wrap.js';
 import { Buffer } from 'node:buffer';
 import { join } from 'node:path';
@@ -490,7 +491,7 @@ export async function handleMessage(
       // double-injecting history. We still persist to our own store (for the
       // non-persistent fallback, /reset, and group context), so this only
       // changes what the agent is *prompted* with, not what we record.
-      let sessionOpts: { resume?: string; onSessionId?: (id: string) => void } | undefined;
+      let sessionOpts: { resume?: string; onSessionId?: (id: string) => void; groupInstructions?: string } | undefined;
       let historyForQuery = historyPrefix;
       if (config.sdk.persistentSession) {
         const resume = store.getSdkSessionId(sessionKey);
@@ -499,6 +500,16 @@ export async function handleMessage(
           resume,
           onSessionId: (id: string) => store.setSdkSessionId(sessionKey, id),
         };
+      }
+
+      // v1.0 GROUP.md: inject operator-provided per-group instructions (from
+      // config.groupConfigDir/<channelId>.md) into the system prompt. Only for
+      // groups — DMs key on the peer uid, not a shared channel.
+      if (isGroup) {
+        const groupInstructions = loadGroupConfig(config.groupConfigDir, channelId);
+        if (groupInstructions) {
+          sessionOpts = { ...(sessionOpts ?? {}), groupInstructions };
+        }
       }
 
       const rawChunks = queryAgent(userContentForLLM, historyForQuery, contextStr, config, sessionCtx, onToolUse, sessionOpts);


### PR DESCRIPTION
First v1.0 roadmap item: GROUP.md/THREAD.md configuration.

## What changed and why

Operators can give a specific group its own persona/rules without code changes. Set `groupConfigDir` (`CC_OCTO_GROUP_CONFIG_DIR`) to a directory of `<groupId>.md` files; a matching file's contents are injected into that group's system prompt as a trusted `[Group instructions]` block.

**Design / security:**
- New `src/group-config.ts` — `loadGroupConfig(dir, groupId)`. **Operator-controlled**: the dir must live outside the agent-writable `cwdBase`, because it shapes the system prompt (system-prompt-level instructions must come from a trusted source, not the agent's sandbox).
- `groupId` is **filename-pinned to a safe slug** (rejects path separators, `.`, `..`) so a crafted channel id can't traverse out of the dir. Content capped at 16 KiB (byte-safe truncation). Never throws — a missing/unreadable file degrades to "no instructions".
- `buildSystemPrompt` gains a `[Group instructions]` section, ordered after the global custom prompt and before group context/history. Unlike group context, it is **not** sanitized — it's a trusted operator file, not chat.
- `index.ts` loads the group's config by `channelId` and threads it through `queryAgent` opts. DMs are excluded (they key on the peer uid, not a shared channel).

THREAD.md is reserved until `BotMessage` carries a thread id — the same lookup will then key on the thread.

## Files

- `src/group-config.ts` (new), `src/config.ts`, `src/agent-bridge.ts`, `src/index.ts`
- Tests: `group-config` (new), `agent-bridge` (section + ordering), `e2e` (group injects / DM does not)
- `README.md`, `CHANGELOG.md`, `config.example.json`

## Test results

- `npm run type-check` / `lint` / `build` — clean
- `npm test` — **858 passed** (+20); NUL scan clean

Remaining roadmap: v1.0 webhook mode (last item).