### PR TITLE
fix(router): drop non-conversation channel types (system messages)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ While the major version is `0`, minor releases may carry breaking changes.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Router drops non-conversation channel types** (#68) — found in live
+  deployment: on connect the bot received a system message on `channel_type: 8`
+  (`systemcmdonline`) and replied to it. `SessionRouter` now allowlists only DM /
+  Group / CommunityTopic as repliable; any other (system/command) channel type is
+  dropped before the agent is invoked.
+
 ### Added
 
 - **Webhook inbound transport** (v1.0) — set `transport: "webhook"`

--- a/src/__tests__/session-router.test.ts
+++ b/src/__tests__/session-router.test.ts
@@ -684,3 +684,41 @@ describe('multi-bot loop guard in mention-free groups', () => {
     expect(result?.shouldProcess).toBe(true);
   });
 });
+
+// ─── #68: unsupported/system channel types are dropped ──────────────────
+
+describe('unsupported channel types (system messages)', () => {
+  let router: SessionRouter;
+  beforeEach(() => {
+    vi.clearAllMocks();
+    router = new SessionRouter(makeConfig(), ROBOT_ID);
+  });
+
+  it('drops a system channel_type (8 "systemcmdonline") with no reply', async () => {
+    // Reproduces the live-deployment bug: a system message on channel_type 8
+    // must not be processed as a conversation.
+    const msg = makeMsg({
+      channel_id: 'systemcmdonline',
+      channel_type: 8 as unknown as ChannelType,
+      from_uid: 'system',
+      payload: { type: MessageType.Text, content: '' },
+    });
+    const result = await router.route(msg);
+    expect(result).toBeNull();
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it('drops an unknown channel_type (e.g. 99)', async () => {
+    const msg = makeMsg({ channel_type: 99 as unknown as ChannelType });
+    expect(await router.route(msg)).toBeNull();
+  });
+
+  it('still processes a normal DM', async () => {
+    const msg = makeMsg({
+      channel_id: 'dm-1', channel_type: ChannelType.DM, from_uid: 'human',
+      payload: { type: MessageType.Text, content: 'hi' },
+    });
+    const result = await router.route(msg);
+    expect(result?.shouldProcess).toBe(true);
+  });
+});

--- a/src/session-router.ts
+++ b/src/session-router.ts
@@ -202,6 +202,17 @@ export class SessionRouter {
     return channelType === ChannelType.Group || channelType === ChannelType.CommunityTopic;
   }
 
+  /**
+   * Allowlist of channel types we actually converse on: DM, Group, and
+   * CommunityTopic. Octo also emits system/command channels (e.g. channel_type
+   * 8 "systemcmdonline" on connect) which are NOT user conversations — those
+   * must be dropped, otherwise they fall through the DM/group gates and get
+   * answered with an unsolicited LLM reply. Found in live deployment (#68).
+   */
+  private isSupportedChannel(channelType: ChannelType | undefined): boolean {
+    return channelType === ChannelType.DM || this.isGroupLike(channelType);
+  }
+
   private isMentioned(msg: BotMessage): boolean {
     const mention = msg.payload.mention;
     if (!mention) return false;
@@ -214,6 +225,12 @@ export class SessionRouter {
   private async processMessage(msg: BotMessage, key: string): Promise<RouteResult | null> {
     // Skip messages from self.
     if (msg.from_uid === this.robotId) return null;
+
+    // Drop anything that isn't a real conversation channel (DM / group /
+    // community topic). Octo emits system/command channels (e.g. channel_type 8
+    // "systemcmdonline" on connect) that otherwise slip past the DM/group gates
+    // and get an unsolicited reply (#68).
+    if (!this.isSupportedChannel(msg.channel_type)) return null;
 
     // Skip stream update messages (G21) — only process final (non-stream) messages.
     // When streamOn is true, this is a partial update of an ongoing stream; the final


### PR DESCRIPTION
Closes #68. Found during the live deployment test against `im.deepminer.com.cn`.

## What happened

On connect, `OctoReviewBoooot` received a system message on **`channel_type: 8`** (`channel_id: "systemcmdonline"`, empty body → `[消息]` placeholder) and **generated + sent an unsolicited LLM reply**. Captured in the session store:

```
session_id="systemcmdonline:"  channel_type=8
  user:      [消息]
  assistant: 你好！我看到你的消息似乎是空的…
```

## Root cause

`SessionRouter.processMessage()` gated only by negative checks: DM filters for `channel_type === DM` (1), the @mention gate + bot-loop guards for `isGroupLike()` (2/5). An unknown system `channel_type` (8) is neither → skips the mention gate → processed as a repliable DM. `payload.event` was unset (it arrived as a content message), so the system-event drop missed it.

## Fix

Positive allowlist `isSupportedChannel()` = DM | Group | CommunityTopic; `processMessage()` drops anything else up front, before stream/mention/agent — defense-in-depth alongside the existing `payload.event` and self-message drops.

## Test results

- `npm run type-check` / `lint` / `build` — clean
- `npm test` — **907 passed** (+3: system type 8 dropped no-reply, unknown type 99 dropped, normal DM still processed)

## Deployment validation

The rest of the live test passed end-to-end: real bot registration, WS connect, DM round-trip (inbound → agent → streamed reply, persisted), per-session sandboxes, `0700` dataDir, graceful SIGTERM shutdown. This was the one defect surfaced.