### PR TITLE
fix(octo): ack RECV only after decrypt; fail short-salt CONNACK

### DIFF
--- a/src/__tests__/octo/wksocket-packet.test.ts
+++ b/src/__tests__/octo/wksocket-packet.test.ts
@@ -368,6 +368,51 @@ describe('WKSocket packet-level integration', () => {
     expect(msg.payload.content).toBe('hello from test');
   });
 
+  // ── RECVACK ordering (issue: ack-before-decrypt → silent message loss) ──
+
+  it('sends RECVACK after a successful decrypt', () => {
+    const onMessage = vi.fn();
+    socket = makeSocket(onMessage, vi.fn());
+    socket.connect();
+    const ws = wsRef.current!;
+    ws.emit('open');
+    const { aesKey, aesIV } = doHandshake(ws, 1);
+
+    const before = ws.sent.length;
+    ws.emit('message', Buffer.from(buildRecvPacket({
+      serverVersion: 4, fromUID: 'u', channelID: 'c', channelType: 2,
+      messageID: 1n, messageSeq: 7, timestamp: 1, payload: { type: 1, content: 'hi' },
+      aesKey, aesIV,
+    })));
+
+    expect(onMessage).toHaveBeenCalledOnce();
+    // A RECVACK frame (first byte = RECVACK<<4 = 0x60) was sent.
+    const newFrames = ws.sent.slice(before);
+    expect(newFrames.some((f) => (f[0] >> 4) === 6)).toBe(true);
+  });
+
+  it('does NOT send RECVACK when decrypt fails (lets the server redeliver)', () => {
+    const onMessage = vi.fn();
+    socket = makeSocket(onMessage, vi.fn());
+    socket.connect();
+    const ws = wsRef.current!;
+    ws.emit('open');
+    doHandshake(ws, 1); // establishes the real aesKey/aesIV on the socket
+
+    const before = ws.sent.length;
+    // Encrypt with a WRONG key so the socket's decrypt throws.
+    ws.emit('message', Buffer.from(buildRecvPacket({
+      serverVersion: 4, fromUID: 'u', channelID: 'c', channelType: 2,
+      messageID: 2n, messageSeq: 8, timestamp: 1, payload: { type: 1, content: 'x' },
+      aesKey: 'wrongkey00000000', aesIV: 'wrongiv0000000000'.slice(0, 16),
+    })));
+
+    expect(onMessage).not.toHaveBeenCalled();
+    const newFrames = ws.sent.slice(before);
+    // No RECVACK → message stays un-acked → server will redeliver.
+    expect(newFrames.some((f) => (f[0] >> 4) === 6)).toBe(false);
+  });
+
   // ── Test 5: PONG resets ping counter without error ──────────────────────
 
   it('PONG packet after CONNACK → no crash, onMessage not called', () => {
@@ -418,7 +463,10 @@ describe('WKSocket packet-level integration', () => {
   // placeholder `expect(true).toBe(true)` test in q34-q37-q38.test.ts — now
   // exercised through real CONNACK with a short salt. This test guards the
   // warn-on-server-misbehavior contract added in PR#34 / Q38.
-  it('CONNACK with salt shorter than 16 bytes emits console.warn (Q38)', () => {
+  it('CONNACK with salt shorter than 16 bytes FAILS the connection (not silent-drop)', () => {
+    // A short salt yields an invalid AES-CBC IV → every later message would
+    // silently fail to decrypt. We now fail the handshake instead of warning
+    // and proceeding, so the connection reconnects/re-handshakes.
     const onConnected = vi.fn();
     const onError = vi.fn();
     const onDisconnected = vi.fn();
@@ -436,20 +484,23 @@ describe('WKSocket packet-level integration', () => {
     const ws = wsRef.current!;
     ws.emit('open');
 
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     try {
-      // Short salt: 8 bytes < 16 → triggers warn.
+      // Short salt: 8 bytes < 16 → fail the connection.
       doHandshake(ws, 1, 'shortslt');
-      expect(onConnected).toHaveBeenCalledOnce();
-      expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('CONNACK salt is shorter than 16 bytes'),
+      expect(onConnected).not.toHaveBeenCalled();
+      expect(onError).toHaveBeenCalledWith(
+        expect.objectContaining({ message: expect.stringContaining('salt too short') }),
+      );
+      expect(errSpy).toHaveBeenCalledWith(
+        expect.stringContaining('CONNACK salt too short'),
       );
     } finally {
-      warnSpy.mockRestore();
+      errSpy.mockRestore();
     }
   });
 
-  it('CONNACK with salt >= 16 bytes does NOT warn (negative case)', () => {
+  it('CONNACK with salt >= 16 bytes connects normally (negative case)', () => {
     const onConnected = vi.fn();
     const onError = vi.fn();
     const onDisconnected = vi.fn();
@@ -467,15 +518,8 @@ describe('WKSocket packet-level integration', () => {
     const ws = wsRef.current!;
     ws.emit('open');
 
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    try {
-      doHandshake(ws, 1); // default TEST_SALT is 20 bytes
-      expect(onConnected).toHaveBeenCalledOnce();
-      expect(warnSpy).not.toHaveBeenCalledWith(
-        expect.stringContaining('CONNACK salt is shorter'),
-      );
-    } finally {
-      warnSpy.mockRestore();
-    }
+    doHandshake(ws, 1); // default TEST_SALT is 20 bytes
+    expect(onConnected).toHaveBeenCalledOnce();
+    expect(onError).not.toHaveBeenCalled();
   });
 });

--- a/src/octo/socket.ts
+++ b/src/octo/socket.ts
@@ -660,19 +660,31 @@ export class WKSocket extends EventEmitter {
     }
 
     if (reasonCode === 1) {
-      // Success — derive AES key from DH shared secret
+      // Success — derive AES key from DH shared secret.
+      // A malformed/short salt yields a wrong AES-CBC IV (CryptoJS zero-pads it),
+      // which makes EVERY subsequent payload decrypt fail — i.e. a bot that looks
+      // connected (heartbeat fine) but silently drops every message. Fail the
+      // handshake instead so we reconnect and re-derive, rather than entering
+      // that silent-drop state. (serverKey is validated the same way: a bad DH
+      // key throws in sharedKey(), caught by handleRawData's try/catch.)
+      if (!salt || salt.length < 16) {
+        this.connected = false;
+        console.error(
+          `[WKSocket] CONNACK salt too short (got ${salt?.length ?? 0}, need >=16) — ` +
+          `AES IV would be invalid and every message would silently fail to decrypt. ` +
+          `Failing the connection to force a fresh handshake.`,
+        );
+        if (this.ws) { try { this.ws.close(); } catch { /* ignore */ } }
+        // needReconnect stays true (default) so the close handler reconnects.
+        this.opts.onError?.(new Error("CONNACK salt too short"));
+        return;
+      }
       const serverPubKey = Uint8Array.from(Buffer.from(serverKey, "base64"));
       const secret = sharedKey(this.dhPrivateKey!, serverPubKey);
       const secretBase64 = Buffer.from(secret).toString("base64");
       const aesKeyFull = Md5.init(secretBase64);
       this.aesKey = aesKeyFull.substring(0, 16);
-      this.aesIV = salt && salt.length > 16 ? salt.substring(0, 16) : salt;
-      if (!salt || salt.length < 16) {
-        console.warn(
-          `[WKSocket] CONNACK salt is shorter than 16 bytes (got ${salt?.length ?? 0}). ` +
-          `AES-CBC IV will be zero-padded by CryptoJS. This may indicate a server issue.`,
-        );
-      }
+      this.aesIV = salt.substring(0, 16);
 
       this.connected = true;
       this.lastConnectTime = Date.now();
@@ -714,19 +726,25 @@ export class WKSocket extends EventEmitter {
     }
     const encryptedPayload = dec.readRemaining();
 
-    // Send RECVACK immediately
-    this.sendRaw(encodeRecvackPacket(messageID, messageSeq));
-
-    // Decrypt payload
+    // Decrypt + parse BEFORE acking. RECVACK tells the server "delivered, don't
+    // resend" — if we ack first and decrypt then fails (transient key/IV issue),
+    // the message is lost forever with only a debug log. By acking only after a
+    // successful parse, a transient failure leaves the message un-acked so the
+    // server redelivers it. (A *permanent* decrypt failure means the AES key/IV
+    // from CONNACK is wrong — onConnack now fails the connection in that case,
+    // forcing a fresh handshake rather than a silent-drop or redelivery loop.)
     let payloadObj: Record<string, unknown> | undefined;
     try {
       const decryptedBytes = aesDecrypt(encryptedPayload, this.aesKey, this.aesIV);
       const payloadStr = uintToString(Array.from(decryptedBytes));
       payloadObj = JSON.parse(payloadStr);
     } catch (err) {
-      console.debug("[WKSocket] payload decrypt/parse error:", err);
+      console.error("[WKSocket] payload decrypt/parse error — NOT acking so the server can redeliver:", err);
       return;
     }
+
+    // Parse succeeded — now it is safe to ack.
+    this.sendRaw(encodeRecvackPacket(messageID, messageSeq));
 
     // Build MessagePayload (same shape as SDK's contentObj-based output)
     const payload: MessagePayload = {


### PR DESCRIPTION
Closes #74.

Two silent-failure bugs in the WuKongIM protocol layer (`src/octo/socket.ts`), found in the full-codebase review.

## 1. RECVACK sent before decrypt → permanent silent message loss
`onRecv` acked **immediately**, then decrypted+parsed in a try that just logged on failure. RECVACK = "delivered, don't resend", so any decrypt/parse failure lost the message forever (debug log only) while the bot looked healthy (heartbeat fine).
**Fix:** ack only **after** a successful decrypt+parse → a transient failure leaves the message un-acked and the server redelivers; failure now logs at error level.

## 2. Short-salt CONNACK → guaranteed-decrypt-failure ("silent-drop") state
On success, a salt `< 16` bytes only `console.warn`ed and continued with a zero-padded (wrong) AES-CBC IV, so **every** later payload decrypt failed.
**Fix:** treat a short salt as a failed handshake — close + `onError` so the socket reconnects and re-derives keys, instead of entering that state.

> The earlier review hypothesis that `onConnack` throws *outside* `handleRawData`'s try/catch was checked and **refuted** (`onPacket`→`onConnack` runs inside `unpackOne`, inside the try). The real gap is the salt case above.

## Tests
RECVACK-ordering (sent on success; **not** sent on decrypt failure) + short-salt CONNACK fails the connection (replaces the old Q38 warn assertion). **948 tests**, lint/build/NUL clean.