### PR TITLE
fix(router): per-member group rate limit; guard empty DM from_uid

### DIFF
--- a/src/__tests__/session-router.test.ts
+++ b/src/__tests__/session-router.test.ts
@@ -260,6 +260,41 @@ describe('SessionRouter', () => {
 
   // --- Serial queue ---
 
+  it('group rate limit is per-member, not one shared bucket for the whole channel', async () => {
+    // Regression: with the per-channel sessionKey, keying the session bucket by
+    // sessionKey alone collapsed the whole room into one quota. Each member must
+    // get their own maxPerMinute in the same channel.
+    const cfg = makeConfig({ rateLimit: { maxPerMinute: 2 } });
+    router = new SessionRouter(cfg, ROBOT_ID);
+    const CH = 'group-shared';
+    const mentioned = { type: MessageType.Text, content: 'hi', mention: { uids: [ROBOT_ID] } };
+
+    // Alice uses her full quota (2).
+    const a1 = await router.route(makeMsg({ message_id: 'a1', channel_id: CH, from_uid: 'alice', channel_type: ChannelType.Group, payload: mentioned }));
+    const a2 = await router.route(makeMsg({ message_id: 'a2', channel_id: CH, from_uid: 'alice', channel_type: ChannelType.Group, payload: mentioned }));
+    expect(a1!.shouldProcess).toBe(true);
+    expect(a2!.shouldProcess).toBe(true);
+
+    // Bob in the SAME channel still has his own quota — not blocked by Alice.
+    const b1 = await router.route(makeMsg({ message_id: 'b1', channel_id: CH, from_uid: 'bob', channel_type: ChannelType.Group, payload: mentioned }));
+    const b2 = await router.route(makeMsg({ message_id: 'b2', channel_id: CH, from_uid: 'bob', channel_type: ChannelType.Group, payload: mentioned }));
+    expect(b1!.shouldProcess).toBe(true);
+    expect(b2!.shouldProcess).toBe(true);
+
+    // Alice's 3rd IS blocked (her own quota exhausted).
+    const a3 = await router.route(makeMsg({ message_id: 'a3', channel_id: CH, from_uid: 'alice', channel_type: ChannelType.Group, payload: mentioned }));
+    expect(a3!.shouldProcess).toBe(false);
+  });
+
+  it('sessionKey throws on a DM with empty from_uid (no shared-session collapse)', () => {
+    const cfg = makeConfig({ rateLimit: { maxPerMinute: 5 } });
+    router = new SessionRouter(cfg, ROBOT_ID);
+    const msg = makeMsg({ channel_type: ChannelType.DM, from_uid: '', channel_id: 'dm-ch' });
+    expect(() => router.sessionKey(msg)).toThrow(/no from_uid/);
+  });
+
+  // --- Serial queue (continued) ---
+
   it('processes same session key sequentially', async () => {
     const order: number[] = [];
     const cfg = makeConfig({ rateLimit: { maxPerMinute: 100 } });

--- a/src/session-router.ts
+++ b/src/session-router.ts
@@ -142,6 +142,13 @@ export class SessionRouter {
     const spaceId = this.extractSpaceId(msg);
     if (msg.channel_type === ChannelType.DM) {
       // DM is per-user (private): same peer always resumes the same session.
+      // from_uid IS the peer's identity here; a missing one is unroutable —
+      // never fall back to '' (that would collapse every uid-less DM into ONE
+      // shared session across unrelated peers, leaking history/memory). Mirrors
+      // the group channel_id guard below. Caught upstream → message dropped.
+      if (!msg.from_uid) {
+        throw new Error('DM message has no from_uid — cannot derive a session key');
+      }
       return spaceId ? `${spaceId}:${msg.from_uid}` : msg.from_uid;
     }
     // Group is per-CHANNEL (shared): every member of a group shares one session,
@@ -385,7 +392,16 @@ export class SessionRouter {
     const globalMax = maxPerMinute * GLOBAL_RATE_MULTIPLIER;
 
     const globalBucket = this.getOrCreateGlobalBucket(now, globalMax);
-    const sessionBucket = this.getOrCreateBucket(this.tokenBuckets, key, now, maxPerMinute);
+    // Per-participant session bucket: key by session AND uid. For a group the
+    // sessionKey is the channel_id (shared), so keying the rate bucket by
+    // sessionKey alone would collapse the WHOLE room into one maxPerMinute quota
+    // (the 6th message/min from ANY member blocked). Including uid restores a
+    // per-member per-channel quota — matching the pre-shared-session behavior —
+    // while the global + per-user buckets still bound abuse. For a DM the
+    // sessionKey already embeds the peer, so this is just per-peer. Joined with a
+    // newline (never present in a uid/key) so distinct pairs can't alias.
+    const sessionBucketKey = `${key}\n${uid}`;
+    const sessionBucket = this.getOrCreateBucket(this.tokenBuckets, sessionBucketKey, now, maxPerMinute);
     const userBucket = this.getOrCreateBucket(this.userBuckets, uid, now, maxPerMinute);
 
     this.refillBucket(globalBucket, now, globalMax);


### PR DESCRIPTION
Closes #76. Two regressions from the per-channel sessionKey change.

## 1. Group rate-limit collapsed to one shared bucket
The per-session token bucket was keyed by `sessionKey` = `channel_id`, so a **whole group shared one** `maxPerMinute` quota (default 5) — the 6th message/min from **any** member blocked everyone.
**Fix:** key the session bucket by `${sessionKey}\n${uid}` → each member gets their own per-channel quota (pre-shared-session behavior). Global (10×) + per-user buckets still bound abuse. DMs already embed the peer in sessionKey, so they stay per-peer.

## 2. DM sessionKey: no empty-`from_uid` guard
The group branch throws on missing `channel_id`, but DM returned bare `from_uid` — an empty uid collapsed unrelated peers into one `''` session.
**Fix:** symmetric throw on empty `from_uid` (caught upstream → dropped).

## Tests
Two group members get independent quotas in one channel; DM with empty `from_uid` throws. **950 tests**, lint/build/NUL clean.