### PR TITLE
fix(gateway): startup-leak, heartbeat overlap, lock PID-reuse, O(n²) frames

### DIFF
--- a/src/__tests__/gateway.test.ts
+++ b/src/__tests__/gateway.test.ts
@@ -87,7 +87,9 @@ describe('Process lock', () => {
 
     const lockPath = join(tmpDir, 'gateway.lock');
     expect(existsSync(lockPath)).toBe(true);
-    expect(readFileSync(lockPath, 'utf-8').trim()).toBe(String(process.pid));
+    // Lock format is "<pid> <nonce>" — the first field is our PID.
+    const [pidField] = readFileSync(lockPath, 'utf-8').trim().split(/\s+/);
+    expect(pidField).toBe(String(process.pid));
 
     await gw.stop();
   });
@@ -108,7 +110,8 @@ describe('Process lock', () => {
     const gw = new OctoGateway(makeConfig());
     // Non-numeric PID should be treated as stale (kill would fail) and overwritten
     await gw.start();
-    expect(readFileSync(lockPath, 'utf-8').trim()).toBe(String(process.pid));
+    const [pidField] = readFileSync(lockPath, 'utf-8').trim().split(/\s+/);
+    expect(pidField).toBe(String(process.pid));
     await gw.stop();
   });
 
@@ -121,18 +124,39 @@ describe('Process lock', () => {
     // Should not throw — stale lock is detected and removed
     await gw.start();
 
-    expect(readFileSync(lockPath, 'utf-8').trim()).toBe(String(process.pid));
+    const [pidField] = readFileSync(lockPath, 'utf-8').trim().split(/\s+/);
+    expect(pidField).toBe(String(process.pid));
     await gw.stop();
   });
 
-  it('rejects when another live process holds the lock', async () => {
+  it('rejects when another live, signalable process holds the lock', async () => {
     const lockPath = join(tmpDir, 'gateway.lock');
-    // Write a lock with current process PID (which is alive)
-    // Use PID 1 (init/launchd) which is always alive
-    writeFileSync(lockPath, '1', { mode: 0o600 });
+    // Use OUR OWN pid: it is alive AND signalable by us (process.kill(pid,0) ok),
+    // so acquireLock must treat it as a live holder and refuse. (PID 1 would be
+    // EPERM on a non-root runner, which we now correctly reclaim as a reused PID.)
+    writeFileSync(lockPath, String(process.pid), { mode: 0o600 });
 
     const gw = new OctoGateway(makeConfig());
     await expect(gw.start()).rejects.toThrow(/Another instance is running/);
+  });
+
+  it('reclaims a lock whose PID exists but is not signalable (EPERM → reused PID)', async () => {
+    const lockPath = join(tmpDir, 'gateway.lock');
+    // PID 1 (init/launchd) is alive but owned by root — process.kill(1,0) throws
+    // EPERM for a normal user. Since our bot runs as one service user with its
+    // own dataDir, an unsignalable PID can't be our instance → reclaim as stale.
+    writeFileSync(lockPath, '1', { mode: 0o600 });
+
+    const gw = new OctoGateway(makeConfig());
+    // On a root CI runner kill(1,0) succeeds → would reject; skip that case.
+    if (process.getuid && process.getuid() === 0) {
+      await expect(gw.start()).rejects.toThrow(/Another instance is running/);
+    } else {
+      await gw.start();
+      const [pidField] = readFileSync(lockPath, 'utf-8').trim().split(/\s+/);
+      expect(pidField).toBe(String(process.pid));
+      await gw.stop();
+    }
   });
 });
 
@@ -337,6 +361,35 @@ describe('Heartbeat consecutive failures', () => {
 
     // Should NOT have triggered reconnect
     expect(vi.mocked(registerBot).mock.calls.length).toBe(initialRegCalls);
+
+    await gw.stop();
+  });
+
+  it('does not overlap heartbeats when one is slow to settle', async () => {
+    // A heartbeat that takes longer than the 30s interval must NOT pile up: the
+    // overlap guard skips ticks while one is in flight (no concurrent requests,
+    // no failCount race).
+    let resolveFirst!: () => void;
+    let calls = 0;
+    vi.mocked(sendHeartbeat).mockImplementation(() => {
+      calls++;
+      // Only the first call hangs; if the guard fails, a 2nd call would start.
+      return new Promise<void>((res) => { resolveFirst = res; });
+    });
+
+    const gw = new OctoGateway(makeConfig());
+    await gw.start();
+
+    await vi.advanceTimersByTimeAsync(30_000); // tick 1 → request starts, hangs
+    expect(calls).toBe(1);
+    await vi.advanceTimersByTimeAsync(30_000); // tick 2 → skipped (in flight)
+    await vi.advanceTimersByTimeAsync(30_000); // tick 3 → skipped (in flight)
+    expect(calls).toBe(1); // still only ONE in-flight request, no pile-up
+
+    resolveFirst(); // let it settle
+    await vi.advanceTimersByTimeAsync(100);
+    await vi.advanceTimersByTimeAsync(30_000); // next tick can now issue
+    expect(calls).toBe(2);
 
     await gw.stop();
   });

--- a/src/__tests__/octo/wksocket-packet.test.ts
+++ b/src/__tests__/octo/wksocket-packet.test.ts
@@ -413,6 +413,50 @@ describe('WKSocket packet-level integration', () => {
     expect(newFrames.some((f) => (f[0] >> 4) === 6)).toBe(false);
   });
 
+  // ── Frame assembly (offset-cursor refactor) ────────────────────────────
+
+  it('parses MULTIPLE complete packets delivered in one chunk', () => {
+    const onMessage = vi.fn();
+    socket = makeSocket(onMessage, vi.fn());
+    socket.connect();
+    const ws = wsRef.current!;
+    ws.emit('open');
+    const { aesKey, aesIV } = doHandshake(ws, 1);
+
+    const mk = (seq: number, content: string) => buildRecvPacket({
+      serverVersion: 4, fromUID: 'u', channelID: 'c', channelType: 2,
+      messageID: BigInt(seq), messageSeq: seq, timestamp: 1,
+      payload: { type: 1, content }, aesKey, aesIV,
+    });
+    // Concatenate three RECV frames into a single inbound chunk.
+    const combined = Buffer.concat([Buffer.from(mk(1, 'one')), Buffer.from(mk(2, 'two')), Buffer.from(mk(3, 'three'))]);
+    ws.emit('message', combined);
+
+    expect(onMessage).toHaveBeenCalledTimes(3);
+    expect(onMessage.mock.calls.map((c) => c[0].payload.content)).toEqual(['one', 'two', 'three']);
+  });
+
+  it('reassembles a packet split across two chunks (partial frame buffering)', () => {
+    const onMessage = vi.fn();
+    socket = makeSocket(onMessage, vi.fn());
+    socket.connect();
+    const ws = wsRef.current!;
+    ws.emit('open');
+    const { aesKey, aesIV } = doHandshake(ws, 1);
+
+    const frame = Buffer.from(buildRecvPacket({
+      serverVersion: 4, fromUID: 'u', channelID: 'c', channelType: 2,
+      messageID: 9n, messageSeq: 9, timestamp: 1, payload: { type: 1, content: 'split' },
+      aesKey, aesIV,
+    }));
+    const cut = Math.floor(frame.length / 2);
+    ws.emit('message', frame.subarray(0, cut)); // first half — incomplete
+    expect(onMessage).not.toHaveBeenCalled();
+    ws.emit('message', frame.subarray(cut));     // second half — now complete
+    expect(onMessage).toHaveBeenCalledOnce();
+    expect(onMessage.mock.calls[0][0].payload.content).toBe('split');
+  });
+
   // ── Test 5: PONG resets ping counter without error ──────────────────────
 
   it('PONG packet after CONNACK → no crash, onMessage not called', () => {

--- a/src/gateway.ts
+++ b/src/gateway.ts
@@ -9,6 +9,7 @@ import type { BotMessage } from './octo/types.js';
 import { existsSync, writeFileSync, unlinkSync, readFileSync, mkdirSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { createRequire } from 'node:module';
+import { randomUUID } from 'node:crypto';
 
 // Read version from package.json at load time (Q31: no hardcoded version).
 const _require = createRequire(import.meta.url);
@@ -28,6 +29,9 @@ export class OctoGateway {
   private _ownerUid = '';
   private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
   private lockFilePath: string;
+  /** Random per-process token written into the lock so ownership survives PID
+   *  reuse: release only removes a lock that still carries OUR nonce. */
+  private readonly lockNonce = randomUUID();
   private onMessage: MessageHandler | null = null;
 
   /** When true, new messages are silently dropped (shutdown draining). */
@@ -41,6 +45,11 @@ export class OctoGateway {
   // Heartbeat failure tracking
   private heartbeatFailCount = 0;
   private readonly MAX_HEARTBEAT_FAILURES = 3;
+  /** True while a heartbeat request is in flight — prevents overlapping ticks. */
+  private heartbeatInFlight = false;
+  /** Bumped on each startHeartbeat() so an orphaned tick from a prior run can't
+   *  mutate the new counter (see the generation guard in the tick). */
+  private heartbeatGen = 0;
 
   constructor(
     private readonly config: Config,
@@ -176,8 +185,10 @@ export class OctoGateway {
     mkdirSync(dir, { recursive: true });
 
     if (existsSync(this.lockFilePath)) {
+      // Lock format: "<pid> <nonce>" (nonce optional for forward-compat with
+      // older single-field locks).
       const content = readFileSync(this.lockFilePath, 'utf-8').trim();
-      const pid = parseInt(content, 10);
+      const pid = parseInt(content.split(/\s+/)[0], 10);
       if (pid && !isNaN(pid)) {
         try {
           process.kill(pid, 0); // signal 0 = check existence
@@ -191,21 +202,29 @@ export class OctoGateway {
           } else if (e.message?.includes('Another instance')) {
             throw err;
           } else if (e.code === 'EPERM') {
-            throw new Error(
-              `Another instance is running (PID ${pid}). Lock file: ${this.lockFilePath}`,
+            // The PID exists but is owned by ANOTHER user — it cannot be our bot
+            // (the gateway runs as one service user with its own dataDir), so it
+            // is almost certainly a recycled PID. Treat the lock as stale and
+            // reclaim it rather than refusing to start forever.
+            console.warn(
+              `Lock PID ${pid} exists but is not signalable (EPERM) — likely a reused ` +
+              `PID; reclaiming the stale lock at ${this.lockFilePath}`,
             );
           }
         }
       }
     }
-    writeFileSync(this.lockFilePath, String(process.pid), { mode: 0o600 });
+    writeFileSync(this.lockFilePath, `${process.pid} ${this.lockNonce}`, { mode: 0o600 });
   }
 
   private releaseLock(): void {
     try {
       if (existsSync(this.lockFilePath)) {
         const content = readFileSync(this.lockFilePath, 'utf-8').trim();
-        if (content === String(process.pid)) {
+        // Only remove the lock if it still carries OUR nonce — so a lock another
+        // instance acquired after a PID-reuse race is never deleted by us.
+        const [, nonce] = content.split(/\s+/);
+        if (nonce === this.lockNonce) {
           unlinkSync(this.lockFilePath);
         }
       }
@@ -307,25 +326,40 @@ export class OctoGateway {
   private startHeartbeat(): void {
     this.stopHeartbeat();
     this.heartbeatFailCount = 0;
-    this.heartbeatTimer = setInterval(async () => {
-      try {
-        await sendHeartbeat({
-          apiUrl: this.config.apiUrl,
-          botToken: this.config.botToken,
-        });
-        this.heartbeatFailCount = 0;
-      } catch (err) {
-        this.heartbeatFailCount++;
-        console.error(
-          `Heartbeat failed (${this.heartbeatFailCount}/${this.MAX_HEARTBEAT_FAILURES}):`,
-          String(err),
-        );
-        if (this.heartbeatFailCount >= this.MAX_HEARTBEAT_FAILURES) {
-          console.error('Max heartbeat failures reached, triggering reconnect...');
+    const gen = ++this.heartbeatGen;
+    this.heartbeatTimer = setInterval(() => {
+      // Overlap guard: if the previous heartbeat hasn't settled (degraded API
+      // where a request takes ~>= the 30s interval), skip this tick instead of
+      // piling up concurrent requests and racing heartbeatFailCount.
+      if (this.heartbeatInFlight) return;
+      this.heartbeatInFlight = true;
+      void (async () => {
+        try {
+          await sendHeartbeat({
+            apiUrl: this.config.apiUrl,
+            botToken: this.config.botToken,
+          });
+          // Generation guard: a tick from a superseded startHeartbeat() (e.g.
+          // after a token refresh re-armed the timer) must not touch the live
+          // counter or it could spuriously reset/trip the new one.
+          if (gen !== this.heartbeatGen) return;
           this.heartbeatFailCount = 0;
-          void this.attemptTokenRefresh();
+        } catch (err) {
+          if (gen !== this.heartbeatGen) return;
+          this.heartbeatFailCount++;
+          console.error(
+            `Heartbeat failed (${this.heartbeatFailCount}/${this.MAX_HEARTBEAT_FAILURES}):`,
+            String(err),
+          );
+          if (this.heartbeatFailCount >= this.MAX_HEARTBEAT_FAILURES) {
+            console.error('Max heartbeat failures reached, triggering reconnect...');
+            this.heartbeatFailCount = 0;
+            void this.attemptTokenRefresh();
+          }
+        } finally {
+          this.heartbeatInFlight = false;
         }
-      }
+      })();
     }, 30_000);
   }
 
@@ -334,6 +368,10 @@ export class OctoGateway {
       clearInterval(this.heartbeatTimer);
       this.heartbeatTimer = null;
     }
+    // Invalidate any in-flight tick so its result is ignored, and allow the next
+    // startHeartbeat to issue immediately.
+    this.heartbeatGen++;
+    this.heartbeatInFlight = false;
   }
 
   // --- Graceful shutdown ---

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,7 +54,24 @@ async function main(): Promise<void> {
   // ready: startBot() registers over REST (gets botId) and installs the message
   // handler, but does NOT open the socket. We then cross-register sibling bot
   // ids, and only AFTER that connect every socket.
-  const stacks = await Promise.all(botConfigs.map((c) => startBot(c, multi)));
+  // Start each bot's pipeline. startBot() acquires the gateway.lock, opens the
+  // SQLite store, and arms the cwd-cleanup interval BEFORE any socket connects —
+  // so if one bot's startBot() rejects (bad token, taken lock), the bots that
+  // already succeeded must be torn down, or their locks/stores/intervals leak.
+  // Promise.all would discard the resolved stacks on first rejection, so settle
+  // all and clean up the successful ones before rethrowing.
+  const startResults = await Promise.allSettled(botConfigs.map((c) => startBot(c, multi)));
+  const stacks: BotStack[] = [];
+  let startError: unknown;
+  for (const r of startResults) {
+    if (r.status === 'fulfilled') stacks.push(r.value);
+    else startError = startError ?? r.reason;
+  }
+  if (startError) {
+    console.error('[cc-channel-octo] Startup failed; cleaning up bots that did start...');
+    await Promise.allSettled(stacks.map((s) => s.shutdown()));
+    throw startError;
+  }
 
   // Multi-bot loop guard: make every router aware of ALL bot ids in this
   // process, so a mention-free group can't let one bot reply to another's

--- a/src/octo/socket.ts
+++ b/src/octo/socket.ts
@@ -529,13 +529,21 @@ export class WKSocket extends EventEmitter {
     }
 
     try {
-      let lenBefore: number;
-      let lenAfter: number;
-      do {
-        lenBefore = this.tempBuffer.length;
-        this.tempBuffer = this.unpackOne(this.tempBuffer);
-        lenAfter = this.tempBuffer.length;
-      } while (lenBefore !== lenAfter && lenAfter >= 1);
+      // Parse complete packets using a moving cursor instead of re-slicing the
+      // whole buffer per packet. The old `tempBuffer = tempBuffer.slice(total)`
+      // per iteration was O(n²): a peer dribbling many tiny frames near the 1 MiB
+      // cap forced ~n full-array copies of an ~n-element array, stalling the event
+      // loop (shared across bots) without exceeding the byte cap. Now we advance
+      // an offset and trim the consumed prefix exactly once at the end.
+      let consumed = 0;
+      for (;;) {
+        const used = this.unpackOne(this.tempBuffer, consumed);
+        if (used === 0) break; // incomplete packet — wait for more bytes
+        consumed += used;
+      }
+      if (consumed > 0) {
+        this.tempBuffer = this.tempBuffer.slice(consumed);
+      }
     } catch (err) {
       console.debug("[WKSocket] decode error:", err);
       // Reset buffer and reconnect
@@ -546,32 +554,39 @@ export class WKSocket extends EventEmitter {
     }
   }
 
-  private unpackOne(data: number[]): number[] {
-    if (data.length === 0) return data;
+  /**
+   * Parse ONE packet starting at `start` in `data`. Returns the number of bytes
+   * consumed, or 0 if the buffer does not yet hold a complete packet (caller
+   * should wait for more bytes). Reads via `start + offset` and slices only the
+   * single packet's bytes — never the whole buffer — so repeated calls over a
+   * large buffer stay O(n) total, not O(n²).
+   */
+  private unpackOne(data: number[], start: number): number {
+    const available = data.length - start;
+    if (available <= 0) return 0;
 
-    const header = data[0];
+    const header = data[start];
     const packetType = header >> 4;
 
     // PONG is a single byte
     if (packetType === PacketType.PONG) {
       this.onPong();
-      return data.slice(1);
+      return 1;
     }
     // PING from server (shouldn't happen but handle gracefully)
     if (packetType === PacketType.PING) {
-      return data.slice(1);
+      return 1;
     }
 
-    const length = data.length;
     const fixedHeaderLength = 1;
-    let pos = fixedHeaderLength;
+    let pos = start + fixedHeaderLength;
     let remLength = 0;
     let multiplier = 1;
     let hasMore = false;
     let remLengthFull = true;
 
     do {
-      if (pos > length - 1) {
+      if (pos > data.length - 1) {
         remLengthFull = false;
         break;
       }
@@ -579,7 +594,7 @@ export class WKSocket extends EventEmitter {
       // this, a stream of 0x80 bytes would never terminate and would let
       // tempBuffer grow until handleRawData kills the connection — raise
       // earlier and more explicitly here.
-      if (pos - fixedHeaderLength >= MAX_VARLEN_BYTES) {
+      if (pos - (start + fixedHeaderLength) >= MAX_VARLEN_BYTES) {
         throw new Error(
           `[WKSocket] variable-length encoding exceeded ${MAX_VARLEN_BYTES} bytes — malformed packet`,
         );
@@ -590,17 +605,17 @@ export class WKSocket extends EventEmitter {
       hasMore = (digit & 0x80) !== 0;
     } while (hasMore);
 
-    if (!remLengthFull) return data; // Incomplete frame
+    if (!remLengthFull) return 0; // Incomplete frame — need more bytes
 
-    const remLengthLength = pos - fixedHeaderLength;
+    const remLengthLength = pos - (start + fixedHeaderLength);
     const totalLength = fixedHeaderLength + remLengthLength + remLength;
 
-    if (totalLength > length) return data; // Incomplete packet
+    if (totalLength > available) return 0; // Incomplete packet — need more bytes
 
-    // Extract one complete packet
-    const packetData = new Uint8Array(data.slice(0, totalLength));
+    // Extract exactly this one packet's bytes and dispatch.
+    const packetData = new Uint8Array(data.slice(start, start + totalLength));
     this.onPacket(packetData);
-    return data.slice(totalLength);
+    return totalLength;
   }
 
   // ─── Packet Handling ────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #78. Four gateway/protocol resource & lifecycle bugs from the full-codebase review.

## 1. Multi-bot partial-startup leak (`index.ts`)
`Promise.all(botConfigs.map(startBot))` — `startBot` acquires the lock + opens the store + arms the cwd-cleanup interval before connect, so a later bot's rejection discarded the already-started stacks (locks/stores/intervals leaked). → `Promise.allSettled` then `shutdown()` the started bots before rethrowing.

## 2. Heartbeat overlap + failCount race (`gateway.ts`)
`setInterval(async …)` piled up on a slow API and raced `heartbeatFailCount`; an orphaned tick could mutate a freshly-reset counter. → in-flight guard (skip while pending) + a generation token so a superseded tick is ignored.

## 3. Lock PID-reuse hazard (`gateway.ts`)
Lock keyed only by PID → a recycled PID after a hard crash caused a false "Another instance is running"; the EPERM branch mis-treated a different-user PID as ours. → write `"<pid> <nonce>"`, release only a lock still carrying our nonce, reclaim an EPERM (reused) PID.

## 4. O(n²) frame assembly (`octo/socket.ts`)
`number[]` with a full-array `slice` per packet — a peer dribbling tiny frames near the 1 MiB cap forced ~n copies of an ~n array (event-loop stall). → moving offset cursor; slice only each packet's bytes; trim consumed prefix once.

## Tests
heartbeat no-overlap; lock nonce-format + EPERM-reclaim; socket multi-packet + split-frame reassembly. **952 tests**, lint/build/NUL clean.