### PR TITLE
fix(cleanup): NAT64/6to4 SSRF, /reset comment, joinPath dedup, drop buildPrompt

### DIFF
--- a/src/__tests__/agent-bridge.test.ts
+++ b/src/__tests__/agent-bridge.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { buildSystemPrompt, sanitizeForSystemPrompt, buildPrompt } from '../agent-bridge.js';
+import { buildSystemPrompt, sanitizeForSystemPrompt } from '../agent-bridge.js';
 
 // --- sanitizeForSystemPrompt ---
 
@@ -211,18 +211,4 @@ describe('prompt injection defense (Q3)', () => {
   });
 });
 
-// --- buildPrompt (deprecated, backward compat) ---
-
-describe('buildPrompt (deprecated)', () => {
-  it('still produces the old format for backward compat', () => {
-    const result = buildPrompt('[user]: hello\n[assistant]: hi', 'context here', 'new message');
-    expect(result).toContain('[Group context]\ncontext here');
-    expect(result).toContain('[Conversation history]\n[user]: hello');
-    expect(result).toContain('[Current message]\nnew message');
-  });
-
-  it('omits empty sections', () => {
-    const result = buildPrompt('', '', 'just a message');
-    expect(result).toBe('[Current message]\njust a message');
-  });
-});
+// --- buildPrompt removed (dead code) ---

--- a/src/__tests__/e2e.test.ts
+++ b/src/__tests__/e2e.test.ts
@@ -43,7 +43,6 @@ vi.mock('../agent-bridge.js', async (importOriginal) => {
     ...original,
     buildSystemPrompt: original.buildSystemPrompt,
     sanitizeForSystemPrompt: original.sanitizeForSystemPrompt,
-    buildPrompt: original.buildPrompt,
     queryAgent: vi.fn(),
   };
 });

--- a/src/__tests__/url-policy.test.ts
+++ b/src/__tests__/url-policy.test.ts
@@ -72,6 +72,26 @@ describe('isPrivateOrLocalAddress (S5 hex v4-mapped fix)', () => {
     expect(isPrivateOrLocalAddress(addr)).toBe(expected);
   });
 
+  // ── NAT64 (64:ff9b::/96) embeds an IPv4 in the low 32 bits ────
+  it.each([
+    ['64:ff9b::7f00:1', true],        // 127.0.0.1
+    ['64:ff9b::a9fe:a9fe', true],     // 169.254.169.254 (metadata)
+    ['64:ff9b::127.0.0.1', true],     // dotted-quad tail form
+    ['64:ff9b::0808:0808', false],    // 8.8.8.8 (public)
+    ['64:ff9b::8.8.8.8', false],
+  ])('NAT64 %s → %s', (addr, expected) => {
+    expect(isPrivateOrLocalAddress(addr)).toBe(expected);
+  });
+
+  // ── 6to4 (2002::/16) embeds an IPv4 in bits 16..47 ────────────
+  it.each([
+    ['2002:7f00:1::1', true],         // 127.0.0.1
+    ['2002:a9fe:a9fe::1', true],      // 169.254.169.254
+    ['2002:0808:0808::1', false],     // 8.8.8.8 (public)
+  ])('6to4 %s → %s', (addr, expected) => {
+    expect(isPrivateOrLocalAddress(addr)).toBe(expected);
+  });
+
   it('returns false for malformed input', () => {
     expect(isPrivateOrLocalAddress('not-an-ip')).toBe(false);
     expect(isPrivateOrLocalAddress('')).toBe(false);

--- a/src/agent-bridge.ts
+++ b/src/agent-bridge.ts
@@ -226,25 +226,6 @@ function truncateSystemPrompt(parts: string[]): string {
 }
 
 /**
- * Build the prompt string from history, group context, and current message.
- *
- * @deprecated Use queryAgent() directly — it builds the system prompt internally
- * with proper role separation. This function is retained only for backward
- * compatibility with existing tests.
- */
-export function buildPrompt(historyPrefix: string, groupContext: string, message: string): string {
-  const parts: string[] = [];
-  if (groupContext) {
-    parts.push(`[Group context]\n${groupContext}`);
-  }
-  if (historyPrefix) {
-    parts.push(`[Conversation history]\n${historyPrefix}`);
-  }
-  parts.push(`[Current message]\n${message}`);
-  return parts.join('\n\n');
-}
-
-/**
  * Query Claude Agent SDK with structural role separation.
  *
  * - userMessage is passed as the SDK `prompt` (user role).

--- a/src/config.ts
+++ b/src/config.ts
@@ -628,18 +628,18 @@ export function resolveBotConfigs(config: Config): Config[] {
     seenIds.add(id);
 
     // Derive the bot's self-contained subtree under baseDir.
-    const botRoot = joinPath(config.baseDir, id);
-    const botDataDir = joinPath(botRoot, 'data');
-    const botCwdBase = joinPath(botRoot, 'workspace');
-    const botMemoryBase = joinPath(botRoot, 'memory');
+    const botRoot = pathJoin(config.baseDir, id);
+    const botDataDir = pathJoin(botRoot, 'data');
+    const botCwdBase = pathJoin(botRoot, 'workspace');
+    const botMemoryBase = pathJoin(botRoot, 'memory');
 
     // Per-bot config.json (in the bot's own subtree) is the highest-priority
     // layer: global shared ⊕ inline bots[] entry ⊕ <baseDir>/<id>/config.json.
-    const perBotFile = readConfigFile(joinPath(botRoot, 'config.json'));
+    const perBotFile = readConfigFile(pathJoin(botRoot, 'config.json'));
     const botToken = perBotFile.botToken ?? bot.botToken ?? '';
     if (!botToken) {
       throw new Error(
-        `Bot "${id}": missing botToken — set it in ${joinPath(botRoot, 'config.json')}`,
+        `Bot "${id}": missing botToken — set it in ${pathJoin(botRoot, 'config.json')}`,
       );
     }
     if (seenTokens.has(botToken)) {
@@ -733,11 +733,6 @@ export function resolveBotConfigs(config: Config): Config[] {
   return resolvedBots;
 }
 
-/** Join two path segments without importing node:path into the type surface. */
-function joinPath(a: string, b: string): string {
-  return a.replace(/\/+$/, '') + '/' + b;
-}
-
 /**
  * v1.1: openclaw-style per-bot personality. Read `<botRoot>/SOUL.md` if it
  * exists and return its trimmed contents as the bot's "soul" (voice/stance/
@@ -747,7 +742,7 @@ function joinPath(a: string, b: string): string {
  * config string. Best-effort — a read error never blocks startup.
  */
 export function loadSoul(botRoot: string): string | undefined {
-  const path = joinPath(botRoot, 'SOUL.md');
+  const path = pathJoin(botRoot, 'SOUL.md');
   if (!existsSync(path)) return undefined;
   try {
     const content = readFileSync(path, 'utf-8').trim();

--- a/src/index.ts
+++ b/src/index.ts
@@ -294,7 +294,10 @@ export async function handleMessage(
       // query — so a command never reaches the LLM, is not stored as a turn,
       // and does not leak into other members' group context. Only text
       // messages carry cleanContent; non-text payloads skip this entirely.
-      // Scoped to this sessionKey (per-user, even in groups).
+      // Scoped to this sessionKey: in a DM that's the peer; in a GROUP the
+      // sessionKey is the channel, so /reset clears the WHOLE group's shared
+      // history (any member can — by the shared-workspace design) and does NOT
+      // clear long-term memory. See commands.ts.
       if (result.cleanContent !== undefined) {
         const command = handleCommand(result.cleanContent, sessionKey, store, config, msg.message_seq);
         if (command.handled) {

--- a/src/url-policy.ts
+++ b/src/url-policy.ts
@@ -70,10 +70,37 @@ export function isPrivateOrLocalAddress(address: string): boolean {
       const dotted = `${(high >> 8) & 0xff}.${high & 0xff}.${(low >> 8) & 0xff}.${low & 0xff}`;
       return isPrivateIPv4(dotted);
     }
+    // NAT64 well-known prefix 64:ff9b::/96 — the last 32 bits embed an IPv4
+    // address. A name resolving to e.g. `64:ff9b::7f00:1` (= 127.0.0.1) on a
+    // NAT64-enabled host would otherwise reach loopback. The embedded v4 is the
+    // final two hextets (dotted-quad form `64:ff9b::a.b.c.d` is also accepted).
+    if (lower.startsWith("64:ff9b:")) {
+      const dotTail = lower.match(/(\d+\.\d+\.\d+\.\d+)$/);
+      if (dotTail) return isPrivateIPv4(dotTail[1]);
+      const hexTail = lower.match(/:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
+      if (hexTail) {
+        const embedded = decodeEmbeddedV4(hexTail[1], hexTail[2]);
+        if (embedded) return isPrivateIPv4(embedded);
+      }
+    }
+    // 6to4 2002::/16 — bits 16..47 embed an IPv4 address (2002:V4hi:V4lo::/48).
+    const sixToFour = lower.match(/^2002:([0-9a-f]{1,4}):([0-9a-f]{1,4}):/);
+    if (sixToFour) {
+      const embedded = decodeEmbeddedV4(sixToFour[1], sixToFour[2]);
+      if (embedded && isPrivateIPv4(embedded)) return true;
+    }
     return false;
   }
   // Not a valid IP literal — caller should resolve via DNS first.
   return false;
+}
+
+/** Decode two IPv6 hextets (hex strings) into a dotted-quad IPv4 string. */
+function decodeEmbeddedV4(hiHex: string, loHex: string): string | null {
+  const high = parseInt(hiHex, 16);
+  const low = parseInt(loHex, 16);
+  if (Number.isNaN(high) || Number.isNaN(low)) return null;
+  return `${(high >> 8) & 0xff}.${high & 0xff}.${(low >> 8) & 0xff}.${low & 0xff}`;
 }
 
 function isPrivateIPv4(address: string): boolean {


### PR DESCRIPTION
Closes #80. Medium + cleanup findings from the full-codebase review.

- **`url-policy.ts` (SSRF):** `isPrivateOrLocalAddress` (run on each resolved IP) now detects **NAT64** (`64:ff9b::/96`) and **6to4** (`2002::/16`) IPv6 addresses, which embed an IPv4 — on a NAT64-enabled host a name resolving to `64:ff9b::7f00:1` reached loopback. Added a shared `decodeEmbeddedV4` helper + range checks, with tests for both encodings.
- **`index.ts`:** corrected the stale `/reset` comment ("per-user, even in groups" was false under the shared-per-channel design — `/reset` clears the whole group's history, not long-term memory). No permission gate: clearing the room is the intended shared-workspace behavior.
- **`config.ts`:** removed the local `joinPath` reimplementation; use `node:path` `join` (already imported).
- **`agent-bridge.ts`:** removed the dead `@deprecated buildPrompt` (tests only) + its tests.

**Deferred** (too much churn for the value — ~80 test refs): dropping the `cwd` alias / a `ResolvedBotConfig` split, and the test-only `route()` / `buildHistoryPrefix`. Noted in #80 for a future dedicated refactor.

**960 tests**, lint/build/NUL clean.