### PR TITLE
feat(media): native image input — download inbound images for the agent to see

### DIFF
--- a/src/__tests__/inbound.test.ts
+++ b/src/__tests__/inbound.test.ts
@@ -35,6 +35,29 @@ describe('buildMediaUrl', () => {
     expect(buildMediaUrl('http://169.254.169.254/meta', API_URL)).toBeUndefined();
   });
 
+  // #86: Octo serves media from a separate CDN host than apiUrl. An absolute
+  // URL on the configured/STS CDN host is allowed; any other host still rejected.
+  it('allows absolute URLs on the CDN host when provided', () => {
+    const CDN = 'cdn.example.com';
+    // CDN host — allowed
+    expect(buildMediaUrl('https://cdn.example.com/im/chat/x.png', API_URL, CDN))
+      .toBe('https://cdn.example.com/im/chat/x.png');
+    // apiUrl host still allowed alongside the CDN host
+    expect(buildMediaUrl('https://api.example.com/file/y.jpg', API_URL, CDN))
+      .toBe('https://api.example.com/file/y.jpg');
+    // A DIFFERENT host is still rejected even with a CDN configured
+    expect(buildMediaUrl('https://attacker.com/a.jpg', API_URL, CDN)).toBeUndefined();
+    // Without the CDN host arg, the CDN URL is rejected (back-compat default)
+    expect(buildMediaUrl('https://cdn.example.com/im/chat/x.png', API_URL)).toBeUndefined();
+  });
+
+  it('does not pass through a non-http(s) absolute URL as-is, even on the CDN host', () => {
+    // ftp:// doesn't match the http(s) absolute branch, so it's never returned
+    // verbatim; it's treated as a (sanitized) relative path under apiUrl/file.
+    const out = buildMediaUrl('ftp://cdn.example.com/x.png', API_URL, 'cdn.example.com');
+    expect(out).not.toBe('ftp://cdn.example.com/x.png');
+  });
+
   it('rejects protocol downgrade (https apiUrl + http target)', () => {
     expect(buildMediaUrl('http://api.example.com/file/x.jpg', API_URL)).toBeUndefined();
   });
@@ -292,6 +315,23 @@ describe('resolveContent: RichText (type=14)', () => {
     expect(r.mediaUrls).toHaveLength(2);
     expect(r.mediaUrls?.[0]).toContain('img1.png');
     expect(r.mediaUrl).toBe(r.mediaUrls?.[0]);
+  });
+
+  it('collects absolute CDN-host image URLs when cdnHost is provided (#86)', () => {
+    // Real Octo shape: RichText with an absolute URL on a separate CDN host.
+    const payload = {
+      type: MessageType.RichText,
+      content: [
+        { type: RICH_TEXT_BLOCK_IMAGE, url: 'https://cdn.example.com/im/chat/a.png' },
+        { type: RICH_TEXT_BLOCK_TEXT, text: '这是什么图' },
+      ],
+      plain: '[图片]这是什么图',
+    } as unknown as MessagePayload;
+    // Without cdnHost the CDN URL is dropped (the bug this fixes).
+    expect(resolveContent(payload, API_URL).mediaUrls).toBeUndefined();
+    // With cdnHost it is collected.
+    const r = resolveContent(payload, API_URL, 'cdn.example.com');
+    expect(r.mediaUrls).toEqual(['https://cdn.example.com/im/chat/a.png']);
   });
 
   it('uses top-level plain when present (server-authoritative)', () => {

--- a/src/__tests__/media-inbound.test.ts
+++ b/src/__tests__/media-inbound.test.ts
@@ -1,0 +1,111 @@
+/**
+ * downloadInboundImage tests (#86 native image input).
+ *
+ * Verifies: content-type allow/deny, size cap, SSRF reject (private host),
+ * Authorization scoping, path stays under the session cwd, and empty-body
+ * handling. DNS is mocked so assertPublicUrl resolves deterministically;
+ * globalThis.fetch is stubbed (fetchWithRedirectGuard calls it internally).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, existsSync, readdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, isAbsolute } from 'node:path';
+
+vi.mock('node:dns/promises', () => ({
+  lookup: vi.fn(async (hostname: string) => {
+    if (hostname === 'api.example.com' || hostname.includes('public')) {
+      return [{ address: '203.0.113.42', family: 4 }];
+    }
+    // Loopback for the SSRF-reject case.
+    if (hostname === 'internal.local') return [{ address: '127.0.0.1', family: 4 }];
+    throw new Error(`Test DNS mock: unexpected hostname ${hostname}`);
+  }),
+}));
+
+import { downloadInboundImage, INBOUND_MEDIA_DIR, MAX_IMAGE_BYTES } from '../media-inbound.js';
+
+const API_URL = 'https://api.example.com';
+const BOT_TOKEN = 'bf_secret_xyz';
+
+/** Build a fake fetch Response with a streaming body of `bytes`. */
+function streamResponse(bytes: Uint8Array, contentType: string, status = 200): Response {
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) { controller.enqueue(bytes); controller.close(); },
+  });
+  return new Response(status === 200 ? body : null, {
+    status,
+    headers: { 'content-type': contentType },
+  });
+}
+
+describe('downloadInboundImage', () => {
+  let cwd: string;
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    cwd = mkdtempSync(join(tmpdir(), 'cc-img-test-'));
+    fetchSpy = vi.spyOn(globalThis, 'fetch');
+  });
+  afterEach(() => {
+    fetchSpy.mockRestore();
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it('downloads a PNG into <cwd>/.cc-octo-media and returns a relative path', async () => {
+    fetchSpy.mockResolvedValue(streamResponse(new Uint8Array([1, 2, 3, 4]), 'image/png'));
+    const r = await downloadInboundImage({ url: `${API_URL}/file/a.png`, cwdDir: cwd, botToken: BOT_TOKEN, apiUrl: API_URL });
+    expect('relPath' in r).toBe(true);
+    if ('relPath' in r) {
+      expect(r.relPath.startsWith(INBOUND_MEDIA_DIR)).toBe(true);
+      expect(r.relPath.endsWith('.png')).toBe(true);
+      expect(isAbsolute(r.relPath)).toBe(false);
+      expect(existsSync(r.localPath)).toBe(true);
+      // File is inside the cwd sandbox.
+      expect(r.localPath.startsWith(cwd)).toBe(true);
+    }
+  });
+
+  it('maps content-type to the right extension (jpeg/gif/webp)', async () => {
+    for (const [ct, ext] of [['image/jpeg', 'jpg'], ['image/gif', 'gif'], ['image/webp', 'webp']] as const) {
+      fetchSpy.mockResolvedValue(streamResponse(new Uint8Array([9]), ct));
+      const r = await downloadInboundImage({ url: `${API_URL}/x`, cwdDir: cwd, botToken: BOT_TOKEN, apiUrl: API_URL });
+      expect('relPath' in r && r.relPath.endsWith('.' + ext)).toBe(true);
+    }
+  });
+
+  it('rejects a non-image content type', async () => {
+    fetchSpy.mockResolvedValue(streamResponse(new Uint8Array([1]), 'text/html'));
+    const r = await downloadInboundImage({ url: `${API_URL}/x`, cwdDir: cwd, botToken: BOT_TOKEN, apiUrl: API_URL });
+    expect('error' in r && /不支持的图片类型/.test(r.error)).toBe(true);
+  });
+
+  it('rejects an oversize image and deletes the partial file', async () => {
+    const big = new Uint8Array(MAX_IMAGE_BYTES + 1);
+    fetchSpy.mockResolvedValue(streamResponse(big, 'image/png'));
+    const r = await downloadInboundImage({ url: `${API_URL}/big.png`, cwdDir: cwd, botToken: BOT_TOKEN, apiUrl: API_URL });
+    expect('error' in r && /上限/.test(r.error)).toBe(true);
+    // No leftover file in the media dir.
+    const dir = join(cwd, INBOUND_MEDIA_DIR);
+    expect(!existsSync(dir) || readdirSync(dir).length === 0).toBe(true);
+  });
+
+  it('rejects an SSRF target (private/loopback host) without fetching', async () => {
+    const r = await downloadInboundImage({ url: 'https://internal.local/x.png', cwdDir: cwd, botToken: BOT_TOKEN, apiUrl: API_URL });
+    expect('error' in r && /拒绝下载/.test(r.error)).toBe(true);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('reports an HTTP error', async () => {
+    fetchSpy.mockResolvedValue(streamResponse(new Uint8Array(), 'image/png', 404));
+    const r = await downloadInboundImage({ url: `${API_URL}/missing.png`, cwdDir: cwd, botToken: BOT_TOKEN, apiUrl: API_URL });
+    expect('error' in r && /HTTP 404/.test(r.error)).toBe(true);
+  });
+
+  it('sends the bot token only to the same host (Authorization scoping)', async () => {
+    fetchSpy.mockResolvedValue(streamResponse(new Uint8Array([1]), 'image/png'));
+    await downloadInboundImage({ url: `${API_URL}/a.png`, cwdDir: cwd, botToken: BOT_TOKEN, apiUrl: API_URL });
+    const init = fetchSpy.mock.calls[0]?.[1] as RequestInit | undefined;
+    const auth = (init?.headers as Record<string, string> | undefined)?.Authorization;
+    expect(auth).toBe(`Bearer ${BOT_TOKEN}`);
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -179,6 +179,14 @@ export interface Config {
    * single-bot case. Populated by `resolveBotConfigs()`.
    */
   botId?: string;
+  /**
+   * #86: media CDN host (no scheme), prefetched at startup from the upload-
+   * credentials STS response (`cdnBaseUrl`). Octo serves media from a separate
+   * CDN host than `apiUrl`; inbound media URLs on this host are allowed by
+   * buildMediaUrl. Runtime-populated (not from the config file); undefined until
+   * the prefetch succeeds, in which case only same-apiUrl-host media is allowed.
+   */
+  mediaCdnHost?: string;
 }
 
 /**

--- a/src/inbound.ts
+++ b/src/inbound.ts
@@ -27,7 +27,7 @@ import { assertPublicUrl, fetchWithRedirectGuard } from './url-policy.js';
  * Returns true only when both URLs parse successfully and have matching host
  * (case-insensitive). Falsy or malformed inputs return false (fail-closed).
  */
-function isSameHost(url: string, apiUrl: string): boolean {
+export function isSameHost(url: string, apiUrl: string): boolean {
   try {
     return new URL(url).host.toLowerCase() === new URL(apiUrl).host.toLowerCase();
   } catch {
@@ -118,7 +118,7 @@ export interface ResolvedContent {
  *     payload.url from later being fetched with the bot's Authorization
  *     header (which would leak botToken to the attacker's server).
  */
-export function buildMediaUrl(relUrl?: string, apiUrl?: string): string | undefined {
+export function buildMediaUrl(relUrl?: string, apiUrl?: string, cdnHost?: string): string | undefined {
   if (!relUrl) return undefined;
 
   // Reject backslashes outright — they're not valid in URL paths and are a
@@ -128,14 +128,25 @@ export function buildMediaUrl(relUrl?: string, apiUrl?: string): string | undefi
   // Reject scheme-relative URLs (`//attacker.com/path`).
   if (relUrl.startsWith('//')) return undefined;
 
-  // Absolute http(s) URL — only allow when host matches apiUrl host.
+  // Absolute http(s) URL — allow when the host matches the apiUrl host OR the
+  // configured/STS-derived CDN host. Octo serves media from a SEPARATE CDN
+  // (e.g. cdn.deepminer.com.cn) distinct from the API host, so a strict
+  // same-host check silently dropped every real image URL (#86). The download
+  // path still SSRF-checks (assertPublicUrl) and scopes the bot token per hop,
+  // so an allowed host is necessary but not sufficient to leak the token.
   if (relUrl.startsWith('http://') || relUrl.startsWith('https://')) {
     if (!apiUrl) return undefined;
     try {
       const target = new URL(relUrl);
+      const targetHost = target.host.toLowerCase();
       const base = new URL(apiUrl);
-      if (target.host.toLowerCase() !== base.host.toLowerCase()) return undefined;
-      if (target.protocol !== base.protocol) return undefined;
+      const allowedHosts = new Set<string>([base.host.toLowerCase()]);
+      if (cdnHost) allowedHosts.add(cdnHost.toLowerCase());
+      if (!allowedHosts.has(targetHost)) return undefined;
+      // Only allow http(s); the same-host protocol-downgrade check still applies
+      // to the apiUrl host (a CDN may legitimately use https regardless).
+      if (targetHost === base.host.toLowerCase() && target.protocol !== base.protocol) return undefined;
+      if (target.protocol !== 'http:' && target.protocol !== 'https:') return undefined;
       return relUrl;
     } catch {
       return undefined;
@@ -276,6 +287,7 @@ function buildRichTextPlain(blocks: Array<Record<string, unknown>>): string {
 export function resolveRichTextContent(
   payload: { content?: unknown; plain?: unknown },
   apiUrl?: string,
+  cdnHost?: string,
 ): { text: string; mediaUrls: string[] } {
   const blocks = normalizeRichTextBlocks(payload?.content);
   const mediaUrls: string[] = [];
@@ -283,7 +295,7 @@ export function resolveRichTextContent(
     // Defensive: only collect string URLs so a malformed `{url: {}}` cannot
     // crash buildMediaUrl downstream.
     if (blk.type === RICH_TEXT_BLOCK_IMAGE && typeof blk.url === 'string' && blk.url) {
-      const full = buildMediaUrl(blk.url, apiUrl);
+      const full = buildMediaUrl(blk.url, apiUrl, cdnHost);
       if (full) mediaUrls.push(full);
       if (mediaUrls.length >= RICH_TEXT_MAX_MEDIA_URLS) break;
     }
@@ -296,9 +308,9 @@ export function resolveRichTextContent(
 
 // ─── Inner message rendering (MultipleForward children) ──────────────────
 
-function resolveInnerMessageText(payload: ForwardMessage['payload'], apiUrl?: string): string {
+function resolveInnerMessageText(payload: ForwardMessage['payload'], apiUrl?: string, cdnHost?: string): string {
   if (!payload) return '';
-  const fullUrl = buildMediaUrl(payload.url, apiUrl);
+  const fullUrl = buildMediaUrl(payload.url, apiUrl, cdnHost);
   switch (payload.type) {
     case MessageType.Text:
       return payload.content ?? '';
@@ -321,7 +333,7 @@ function resolveInnerMessageText(payload: ForwardMessage['payload'], apiUrl?: st
     case MessageType.MultipleForward:
       return '[合并转发]';
     case MessageType.RichText: {
-      const rt = resolveRichTextContent(payload as { content?: unknown; plain?: unknown }, apiUrl);
+      const rt = resolveRichTextContent(payload as { content?: unknown; plain?: unknown }, apiUrl, cdnHost);
       return rt.text || '[图文消息]';
     }
     default:
@@ -344,6 +356,7 @@ function resolveInnerMessageText(payload: ForwardMessage['payload'], apiUrl?: st
 export function resolveMultipleForwardText(
   payload: { users?: ForwardUser[]; msgs?: ForwardMessage[] },
   apiUrl?: string,
+  cdnHost?: string,
   _depth = 0,
 ): string {
   if (_depth >= MULTIPLE_FORWARD_MAX_DEPTH) {
@@ -362,11 +375,11 @@ export function resolveMultipleForwardText(
   for (const m of msgs) {
     const senderName = userMap.get(m.from_uid) ?? m.from_uid;
     if (m.payload?.type === MessageType.MultipleForward) {
-      const nested = resolveMultipleForwardText(m.payload, apiUrl, _depth + 1);
+      const nested = resolveMultipleForwardText(m.payload, apiUrl, cdnHost, _depth + 1);
       lines.push(`${senderName}: [合并转发]`);
       lines.push(nested);
     } else {
-      lines.push(`${senderName}: ${resolveInnerMessageText(m.payload, apiUrl)}`);
+      lines.push(`${senderName}: ${resolveInnerMessageText(m.payload, apiUrl, cdnHost)}`);
     }
   }
   if (truncatedCount > 0) {
@@ -387,7 +400,7 @@ export function resolveMultipleForwardText(
  * This is the synchronous part — file inlining (which requires HTTP) is a
  * separate async step done by `tryInlineFile()`.
  */
-export function resolveContent(payload: MessagePayload | undefined, apiUrl?: string): ResolvedContent {
+export function resolveContent(payload: MessagePayload | undefined, apiUrl?: string, cdnHost?: string): ResolvedContent {
   if (!payload) return { text: '' };
 
   switch (payload.type) {
@@ -395,7 +408,7 @@ export function resolveContent(payload: MessagePayload | undefined, apiUrl?: str
       return { text: payload.content ?? '' };
 
     case MessageType.Image: {
-      const imgUrl = buildMediaUrl(payload.url, apiUrl);
+      const imgUrl = buildMediaUrl(payload.url, apiUrl, cdnHost);
       return {
         text: imgUrl ? `[图片]\n${imgUrl}` : '[图片]',
         mediaUrl: imgUrl,
@@ -403,7 +416,7 @@ export function resolveContent(payload: MessagePayload | undefined, apiUrl?: str
     }
 
     case MessageType.GIF: {
-      const url = buildMediaUrl(payload.url, apiUrl);
+      const url = buildMediaUrl(payload.url, apiUrl, cdnHost);
       return {
         text: url ? `[GIF]\n${url}` : '[GIF]',
         mediaUrl: url,
@@ -411,7 +424,7 @@ export function resolveContent(payload: MessagePayload | undefined, apiUrl?: str
     }
 
     case MessageType.Voice: {
-      const url = buildMediaUrl(payload.url, apiUrl);
+      const url = buildMediaUrl(payload.url, apiUrl, cdnHost);
       return {
         // G22: language model receives the URL as a marker; transcription is
         // out of scope for v0.2 and tracked separately.
@@ -421,7 +434,7 @@ export function resolveContent(payload: MessagePayload | undefined, apiUrl?: str
     }
 
     case MessageType.Video: {
-      const url = buildMediaUrl(payload.url, apiUrl);
+      const url = buildMediaUrl(payload.url, apiUrl, cdnHost);
       return {
         text: url ? `[视频]\n${url}` : '[视频]',
         mediaUrl: url,
@@ -429,7 +442,7 @@ export function resolveContent(payload: MessagePayload | undefined, apiUrl?: str
     }
 
     case MessageType.File: {
-      const url = buildMediaUrl(payload.url, apiUrl);
+      const url = buildMediaUrl(payload.url, apiUrl, cdnHost);
       const fileName = typeof payload.name === 'string' ? payload.name : '未知文件';
       return {
         text: url ? `[文件: ${fileName}]\n${url}` : `[文件: ${fileName}]`,
@@ -464,12 +477,13 @@ export function resolveContent(payload: MessagePayload | undefined, apiUrl?: str
         text: resolveMultipleForwardText(
           payload as unknown as { users?: ForwardUser[]; msgs?: ForwardMessage[] },
           apiUrl,
+          cdnHost,
         ),
       };
     }
 
     case MessageType.RichText: {
-      const rt = resolveRichTextContent(payload as unknown as { content?: unknown; plain?: unknown }, apiUrl);
+      const rt = resolveRichTextContent(payload as unknown as { content?: unknown; plain?: unknown }, apiUrl, cdnHost);
       return {
         text: rt.text,
         ...(rt.mediaUrls.length > 0 ? { mediaUrl: rt.mediaUrls[0], mediaUrls: rt.mediaUrls } : {}),

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,13 +15,14 @@ import { GroupContext } from './group-context.js';
 import { queryAgent } from './agent-bridge.js';
 import { sanitizeDisplayName, escapeSectionMarkers, sanitizePromptBody } from './prompt-safety.js';
 import type { SessionCtx } from './cwd-resolver.js';
-import { cleanupExpiredCwds, resolveMemoryDir } from './cwd-resolver.js';
+import { cleanupExpiredCwds, resolveMemoryDir, resolveSessionCwd } from './cwd-resolver.js';
 import { StreamRelay } from './stream-relay.js';
-import { sendMessage, sendReadReceipt, getChannelMessages } from './octo/api.js';
+import { sendMessage, sendReadReceipt, getChannelMessages, getUploadCredentials } from './octo/api.js';
 import type { HistoricalMessage } from './octo/api.js';
 import { ChannelType, MessageType } from './octo/types.js';
 import type { BotMessage } from './octo/types.js';
 import { resolveContent, tryResolveFile, resolveHistoricalMessagePlaceholder } from './inbound.js';
+import { downloadInboundImage, MAX_IMAGES_PER_MESSAGE } from './media-inbound.js';
 import { handleCommand } from './commands.js';
 import { loadGroupConfig } from './group-config.js';
 import { WebhookServer } from './webhook.js';
@@ -180,6 +181,28 @@ async function startBot(config: ReturnType<typeof loadConfig>, multi: boolean): 
   await gateway.register();
   console.log(`[cc-channel-octo] ${label}Bot registered: id=${gateway.botId}`);
 
+  // #86: prefetch the media CDN host (best-effort). Octo serves media from a
+  // separate CDN than apiUrl; without this, inbound image URLs on the CDN host
+  // are rejected by buildMediaUrl and the agent can't see them. The STS
+  // upload-credentials response carries cdnBaseUrl; we only need its host. A
+  // failure leaves mediaCdnHost undefined (same-host-only media), never fatal.
+  try {
+    const creds = await getUploadCredentials({
+      apiUrl: config.apiUrl,
+      botToken: config.botToken,
+      // The credentials endpoint validates the filename's type; use an image
+      // name so the probe isn't rejected (file_type_unsupported). We only read
+      // cdnBaseUrl from the response — nothing is uploaded.
+      filename: 'probe.png',
+    });
+    if (creds.cdnBaseUrl) {
+      config.mediaCdnHost = new URL(creds.cdnBaseUrl).host;
+      console.log(`[cc-channel-octo] ${label}Media CDN host: ${config.mediaCdnHost}`);
+    }
+  } catch (err) {
+    console.warn(`[cc-channel-octo] ${label}Could not prefetch media CDN host (inbound media limited to apiUrl host): ${err instanceof Error ? err.message : String(err)}`);
+  }
+
   // --- Session router ---
   const router = new SessionRouter(config, gateway.botId, gateway.ownerUid);
 
@@ -289,6 +312,15 @@ export async function handleMessage(
       // --- Session ---
       store.getOrCreate(sessionKey, channelId, channelType);
 
+      // Session routing context (cwd/memory partition). Built here (before media
+      // resolution) so inbound images can be downloaded INTO this session's cwd
+      // sandbox for the agent to Read. Group keys are channel_id alone (shared
+      // workspace); DM keys are per-peer. See cwd-resolver.ts header.
+      const sessionCtx: SessionCtx = {
+        kind: isGroup ? 'group' : 'dm',
+        sessionKey,
+      };
+
       // --- v0.3: in-chat slash commands (/reset, /config, /help) ---
       // Handled before group-context caching, history append, and the agent
       // query — so a command never reaches the LLM, is not stored as a turn,
@@ -349,7 +381,7 @@ export async function handleMessage(
       // --- G1: Resolve the inbound payload into LLM-friendly text ---
       // Text messages use the router's cleanContent (with @bot stripping);
       // non-text payloads go through resolveContent for type-aware rendering.
-      const resolved = resolveContent(msg.payload, config.apiUrl);
+      const resolved = resolveContent(msg.payload, config.apiUrl, config.mediaCdnHost);
       let bodyText = result.cleanContent ?? resolved.text;
 
       // Compact history record. For File payloads we store only the metadata
@@ -357,6 +389,49 @@ export async function handleMessage(
       // can't blow up the system prompt on subsequent turns. See PR#33
       // follow-up issue ·2 (齐哥 review).
       let historyRecord = bodyText;
+
+      // #86: Native image input. Octo delivers images as URLs; download them
+      // INTO this session's cwd sandbox so the agent can SEE them via the Read
+      // tool (the SDK's Read renders image files), instead of only getting a URL
+      // string. Covers single-image (Image/GIF) and RichText embedded images.
+      // History keeps the compact marker (not the local path) so it doesn't
+      // accumulate stale paths. Falls back to the URL marker on any failure.
+      {
+        const imageUrls: string[] = [];
+        if (
+          (msg.payload.type === MessageType.Image || msg.payload.type === MessageType.GIF) &&
+          resolved.mediaUrl
+        ) {
+          imageUrls.push(resolved.mediaUrl);
+        } else if (msg.payload.type === MessageType.RichText && resolved.mediaUrls?.length) {
+          imageUrls.push(...resolved.mediaUrls);
+        }
+        if (imageUrls.length > 0) {
+          const cwdBase = config.cwdBase ?? config.cwd;
+          const cwdDir = resolveSessionCwd(cwdBase, sessionCtx);
+          const localPaths: string[] = [];
+          for (const url of imageUrls.slice(0, MAX_IMAGES_PER_MESSAGE)) {
+            try {
+              const r = await downloadInboundImage({ url, cwdDir, botToken: config.botToken, apiUrl: config.apiUrl });
+              if ('relPath' in r) {
+                localPaths.push(r.relPath);
+              } else {
+                console.warn(`[cc-channel-octo] inbound image skipped: ${r.error}`);
+              }
+            } catch (err) {
+              console.error(`[cc-channel-octo] inbound image download failed: ${String(err)}`);
+            }
+          }
+          if (localPaths.length > 0) {
+            // Append a Read hint for THIS turn only (bodyText), keeping the URL
+            // marker too as a fallback reference. historyRecord stays unchanged.
+            const hint = localPaths.length === 1
+              ? `\n[已下载图片到本地: ${localPaths[0]} — 请用 Read 工具查看]`
+              : `\n[已下载 ${localPaths.length} 张图片到本地: ${localPaths.join(', ')} — 请用 Read 工具逐个查看]`;
+            bodyText = bodyText + hint;
+          }
+        }
+      }
 
       // G2: Inline text-file content for File payloads when feasible.
       if (
@@ -514,17 +589,8 @@ export async function handleMessage(
 
       // --- Query agent with structural role separation (Q3 fix) ---
       // userContentForLLM → user role (prompt), history + context → system role (systemPrompt)
-      // cwd isolation: the SessionCtx carries the router-produced sessionKey
-      // verbatim, so the cwd partition is byte-for-byte identical to the history
-      // partition. Group keys are the channel_id alone (session-router.ts), so a
-      // whole group SHARES one sandbox (and one history + one memory) — a group
-      // is a shared workspace, with no member-to-member isolation. DM keys are
-      // per-peer, so DM sandboxes stay private. (This is the intentional reversal
-      // of the per-(channel×user) group isolation; see cwd-resolver.ts header.)
-      const sessionCtx: SessionCtx = {
-        kind: isGroup ? 'group' : 'dm',
-        sessionKey,
-      };
+      // sessionCtx (cwd/memory partition) was built earlier so inbound images
+      // could be downloaded into this session's sandbox.
 
       // v0.3 tool progress (opt-in): send a brief "🔧 Running <tool>…" notice as
       // the agent invokes tools. Dedup consecutive identical tools and cap the

--- a/src/media-inbound.ts
+++ b/src/media-inbound.ts
@@ -1,0 +1,145 @@
+/**
+ * Inbound image download for native multimodal (issue #86).
+ *
+ * Octo delivers images as URLs. To let the agent actually SEE an image (not just
+ * a URL string), we download it INTO the session's cwd sandbox so the model can
+ * open it with the Read tool (the Claude Agent SDK's Read supports image files).
+ * Writing under the session cwd means:
+ *  - the agent can reach it with a relative path,
+ *  - it's isolated per session (same partition as history/memory), and
+ *  - the existing 7-day cwd janitor reclaims it — no separate cleanup needed.
+ *
+ * Reuses the same SSRF/redirect/size hardening as the file-download path.
+ */
+
+import { createWriteStream } from 'node:fs';
+import { mkdir, unlink } from 'node:fs/promises';
+import { join, relative } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { assertPublicUrl, fetchWithRedirectGuard } from './url-policy.js';
+import { isSameHost } from './inbound.js';
+
+/** Subdir (under the session cwd) where downloaded inbound images land. */
+export const INBOUND_MEDIA_DIR = '.cc-octo-media';
+
+/** Per-image hard cap. Claude's vision API rejects very large images; 5 MB
+ *  matches the inbound file cap and is comfortably above any real chat image. */
+export const MAX_IMAGE_BYTES = 5 * 1024 * 1024;
+
+/** Max images materialized from a single message (e.g. a RichText with many). */
+export const MAX_IMAGES_PER_MESSAGE = 6;
+
+const IMAGE_DOWNLOAD_TIMEOUT_MS = 30_000;
+
+/**
+ * Content-Type → file extension for the image formats Claude can natively read.
+ * A response whose type isn't here is rejected (we don't feed unknown blobs to
+ * the model as "images").
+ */
+const ALLOWED_IMAGE_TYPES: Record<string, string> = {
+  'image/png': 'png',
+  'image/jpeg': 'jpg',
+  'image/jpg': 'jpg',
+  'image/gif': 'gif',
+  'image/webp': 'webp',
+};
+
+export type ImageDownloadResult =
+  | { localPath: string; relPath: string }
+  | { error: string };
+
+/**
+ * Download one image URL into `<cwdDir>/.cc-octo-media/`. Returns the absolute
+ * path and the path relative to the cwd (what we show the agent). On any
+ * problem (SSRF reject, non-image type, oversize, HTTP error) returns
+ * `{ error }` so the caller can fall back to the URL marker.
+ */
+export async function downloadInboundImage(params: {
+  url: string;
+  cwdDir: string;
+  botToken: string;
+  apiUrl: string;
+}): Promise<ImageDownloadResult> {
+  const { url, cwdDir, botToken, apiUrl } = params;
+
+  // SSRF defense — reject private/loopback/link-local (and re-checked per hop
+  // inside fetchWithRedirectGuard).
+  try {
+    await assertPublicUrl(url);
+  } catch (err) {
+    return { error: `拒绝下载: ${String(err)}` };
+  }
+
+  const signal = AbortSignal.timeout(IMAGE_DOWNLOAD_TIMEOUT_MS);
+  let resp: Awaited<ReturnType<typeof fetchWithRedirectGuard>>;
+  try {
+    // Scope Authorization PER HOP: only send the bot token while the current
+    // hop is same-host as apiUrl (a redirect to another host drops it).
+    resp = await fetchWithRedirectGuard(url, (currentUrl) => {
+      const headers: Record<string, string> = {};
+      if (isSameHost(currentUrl, apiUrl)) headers.Authorization = `Bearer ${botToken}`;
+      return { headers, signal };
+    });
+  } catch (err) {
+    return { error: `下载失败: ${String(err)}` };
+  }
+
+  if (!resp.ok) return { error: `下载失败 HTTP ${resp.status}` };
+
+  // Only accept image content types Claude can read.
+  const rawType = (resp.headers.get('content-type') ?? '').split(';')[0].trim().toLowerCase();
+  const ext = ALLOWED_IMAGE_TYPES[rawType];
+  if (!ext) return { error: `不支持的图片类型: ${rawType || '未知'}` };
+
+  const body = resp.body;
+  if (!body) return { error: '响应无内容' };
+
+  const dir = join(cwdDir, INBOUND_MEDIA_DIR);
+  await mkdir(dir, { recursive: true });
+  const localPath = join(dir, `${randomUUID()}.${ext}`);
+
+  // Stream to disk with a hard size cap (abort + delete on overflow).
+  const reader = (body as unknown as { getReader: () => ReadableStreamDefaultReader<Uint8Array> }).getReader();
+  const ws = createWriteStream(localPath);
+
+  /** Tear down the write stream and remove the (possibly partial) file. */
+  const cleanup = async (): Promise<void> => {
+    await new Promise<void>((resolve) => {
+      // destroy() then wait for 'close' so the fd is released before unlink,
+      // avoiding a race where unlink runs before the file is fully created.
+      ws.once('close', () => resolve());
+      ws.destroy();
+    });
+    await unlink(localPath).catch(() => {});
+  };
+
+  let total = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > MAX_IMAGE_BYTES) {
+        try { reader.cancel(); } catch { /* ignore */ }
+        await cleanup();
+        return { error: `图片超过大小上限 ${Math.round(MAX_IMAGE_BYTES / 1024 / 1024)}MB` };
+      }
+      if (!ws.write(value)) await new Promise<void>((r) => ws.once('drain', r));
+    }
+    ws.end();
+    await new Promise<void>((resolve, reject) => {
+      ws.on('finish', () => resolve());
+      ws.on('error', reject);
+    });
+  } catch (err) {
+    await cleanup();
+    return { error: `下载失败: ${String(err)}` };
+  }
+
+  if (total === 0) {
+    await cleanup();
+    return { error: '图片为空' };
+  }
+
+  return { localPath, relPath: relative(cwdDir, localPath) };
+}


### PR DESCRIPTION
Closes #86 (P1 of the openclaw-parity roadmap #91).

## Problem
Inbound images were rendered as a `[图片]\n<URL>` text marker — the agent only got a URL string and **could not see the image**. Two deeper issues surfaced during live dogfood:
1. Real Octo serves media from a **separate CDN host** (`cdn.deepminer.com.cn`) than `apiUrl` (`im.deepminer.com.cn`); `buildMediaUrl`'s strict same-host allow-list **silently dropped every CDN image URL** — even the text marker lost its URL.
2. Images arrive as **RichText (type 14)** with the URL in `content[].url`, not as a type-2 Image.

## Fix
- **`buildMediaUrl(relUrl, apiUrl, cdnHost?)`** — allow an absolute http(s) URL whose host matches the apiUrl host **or** the CDN host; other hosts still rejected; the `/file/` sandbox + traversal/SSRF guards unchanged. Threaded `cdnHost` through `resolveContent`/`resolveRichTextContent`/`resolveInnerMessageText`/`resolveMultipleForwardText`.
- **`config.mediaCdnHost`** — prefetched once at startup from the STS upload-credentials `cdnBaseUrl` (best-effort, non-fatal; falls back to same-host-only).
- **`src/media-inbound.ts` `downloadInboundImage()`** — streams an image into the session **cwd sandbox** (`<cwd>/.cc-octo-media/`), reusing SSRF/redirect guards + per-hop token scoping; validates content-type (png/jpeg/gif/webp), 5 MB cap, cleans up partials; returns a cwd-relative path.
- **`index.ts`** — for Image/GIF + RichText images, download into the session cwd and append `[已下载图片到本地: <path> — 请用 Read 工具查看]` to the turn (history keeps the compact marker). Falls back to the URL marker on failure. The existing 7-day cwd janitor reclaims the images.

## Design choices (confirmed with maintainer)
- Images delivered via **download-to-cwd + Read hint** (not base64 blocks) — lighter, reuses cwd isolation.
- **First scope: images only** (Image/GIF/RichText); Voice/Video keep the URL marker.
- CDN host allow via **STS `cdnBaseUrl`** (auto), **per-hop token scoping kept** (CDN gets no bot token).

## Verified
Live: the bot downloaded a real RichText image and described it accurately — *"举着鱼竿的小章鱼吉祥物…Octo"* (the 2500×2500 Octo logo). **982 tests** (+ new media-inbound suite & buildMediaUrl CDN cases), lint (0 warnings), build, NUL clean.