### PR TITLE
feat(agent-tools): read-only octo_management MCP tool server (#87 phase 1)

### DIFF
--- a/src/__tests__/agent-bridge-query.test.ts
+++ b/src/__tests__/agent-bridge-query.test.ts
@@ -4,6 +4,10 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 const mockQuery = vi.hoisted(() => vi.fn());
 vi.mock('@anthropic-ai/claude-agent-sdk', () => ({
   query: mockQuery,
+  // octo-tools.ts (imported transitively via agent-bridge) uses these; provide
+  // lightweight stand-ins so the module loads under the mock.
+  createSdkMcpServer: (opts: { name: string }) => ({ type: 'sdk', name: opts.name, instance: {} }),
+  tool: (name: string, description: string, inputSchema: unknown, handler: unknown) => ({ name, description, inputSchema, handler }),
 }));
 
 import { queryAgent } from '../agent-bridge.js';
@@ -367,6 +371,26 @@ describe('queryAgent', () => {
     ]));
     for await (const _ of queryAgent('t', '', '', makeConfig())) { void _; }
     expect(mockQuery.mock.calls[0][0].options).not.toHaveProperty('settings');
+  });
+
+  it('wires the octo MCP tool server only when sdk.octoTools is enabled (#87)', async () => {
+    mockQuery.mockReturnValue(createMockStream([
+      { type: 'assistant', session_id: 's-1', message: { content: [{ type: 'text', text: 'hi' }] } },
+    ]));
+    const config = makeConfig({ sdk: { allowedTools: '*', permissionMode: 'bypassPermissions', settingSources: [], octoTools: true } });
+    for await (const _ of queryAgent('t', '', '', config)) { void _; }
+    const options = mockQuery.mock.calls[0][0].options;
+    expect(options.mcpServers).toBeDefined();
+    expect(options.mcpServers.octo).toBeDefined();
+    expect(options.mcpServers.octo.name).toBe('octo');
+  });
+
+  it('omits mcpServers when sdk.octoTools is off (default)', async () => {
+    mockQuery.mockReturnValue(createMockStream([
+      { type: 'assistant', session_id: 's-1', message: { content: [{ type: 'text', text: 'hi' }] } },
+    ]));
+    for await (const _ of queryAgent('t', '', '', makeConfig())) { void _; }
+    expect(mockQuery.mock.calls[0][0].options).not.toHaveProperty('mcpServers');
   });
 
   it('reports the SDK session_id once via onSessionId', async () => {

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -29,6 +29,7 @@ const CC_VARS = [
   'CC_OCTO_CONTEXT_HISTORY_LIMIT', 'CC_OCTO_BOT_BLOCKLIST',
   'CC_OCTO_MENTION_FREE_GROUPS', 'CC_OCTO_MAX_RESPONSE_CHARS',
   'ANTHROPIC_BASE_URL', 'CC_OCTO_SDK_TOOL_PROGRESS', 'CC_OCTO_SDK_PERSISTENT_SESSION',
+  'CC_OCTO_SDK_OCTO_TOOLS',
   'CC_OCTO_GROUP_CONFIG_DIR',
   'CC_OCTO_TRANSPORT', 'CC_OCTO_WEBHOOK_HOST', 'CC_OCTO_WEBHOOK_PORT',
   'CC_OCTO_WEBHOOK_PATH', 'CC_OCTO_WEBHOOK_SECRET',
@@ -663,6 +664,35 @@ describe('v0.3: tool progress toggle', () => {
       expect(loadConfig(path).sdk.toolProgress).toBe(false);
     },
   );
+});
+
+// ─── #87: sdk.octoTools ────────────────────────────────────────────────
+
+describe('sdk.octoTools toggle', () => {
+  beforeEach(setup);
+  afterEach(teardown);
+
+  it('defaults to undefined (off)', () => {
+    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
+    expect(loadConfig(path).sdk.octoTools).toBeUndefined();
+  });
+
+  it('reads sdk.octoTools=true from the config file', () => {
+    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a', sdk: { octoTools: true } });
+    expect(loadConfig(path).sdk.octoTools).toBe(true);
+  });
+
+  it.each(['true', '1', 'yes', 'on'])('CC_OCTO_SDK_OCTO_TOOLS=%s enables it', (val) => {
+    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
+    process.env.CC_OCTO_SDK_OCTO_TOOLS = val;
+    expect(loadConfig(path).sdk.octoTools).toBe(true);
+  });
+
+  it.each(['false', '0', 'off', ''])('CC_OCTO_SDK_OCTO_TOOLS=%s disables it', (val) => {
+    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a', sdk: { octoTools: true } });
+    process.env.CC_OCTO_SDK_OCTO_TOOLS = val;
+    expect(loadConfig(path).sdk.octoTools).toBe(false);
+  });
 });
 
 // ─── Multi-bot (resolveBotConfigs, two-layer) ──────────────────────────

--- a/src/__tests__/octo-tools.test.ts
+++ b/src/__tests__/octo-tools.test.ts
@@ -1,0 +1,100 @@
+/**
+ * octo-tools (#87) read-only agent tool tests.
+ *
+ * Drives each tool's handler directly (the MCP server keeps tools in private
+ * internals, so we test via buildOctoTools). octo/api.js is mocked.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Config } from '../config.js';
+
+vi.mock('../octo/api.js', () => ({
+  fetchBotGroups: vi.fn(),
+  getGroupInfo: vi.fn(),
+  getGroupMembers: vi.fn(),
+  searchSpaceMembers: vi.fn(),
+}));
+
+import { buildOctoTools, createOctoToolServer, OCTO_TOOL_SERVER_NAME } from '../octo-tools.js';
+import { fetchBotGroups, getGroupInfo, getGroupMembers, searchSpaceMembers } from '../octo/api.js';
+
+function cfg(): Config {
+  return {
+    botToken: 'bf_tok',
+    apiUrl: 'https://api.example.com',
+    baseDir: '/base',
+    cwd: '/base/default/workspace',
+    cwdBase: '/base/default/workspace',
+    dataDir: '/base/default/data',
+    sdk: { allowedTools: '*', permissionMode: 'bypassPermissions', settingSources: [] },
+    rateLimit: { maxPerMinute: 5 },
+    context: { maxContextChars: 6000, historyLimit: 40 },
+    maxResponseChars: 524_288,
+  };
+}
+
+/** Find a tool definition by name. */
+function getTool(name: string) {
+  const t = buildOctoTools(cfg()).find((x) => x.name === name);
+  if (!t) throw new Error(`tool ${name} not found`);
+  return t;
+}
+
+/** Extract the text content of a tool result. */
+function text(result: { content: Array<{ type: string; text?: string }> }): string {
+  return result.content.map((c) => c.text ?? '').join('');
+}
+
+describe('octo-tools: read-only server', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('exposes exactly the four read-only tools', () => {
+    const names = buildOctoTools(cfg()).map((t) => t.name).sort();
+    expect(names).toEqual(['group_info', 'group_members', 'list_groups', 'search_members']);
+  });
+
+  it('createOctoToolServer builds an MCP server named "octo"', () => {
+    const server = createOctoToolServer(cfg());
+    expect(OCTO_TOOL_SERVER_NAME).toBe('octo');
+    expect((server as { name: string }).name).toBe('octo');
+  });
+
+  it('list_groups calls fetchBotGroups with apiUrl/botToken and returns JSON', async () => {
+    vi.mocked(fetchBotGroups).mockResolvedValue([{ groupNo: 'g1', name: 'Group One' }] as never);
+    const r = await getTool('list_groups').handler({}, {});
+    expect(fetchBotGroups).toHaveBeenCalledWith({ apiUrl: 'https://api.example.com', botToken: 'bf_tok' });
+    expect(text(r)).toContain('Group One');
+  });
+
+  it('group_info passes the groupNo through', async () => {
+    vi.mocked(getGroupInfo).mockResolvedValue({ groupNo: 'g7', name: 'Seven' } as never);
+    const r = await getTool('group_info').handler({ groupNo: 'g7' }, {});
+    expect(getGroupInfo).toHaveBeenCalledWith({ apiUrl: 'https://api.example.com', botToken: 'bf_tok', groupNo: 'g7' });
+    expect(text(r)).toContain('Seven');
+  });
+
+  it('group_members passes the groupNo through', async () => {
+    vi.mocked(getGroupMembers).mockResolvedValue([{ uid: 'u1', name: 'Alice' }] as never);
+    const r = await getTool('group_members').handler({ groupNo: 'g9' }, {});
+    expect(getGroupMembers).toHaveBeenCalledWith({ apiUrl: 'https://api.example.com', botToken: 'bf_tok', groupNo: 'g9' });
+    expect(text(r)).toContain('Alice');
+  });
+
+  it('search_members forwards keyword + optional limit', async () => {
+    vi.mocked(searchSpaceMembers).mockResolvedValue([{ uid: 'u2', name: 'Bob' }] as never);
+    await getTool('search_members').handler({ keyword: 'Bo', limit: 10 }, {});
+    expect(searchSpaceMembers).toHaveBeenCalledWith({ apiUrl: 'https://api.example.com', botToken: 'bf_tok', keyword: 'Bo', limit: 10 });
+  });
+
+  it('omits limit when not provided', async () => {
+    vi.mocked(searchSpaceMembers).mockResolvedValue([] as never);
+    await getTool('search_members').handler({ keyword: 'x' }, {});
+    expect(searchSpaceMembers).toHaveBeenCalledWith({ apiUrl: 'https://api.example.com', botToken: 'bf_tok', keyword: 'x' });
+  });
+
+  it('returns an isError result (no throw) when the API call fails', async () => {
+    vi.mocked(fetchBotGroups).mockRejectedValue(new Error('boom'));
+    const r = await getTool('list_groups').handler({}, {}) as { isError?: boolean; content: Array<{ text?: string }> };
+    expect(r.isError).toBe(true);
+    expect(text(r)).toContain('boom');
+  });
+});

--- a/src/agent-bridge.ts
+++ b/src/agent-bridge.ts
@@ -16,6 +16,7 @@ import { resolveSessionCwd } from './cwd-resolver.js';
 import type { SessionCtx } from './cwd-resolver.js';
 import { safeBody, safeSectioned, trustedText, escapeSectionMarkers } from './prompt-safety.js';
 import type { SafeText } from './prompt-safety.js';
+import { createOctoToolServer, OCTO_TOOL_SERVER_NAME } from './octo-tools.js';
 
 const VALID_PERMISSION_MODES: Set<string> = new Set([
   'default', 'acceptEdits', 'bypassPermissions', 'plan', 'dontAsk', 'auto',
@@ -326,6 +327,13 @@ export async function* queryAgent(
               autoMemoryDirectory: opts.memoryDir,
             } satisfies Settings,
           }
+        : {}),
+      // #87: opt-in read-only Octo management tools (list_groups, group_info,
+      // group_members, search_members) exposed as an in-process MCP server.
+      // Surface as mcp__octo__<tool>. With the default allowedTools `"*"` they
+      // are auto-allowed; an explicit whitelist must list them to enable.
+      ...(config.sdk.octoTools
+        ? { mcpServers: { [OCTO_TOOL_SERVER_NAME]: createOctoToolServer(config) } }
         : {}),
       // Q2: `"*"` means "no whitelist" — drop the option so the SDK falls back
       // to its built-in tool set. An explicit string[] is forwarded as-is.

--- a/src/config.ts
+++ b/src/config.ts
@@ -131,6 +131,13 @@ export interface Config {
      */
     toolProgress?: boolean;
     /**
+     * #87: when true, expose the read-only Octo management tool server to the
+     * agent (list_groups, group_info, group_members, search_members) so the
+     * model can answer questions about the bot's groups/members. Default false
+     * (opt-in — it widens the agent's reach). Env: `CC_OCTO_SDK_OCTO_TOOLS=true`.
+     */
+    octoTools?: boolean;
+    /**
      * v0.3: when true, use the SDK's v2 Session API to persist agent workspace
      * state across messages — each session's SDK session id is stored and
      * `resume`d on the next turn, so open files / command history / context
@@ -434,6 +441,10 @@ function applyEnv(cfg: Config): Config {
   // v0.3: tool-progress messages. Accept the usual truthy spellings.
   if (env.CC_OCTO_SDK_TOOL_PROGRESS !== undefined) {
     next.sdk.toolProgress = /^(1|true|yes|on)$/i.test(env.CC_OCTO_SDK_TOOL_PROGRESS.trim());
+  }
+  // #87: read-only Octo management tool server (opt-in).
+  if (env.CC_OCTO_SDK_OCTO_TOOLS !== undefined) {
+    next.sdk.octoTools = /^(1|true|yes|on)$/i.test(env.CC_OCTO_SDK_OCTO_TOOLS.trim());
   }
   // v0.3: persistent (v2) sessions.
   if (env.CC_OCTO_SDK_PERSISTENT_SESSION !== undefined) {

--- a/src/octo-tools.ts
+++ b/src/octo-tools.ts
@@ -1,0 +1,123 @@
+/**
+ * Octo management agent tools (#87) — READ-ONLY phase.
+ *
+ * Registers an in-process MCP server exposing a few Octo group/member lookups to
+ * the agent, so the model can answer "which groups am I in?", "who's in this
+ * group?", "find user X" without the operator pre-wiring anything. Backed by the
+ * existing read-only REST in octo/api.ts.
+ *
+ * Scope is deliberately read-only this round — no group/member/thread mutation,
+ * no GROUP.md writes. Those are a later, permission-gated phase (#87 Phase 2 /
+ * #90). The whole server is gated behind `config.sdk.octoTools` (default off).
+ */
+
+import { z } from 'zod';
+import { createSdkMcpServer, tool } from '@anthropic-ai/claude-agent-sdk';
+import type { Config } from './config.js';
+import {
+  fetchBotGroups,
+  getGroupInfo,
+  getGroupMembers,
+  searchSpaceMembers,
+} from './octo/api.js';
+
+/** MCP server name; tools surface to the model as `mcp__octo__<tool>`. */
+export const OCTO_TOOL_SERVER_NAME = 'octo';
+
+/** Wrap a JSON-serializable value as an MCP text result. */
+function jsonResult(value: unknown): { content: Array<{ type: 'text'; text: string }> } {
+  return { content: [{ type: 'text', text: JSON.stringify(value, null, 2) }] };
+}
+
+/** Wrap an error as an MCP error text result (the model sees the reason, no throw). */
+function errResult(err: unknown): { content: Array<{ type: 'text'; text: string }>; isError: true } {
+  return {
+    content: [{ type: 'text', text: `Error: ${err instanceof Error ? err.message : String(err)}` }],
+    isError: true,
+  };
+}
+
+/**
+ * Build the read-only Octo tool DEFINITIONS for a resolved single-bot config.
+ * Exported separately from the server so tests can invoke each handler directly
+ * (the MCP server keeps its tools in private internals).
+ */
+export function buildOctoTools(config: Config) {
+  const apiUrl = config.apiUrl;
+  const botToken = config.botToken;
+
+  return [
+    tool(
+      'list_groups',
+      'List the Octo groups this bot belongs to (group number, name). Read-only.',
+      {},
+      async () => {
+        try {
+          const groups = await fetchBotGroups({ apiUrl, botToken });
+          return jsonResult(groups);
+        } catch (err) {
+          return errResult(err);
+        }
+      },
+    ),
+    tool(
+      'group_info',
+      'Get a single Octo group\'s info (name, notice, member count, etc.) by its group number. Read-only.',
+      { groupNo: z.string().min(1).describe('The group number (groupNo) to look up.') },
+      async (args) => {
+        try {
+          const info = await getGroupInfo({ apiUrl, botToken, groupNo: args.groupNo });
+          return jsonResult(info);
+        } catch (err) {
+          return errResult(err);
+        }
+      },
+    ),
+    tool(
+      'group_members',
+      'List the members (uid, name) of an Octo group by its group number. Read-only.',
+      { groupNo: z.string().min(1).describe('The group number (groupNo) whose members to list.') },
+      async (args) => {
+        try {
+          const members = await getGroupMembers({ apiUrl, botToken, groupNo: args.groupNo });
+          return jsonResult(members);
+        } catch (err) {
+          return errResult(err);
+        }
+      },
+    ),
+    tool(
+      'search_members',
+      'Search members in the bot\'s Space by a name keyword. Read-only.',
+      {
+        keyword: z.string().min(1).describe('Name keyword to search for.'),
+        limit: z.number().int().positive().max(50).optional().describe('Max results (default server-side).'),
+      },
+      async (args) => {
+        try {
+          const results = await searchSpaceMembers({
+            apiUrl,
+            botToken,
+            keyword: args.keyword,
+            ...(args.limit !== undefined ? { limit: args.limit } : {}),
+          });
+          return jsonResult(results);
+        } catch (err) {
+          return errResult(err);
+        }
+      },
+    ),
+  ];
+}
+
+/**
+ * Build the read-only Octo tool server for a resolved single-bot config.
+ * Returns an MCP server config to drop into the SDK `mcpServers` option.
+ */
+export function createOctoToolServer(config: Config) {
+  return createSdkMcpServer({
+    name: OCTO_TOOL_SERVER_NAME,
+    version: '1.0.0',
+    tools: buildOctoTools(config),
+  });
+}


### PR DESCRIPTION
Closes #87 (read-only phase). P2 of the openclaw-parity roadmap #91.

## Problem
cc registered **no custom agent tools** — `agent-bridge.ts` only forwarded the SDK's built-in tools, so the model could not perform any Octo-side operation (the biggest capability gap vs openclaw).

## This PR — read-only phase
An in-process MCP server (`createSdkMcpServer`) exposing four **read-only** lookups, backed by existing `octo/api.ts` REST:

| tool | API |
|---|---|
| `list_groups` | `fetchBotGroups` |
| `group_info(groupNo)` | `getGroupInfo` |
| `group_members(groupNo)` | `getGroupMembers` |
| `search_members(keyword, limit?)` | `searchSpaceMembers` |

Surface as `mcp__octo__<tool>`. **Gated behind `sdk.octoTools`** (default off; env `CC_OCTO_SDK_OCTO_TOOLS`). `agent-bridge` wires `mcpServers:{octo:…}` only when enabled — with the default `allowedTools:"*"` they auto-allow; an explicit whitelist must list them. Handlers return JSON text and surface API failures as an `isError` result (never throw into the stream).

Scope is deliberately read-only; mutation (create/update group, add/remove members, GROUP.md writes) + thread management are a later **permission-gated** phase (depends on #90).

## Verified
Live, with the flag on: asked "搜索成员 李", the bot called `search_members` and returned real names it could not have guessed — **李梦林 / 李志伟 / 李飞飞** (correctly tagging the bot 🤖). Also confirmed `list_groups` returns the true (empty) group list matching a direct API call.

`src/octo-tools.ts` exports `buildOctoTools` (definitions, for direct handler tests) + `createOctoToolServer` (MCP wrapper). **1002 tests** (+ octo-tools suite, agent-bridge mcpServers gating, config flag), lint (0 warnings), build, NUL clean.