### PR TITLE
ci: pass TRIAGE_WEBHOOK_URL to octo-issue-notify

### DIFF
--- a/.github/workflows/octo-issue-notify.yml
+++ b/.github/workflows/octo-issue-notify.yml
@@ -18,3 +18,4 @@ jobs:
       event_action: ${{ github.event.action }}
     secrets:
       OCTO_BOT_TOKEN: ${{ secrets.OCTO_BOT_TOKEN }}
+      TRIAGE_WEBHOOK_URL: ${{ secrets.TRIAGE_WEBHOOK_URL }}


### PR DESCRIPTION
Onboarding template only forwarded OCTO_BOT_TOKEN; the triage webhook mode never got its URL and was silently skipped. Forward TRIAGE_WEBHOOK_URL so the triage agent is invoked when the secret is set.