### PR TITLE
refactor(config)!: JSON-only config, remove all env-var overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,17 @@ While the major version is `0`, minor releases may carry breaking changes.
   Group / CommunityTopic as repliable; any other (system/command) channel type is
   dropped before the agent is invoked.
 
+### Changed
+
+- **Config is JSON-only — all environment-variable overrides removed** (#103).
+  The entire `CC_OCTO_*` env surface and the `ANTHROPIC_BASE_URL` env read are
+  gone; `applyEnv()` (and its `parseCsv`/`parseIntStrict` helpers) were deleted.
+  Configuration now comes solely from the two-layer config.json (global +
+  per-bot). `sdk.anthropicBaseUrl` remains a config.json field (still forwarded
+  to the SDK subprocess as `ANTHROPIC_BASE_URL`). **Migration:** move any
+  `CC_OCTO_*` / `ANTHROPIC_BASE_URL` values into `~/.cc-channel-octo/config.json`
+  (or the per-bot file). Old env vars are now silently ignored.
+
 ### Added
 
 - **Agent skills — generic external tooling** (#100) — external CLIs (octo-cli,

--- a/README.md
+++ b/README.md
@@ -100,48 +100,39 @@ npm start
 
 The bot is now online. Send it a DM or @mention it in a group.
 
-### Environment Variables
-
-Shared/global fields can be overridden via environment variables (highest priority):
-
-```bash
-CC_OCTO_API_URL=https://octo.example.com \
-npm start
-```
-
-> Per-bot tokens and the directory layout are NOT env-configurable — the token
-> lives in `<baseDir>/<id>/config.json` and all dirs derive from `baseDir`.
-
 ## Configuration
 
-Two layers: a **global** `~/.cc-channel-octo/config.json` (shared defaults + the
-`bots` list) and one **per-bot** `~/.cc-channel-octo/<id>/config.json` (its
-token + overrides). Per-bot fields win; env vars override the shared layer.
+All configuration comes from JSON files — there are **no environment-variable
+overrides**. Two layers: a **global** `~/.cc-channel-octo/config.json` (shared
+defaults + the `bots` list) and one **per-bot** `~/.cc-channel-octo/<id>/config.json`
+(its token + overrides). Per-bot fields win over the global layer; per-bot
+directories are derived from `baseDir` (see the tree above) and are not
+configurable.
 
-| Field | Env Var | Default | Description |
-|-------|---------|---------|-------------|
-| `botToken` | — | *(required, per-bot)* | Octo bot token (`bf_*`). Lives in `<baseDir>/<id>/config.json`, not the global file. |
-| `apiUrl` | `CC_OCTO_API_URL` | *(required)* | Octo API base URL (shared; a bot may override). |
-| `bots` | — | `[{id:"default"}]` | Which bots to run; each `id` selects its subtree + per-bot config. |
-| *(dirs)* | — | *(derived)* | `data`/`workspace`/`memory` are always `<baseDir>/<id>/…` — not configurable. |
-| `sdk.model` | `CC_OCTO_SDK_MODEL` | *(SDK default)* | Claude model override |
-| `sdk.allowedTools` | `CC_OCTO_SDK_ALLOWED_TOOLS` | `"*"` | Either `"*"` (allow every tool the SDK exposes) or an explicit string array whitelist. Env accepts a value containing `*` (wildcard) or a CSV list. |
-| `sdk.permissionMode` | `CC_OCTO_SDK_PERMISSION_MODE` | `bypassPermissions` | SDK permission mode |
-| `sdk.maxTurns` | `CC_OCTO_SDK_MAX_TURNS` | *(SDK default)* | Max agentic turns per query |
-| `sdk.systemPrompt` | `CC_OCTO_SDK_SYSTEM_PROMPT` | *(built-in)* | Custom system prompt |
-| `sdk.toolProgress` | `CC_OCTO_SDK_TOOL_PROGRESS` | `false` | When true, post `🔧 Running <tool>…` notices as the agent invokes tools (deduped, capped per turn) |
-| `sdk.persistentSession` | `CC_OCTO_SDK_PERSISTENT_SESSION` | `false` | When true, persist agent workspace state across messages via the SDK v2 Session API (resume by stored session id). `/reset` clears it. |
-| `sdk.settingSources` | `CC_OCTO_SDK_SETTING_SOURCES` | `['project']` | Filesystem settings sources the SDK loads. Default `['project']` so it discovers skills symlinked into the session sandbox's `.claude/skills/` (see [Agent skills](#agent-skills)). Memory stays isolated regardless (inline auto-memory dir pin). Add `'user'` only to deliberately load the operator's real `~/.claude`. |
-| `groupConfigDir` | `CC_OCTO_GROUP_CONFIG_DIR` | *(unset)* | Directory of per-group instruction files (`<groupId>.md`). A match is injected into the system prompt as trusted custom instructions for that group. See [Per-group instructions](#per-group-instructions). |
-| `sdk.anthropicBaseUrl` | `ANTHROPIC_BASE_URL` | *(unset)* | Override the upstream Claude API endpoint. See [Self-hosted gateway](#self-hosted-gateway) below. |
-| `rateLimit.maxPerMinute` | `CC_OCTO_RATE_LIMIT_MAX_PER_MINUTE` | `5` | Max requests per minute per session |
-| `context.maxContextChars` | `CC_OCTO_CONTEXT_MAX_CHARS` | `6000` | Max characters of group context injected into prompts |
-| `context.historyLimit` | `CC_OCTO_CONTEXT_HISTORY_LIMIT` | `40` | Max messages in session history window |
-| `botBlocklist` | `CC_OCTO_BOT_BLOCKLIST` | `[]` | Comma-separated bot UIDs to ignore in DMs (prevents bot loops) |
-| `mentionFreeGroups` | `CC_OCTO_MENTION_FREE_GROUPS` | `[]` | Comma-separated group channel IDs where the bot responds to every text message without requiring an `@bot` mention (G12). |
-| `transport` | `CC_OCTO_TRANSPORT` | `websocket` | Inbound transport: `websocket` (WuKongIM long connection) or `webhook` (HTTP endpoint). See [Webhook mode](#webhook-mode). |
-| `webhook.secret` | `CC_OCTO_WEBHOOK_SECRET` | *(unset)* | Shared secret required in webhook mode (header `x-webhook-secret` or `?secret=`). |
-| `webhook.host` / `.port` / `.path` | `CC_OCTO_WEBHOOK_HOST` / `_PORT` / `_PATH` | `127.0.0.1` / `8787` / `/octo/webhook` | Webhook server bind + route. |
+| Field | Default | Description |
+|-------|---------|-------------|
+| `botToken` | *(required, per-bot)* | Octo bot token (`bf_*`). Lives in `<baseDir>/<id>/config.json`, not the global file. |
+| `apiUrl` | *(required)* | Octo API base URL (shared; a bot may override). |
+| `bots` | `[{id:"default"}]` | Which bots to run; each `id` selects its subtree + per-bot config. |
+| *(dirs)* | *(derived)* | `data`/`workspace`/`memory`/`skills` are always `<baseDir>/<id>/…` — not configurable. |
+| `sdk.model` | *(SDK default)* | Claude model override |
+| `sdk.allowedTools` | `"*"` | Either `"*"` (allow every tool the SDK exposes) or an explicit string array whitelist. |
+| `sdk.permissionMode` | `bypassPermissions` | SDK permission mode |
+| `sdk.maxTurns` | *(SDK default)* | Max agentic turns per query |
+| `sdk.systemPrompt` | *(built-in)* | Custom system prompt (a `<baseDir>/<id>/SOUL.md` overrides this). |
+| `sdk.toolProgress` | `false` | When true, post `🔧 Running <tool>…` notices as the agent invokes tools (deduped, capped per turn) |
+| `sdk.persistentSession` | `false` | When true, persist agent workspace state across messages via the SDK v2 Session API (resume by stored session id). `/reset` clears it. |
+| `sdk.settingSources` | `['project']` | Filesystem settings sources the SDK loads. Default `['project']` so it discovers skills symlinked into the session sandbox's `.claude/skills/` (see [Agent skills](#agent-skills)). Memory stays isolated regardless (inline auto-memory dir pin). Add `'user'` only to deliberately load the operator's real `~/.claude`. |
+| `groupConfigDir` | *(unset)* | Directory of per-group instruction files (`<groupId>.md`). A match is injected into the system prompt as trusted custom instructions for that group. See [Per-group instructions](#per-group-instructions). |
+| `sdk.anthropicBaseUrl` | *(unset)* | Override the upstream Claude API endpoint. See [Self-hosted gateway](#self-hosted-gateway) below. |
+| `rateLimit.maxPerMinute` | `5` | Max requests per minute per session |
+| `context.maxContextChars` | `6000` | Max characters of group context injected into prompts |
+| `context.historyLimit` | `40` | Max messages in session history window |
+| `botBlocklist` | `[]` | Bot UIDs to ignore in DMs (prevents bot loops) |
+| `mentionFreeGroups` | `[]` | Group channel IDs where the bot responds to every text message without requiring an `@bot` mention (G12). |
+| `transport` | `websocket` | Inbound transport: `websocket` (WuKongIM long connection) or `webhook` (HTTP endpoint). See [Webhook mode](#webhook-mode). |
+| `webhook.secret` | *(unset)* | Shared secret required in webhook mode (header `x-webhook-secret` or `?secret=`). |
+| `webhook.host` / `.port` / `.path` | `127.0.0.1` / `8787` / `/octo/webhook` | Webhook server bind + route. |
 
 ### Self-hosted gateway
 
@@ -165,13 +156,6 @@ resolve to a private/link-local address. An unsafe value fails fast at startup.
 }
 ```
 
-Or via environment (highest priority, no `CC_OCTO_` prefix — uses the Anthropic
-SDK standard variable name):
-
-```bash
-ANTHROPIC_BASE_URL=https://claude-gw.internal.example.com npm start
-```
-
 Leave the field unset to talk to Anthropic's public endpoint directly.
 
 ### Per-group instructions
@@ -183,10 +167,11 @@ that group's system prompt as a trusted, **unsanitized** `[Group instructions]`
 block. Only groups use this; DMs key on the peer uid. The key is the channel id,
 so all topics under one `CommunityTopic` channel id share the same file.
 
-```bash
-CC_OCTO_GROUP_CONFIG_DIR=/home/deploy/cc-octo-groups npm start
-# /home/deploy/cc-octo-groups/s12_345.md:
-#   Always answer in formal English and cite sources.
+```jsonc
+// ~/.cc-channel-octo/config.json
+{ "groupConfigDir": "/home/deploy/cc-octo-groups" }
+// /home/deploy/cc-octo-groups/s12_345.md:
+//   Always answer in formal English and cite sources.
 ```
 
 > ⚠️ **Security — this is a trusted, unsanitized prompt-injection sink.** Its
@@ -282,12 +267,13 @@ instead receive inbound messages over HTTP — useful behind a reverse proxy or
 where outbound long connections aren't possible. The bot still registers over
 REST (for its id and for sending replies); only the inbound path changes.
 
-```bash
-CC_OCTO_TRANSPORT=webhook \
-CC_OCTO_WEBHOOK_SECRET=$(openssl rand -hex 32) \
-CC_OCTO_WEBHOOK_PORT=8787 \
-npm start
-# → POST http://127.0.0.1:8787/octo/webhook
+```jsonc
+// ~/.cc-channel-octo/config.json (or a per-bot config.json)
+{
+  "transport": "webhook",
+  "webhook": { "secret": "<openssl rand -hex 32>", "port": 8787 }
+}
+// → POST http://127.0.0.1:8787/octo/webhook
 ```
 
 Every request must present the shared secret (header `x-webhook-secret` or

--- a/config.example.json
+++ b/config.example.json
@@ -7,17 +7,17 @@
     { "id": "default" }
   ],
 
-  "_comment_group_config_dir": "v1.0: optional directory of per-group instruction files (<groupId>.md), injected as trusted custom instructions. Operator-controlled — keep it OUTSIDE every bot's workspace (the agent can write there) AND non-writable by the gateway user. Env override: CC_OCTO_GROUP_CONFIG_DIR. Omit to disable.",
+  "_comment_group_config_dir": "v1.0: optional directory of per-group instruction files (<groupId>.md), injected as trusted custom instructions. Operator-controlled — keep it OUTSIDE every bot's workspace (the agent can write there) AND non-writable by the gateway user. Omit to disable.",
 
   "sdk": {
-    "_comment_anthropic_base_url": "Q1: Optional self-hosted Claude API gateway base URL. Forwarded to the SDK subprocess (scoped). Must be https:// (or http://localhost for dev) — SSRF-validated at boot. Or set ANTHROPIC_BASE_URL env (highest priority).",
-    "_comment_allowed_tools": "Q2: either '*' (allow every tool the SDK exposes) or an explicit string[] whitelist. Env override CC_OCTO_SDK_ALLOWED_TOOLS accepts the same two shapes.",
+    "_comment_anthropic_base_url": "Q1: Optional self-hosted Claude API gateway base URL. Forwarded to the SDK subprocess (scoped). Must be https:// (or http://localhost for dev) — SSRF-validated at boot. Omit to use Anthropic's public endpoint.",
+    "_comment_allowed_tools": "Q2: either '*' (allow every tool the SDK exposes) or an explicit string[] whitelist.",
     "allowedTools": "*",
     "permissionMode": "bypassPermissions",
-    "_comment_tool_progress": "v0.3: set toolProgress=true to post '🔧 Running <tool>…' notices. Env: CC_OCTO_SDK_TOOL_PROGRESS=true. Off by default.",
-    "_comment_persistent_session": "v0.3: set persistentSession=true to keep agent workspace state across messages via the SDK v2 Session API. Env: CC_OCTO_SDK_PERSISTENT_SESSION=true. Off by default.",
-    "_comment_setting_sources": "v1.1: which host filesystem settings the SDK loads (user=~/.claude, project=.claude, local=.claude/*.local). Default [] (SDK isolation) so the bot NEVER reads/writes the operator's real ~/.claude — the agent could otherwise write 'remembered' facts into your global CLAUDE.md instead of its scoped auto-memory dir. Set [\"user\"] only as an explicit opt-in.",
-    "settingSources": []
+    "_comment_tool_progress": "v0.3: set toolProgress=true to post '🔧 Running <tool>…' notices. Off by default.",
+    "_comment_persistent_session": "v0.3: set persistentSession=true to keep agent workspace state across messages via the SDK v2 Session API. Off by default.",
+    "_comment_setting_sources": "#100: which host filesystem settings the SDK loads (user=~/.claude, project=.claude, local=.claude/*.local). Default [\"project\"] so the SDK discovers skills symlinked into each session sandbox's .claude/skills/. Memory stays isolated regardless (the auto-memory dir is pinned via inline settings, ranked above projectSettings). Add \"user\" only to deliberately load the operator's real ~/.claude.",
+    "settingSources": ["project"]
   },
 
   "rateLimit": {
@@ -29,6 +29,6 @@
     "historyLimit": 40
   },
 
-  "_comment_mention_free": "G12: group_ids listed here process every text message without requiring an @bot mention. Env override: CC_OCTO_MENTION_FREE_GROUPS (csv).",
+  "_comment_mention_free": "G12: group_ids listed here process every text message without requiring an @bot mention.",
   "mentionFreeGroups": []
 }

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -2,12 +2,10 @@
  * Config tests.
  *
  * Coverage:
- *  - loadConfig three-level priority (env > file > defaults)
- *  - parseCsv / parseIntStrict boundary cases
+ *  - loadConfig file-over-defaults priority
  *  - Required field validation (botToken / apiUrl)
  *  - Invalid JSON error message includes file path
  *  - _-prefix key filtering
- *  - Full CC_OCTO_* env override coverage
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
@@ -108,9 +106,9 @@ describe('loadConfig defaults', () => {
   });
 });
 
-// ─── 2. Three-Level Priority ────────────────────────────────────────────────
+// ─── 2. Config File over Defaults ───────────────────────────────────────────
 
-describe('three-level priority: env > file > defaults', () => {
+describe('config-file over defaults', () => {
   beforeEach(setup);
   afterEach(teardown);
 
@@ -123,26 +121,6 @@ describe('three-level priority: env > file > defaults', () => {
     const cfg = loadConfig(path);
     expect(cfg.apiUrl).toBe('https://file.test');
     expect(cfg.rateLimit.maxPerMinute).toBe(10);
-  });
-
-  it('env overrides file', () => {
-    const path = writeConfig({
-      botToken: 'bf_file',
-      apiUrl: 'https://file.test',
-    });
-    process.env.CC_OCTO_API_URL = 'https://env.override';
-    const cfg = loadConfig(path);
-    expect(cfg.apiUrl).toBe('https://env.override');
-  });
-
-  it('env overrides defaults when no config file', () => {
-    process.env.CC_OCTO_BOT_TOKEN = 'bf_env';
-    process.env.CC_OCTO_API_URL = 'https://env.test';
-    const cfg = loadConfig(join(tmpDir, 'nonexistent.json'));
-    expect(cfg.botToken).toBe('bf_env');
-    expect(cfg.apiUrl).toBe('https://env.test');
-    // baseDir derives from the (nonexistent) config path's directory.
-    expect(cfg.baseDir).toBe(tmpDir);
   });
 });
 
@@ -183,28 +161,6 @@ describe('required field validation', () => {
   });
 });
 
-// ─── Removed dir env vars fail loudly (migration safety) ────────────────
-
-describe('removed directory env vars', () => {
-  beforeEach(setup);
-  afterEach(teardown);
-
-  it.each(['CC_OCTO_CWDBASE', 'CC_OCTO_CWD', 'CC_OCTO_DATA_DIR', 'CC_OCTO_MEMORY_BASE'])(
-    'throws a migration error when %s is set (no silent mislocation)',
-    (envVar) => {
-      const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
-      process.env[envVar] = '/some/path';
-      expect(() => loadConfig(path)).toThrow(/Removed config env var/);
-    },
-  );
-
-  it('a blank removed env var is treated as unset (no throw)', () => {
-    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
-    process.env.CC_OCTO_DATA_DIR = '';
-    expect(() => loadConfig(path)).not.toThrow();
-  });
-});
-
 // ─── 4. Invalid JSON ───────────────────────────────────────────────────────
 
 describe('invalid config file', () => {
@@ -238,182 +194,16 @@ describe('_-prefix key filtering', () => {
   });
 });
 
-// ─── 6. Env Override Full Coverage ──────────────────────────────────────────
-
-describe('CC_OCTO_* env override coverage', () => {
-  beforeEach(setup);
-  afterEach(teardown);
-
-  it('CC_OCTO_BOT_TOKEN + CC_OCTO_API_URL', () => {
-    process.env.CC_OCTO_BOT_TOKEN = 'bf_env_tok';
-    process.env.CC_OCTO_API_URL = 'https://env-api';
-    const cfg = loadConfig(join(tmpDir, 'nope.json'));
-    expect(cfg.botToken).toBe('bf_env_tok');
-    expect(cfg.apiUrl).toBe('https://env-api');
-  });
-
-  it('CC_OCTO_SDK_MODEL', () => {
-    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
-    process.env.CC_OCTO_SDK_MODEL = 'claude-opus-4-0-20250514';
-    expect(loadConfig(path).sdk.model).toBe('claude-opus-4-0-20250514');
-  });
-
-  it('CC_OCTO_SDK_ALLOWED_TOOLS (csv)', () => {
-    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
-    process.env.CC_OCTO_SDK_ALLOWED_TOOLS = 'Read, Grep, Glob';
-    expect(loadConfig(path).sdk.allowedTools).toEqual(['Read', 'Grep', 'Glob']);
-  });
-
-  it('CC_OCTO_SDK_PERMISSION_MODE', () => {
-    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
-    process.env.CC_OCTO_SDK_PERMISSION_MODE = 'acceptEdits';
-    expect(loadConfig(path).sdk.permissionMode).toBe('acceptEdits');
-  });
-
-  it('CC_OCTO_SDK_MAX_TURNS', () => {
-    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
-    process.env.CC_OCTO_SDK_MAX_TURNS = '10';
-    expect(loadConfig(path).sdk.maxTurns).toBe(10);
-  });
-
-  it('CC_OCTO_SDK_SYSTEM_PROMPT', () => {
-    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
-    process.env.CC_OCTO_SDK_SYSTEM_PROMPT = 'You are a helpful bot';
-    expect(loadConfig(path).sdk.systemPrompt).toBe('You are a helpful bot');
-  });
-
-  it('CC_OCTO_SDK_SETTING_SOURCES (csv)', () => {
-    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
-    process.env.CC_OCTO_SDK_SETTING_SOURCES = 'user, project';
-    expect(loadConfig(path).sdk.settingSources).toEqual(['user', 'project']);
-  });
-
-  it('CC_OCTO_RATE_LIMIT_MAX_PER_MINUTE', () => {
-    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
-    process.env.CC_OCTO_RATE_LIMIT_MAX_PER_MINUTE = '20';
-    expect(loadConfig(path).rateLimit.maxPerMinute).toBe(20);
-  });
-
-  it('CC_OCTO_CONTEXT_MAX_CHARS', () => {
-    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
-    process.env.CC_OCTO_CONTEXT_MAX_CHARS = '3000';
-    expect(loadConfig(path).context.maxContextChars).toBe(3000);
-  });
-
-  it('CC_OCTO_CONTEXT_HISTORY_LIMIT', () => {
-    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
-    process.env.CC_OCTO_CONTEXT_HISTORY_LIMIT = '20';
-    expect(loadConfig(path).context.historyLimit).toBe(20);
-  });
-
-  it('CC_OCTO_BOT_BLOCKLIST (csv)', () => {
-    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
-    process.env.CC_OCTO_BOT_BLOCKLIST = 'bot-a, bot-b, bot-c';
-    expect(loadConfig(path).botBlocklist).toEqual(['bot-a', 'bot-b', 'bot-c']);
-  });
-
-  it('CC_OCTO_MENTION_FREE_GROUPS (csv) overrides config (G12)', () => {
-    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
-    process.env.CC_OCTO_MENTION_FREE_GROUPS = 'group-1, group-2,group-3';
-    expect(loadConfig(path).mentionFreeGroups).toEqual(['group-1', 'group-2', 'group-3']);
-  });
-});
-
-// ─── 7. parseIntStrict Boundary Cases ───────────────────────────────────────
-
-describe('parseIntStrict via env', () => {
-  beforeEach(setup);
-  afterEach(teardown);
-
-  it('rejects hex string (0xff)', () => {
-    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
-    process.env.CC_OCTO_SDK_MAX_TURNS = '0xff';
-    expect(() => loadConfig(path)).toThrow(/Invalid integer/);
-  });
-
-  it('rejects negative number', () => {
-    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
-    process.env.CC_OCTO_SDK_MAX_TURNS = '-5';
-    expect(() => loadConfig(path)).toThrow(/Invalid integer/);
-  });
-
-  it('accepts zero for maxTurns', () => {
-    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
-    process.env.CC_OCTO_SDK_MAX_TURNS = '0';
-    expect(loadConfig(path).sdk.maxTurns).toBe(0);
-  });
-
-  it('rejects scientific notation', () => {
-    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
-    process.env.CC_OCTO_SDK_MAX_TURNS = '1e3';
-    expect(() => loadConfig(path)).toThrow(/Invalid integer/);
-  });
-
-  it('rejects float', () => {
-    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
-    process.env.CC_OCTO_SDK_MAX_TURNS = '3.14';
-    expect(() => loadConfig(path)).toThrow(/Invalid integer/);
-  });
-
-  it('rejects empty string (env var set but empty)', () => {
-    // Empty string env vars are falsy, so CC_OCTO_SDK_MAX_TURNS="" won't trigger parseIntStrict.
-    // But let's verify the behavior: empty string should not override.
-    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
-    process.env.CC_OCTO_SDK_MAX_TURNS = '';
-    const cfg = loadConfig(path);
-    expect(cfg.sdk.maxTurns).toBeUndefined(); // empty string = falsy = no override
-  });
-
-  it('rejects non-numeric string', () => {
-    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
-    process.env.CC_OCTO_SDK_MAX_TURNS = 'abc';
-    expect(() => loadConfig(path)).toThrow(/Invalid integer/);
-  });
-
-  it('accepts valid positive integer', () => {
-    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
-    process.env.CC_OCTO_SDK_MAX_TURNS = '42';
-    expect(loadConfig(path).sdk.maxTurns).toBe(42);
-  });
-});
-
-// ─── 8. parseCsv Edge Cases ─────────────────────────────────────────────────
-
-describe('parseCsv via env', () => {
-  beforeEach(setup);
-  afterEach(teardown);
-
-  it('trims whitespace around items', () => {
-    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
-    process.env.CC_OCTO_SDK_ALLOWED_TOOLS = '  Read ,  Grep  , Glob  ';
-    expect(loadConfig(path).sdk.allowedTools).toEqual(['Read', 'Grep', 'Glob']);
-  });
-
-  it('filters empty segments from trailing commas', () => {
-    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
-    process.env.CC_OCTO_SDK_ALLOWED_TOOLS = 'Read,,Grep,,,';
-    expect(loadConfig(path).sdk.allowedTools).toEqual(['Read', 'Grep']);
-  });
-
-  it('single item without commas', () => {
-    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
-    process.env.CC_OCTO_SDK_ALLOWED_TOOLS = 'Read';
-    expect(loadConfig(path).sdk.allowedTools).toEqual(['Read']);
-  });
-});
-
-// ─── 9. Config File Missing ─────────────────────────────────────────────────
+// ─── 6. Config File Missing ─────────────────────────────────────────────────
 
 describe('missing config file', () => {
   beforeEach(setup);
   afterEach(teardown);
 
-  it('falls back to defaults + env when config file does not exist', () => {
-    process.env.CC_OCTO_BOT_TOKEN = 'bf_env';
-    process.env.CC_OCTO_API_URL = 'https://env-api';
-    const cfg = loadConfig(join(tmpDir, 'missing.json'));
-    expect(cfg.botToken).toBe('bf_env');
-    expect(cfg.sdk.permissionMode).toBe('bypassPermissions'); // default
+  it('throws on a missing config file (apiUrl has no source)', () => {
+    // With no env override path, a missing config.json leaves apiUrl unset,
+    // which is a required field — loadConfig must fail loudly.
+    expect(() => loadConfig(join(tmpDir, 'missing.json'))).toThrow(/apiUrl/);
   });
 });
 
@@ -474,23 +264,6 @@ describe('Q1: anthropicBaseUrl', () => {
     expect(loadConfig(path).sdk.anthropicBaseUrl).toBe('https://gw.example.com');
   });
 
-  it('ANTHROPIC_BASE_URL env overrides config file', () => {
-    const path = writeConfig({
-      botToken: 'bf_t',
-      apiUrl: 'https://a',
-      sdk: { anthropicBaseUrl: 'https://from-file' },
-    });
-    process.env.ANTHROPIC_BASE_URL = 'https://from-env';
-    expect(loadConfig(path).sdk.anthropicBaseUrl).toBe('https://from-env');
-  });
-
-  it('uses Anthropic SDK standard variable name (no CC_OCTO_ prefix)', () => {
-    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
-    // A CC_OCTO_ANTHROPIC_BASE_URL would NOT take effect — only the bare var.
-    process.env.ANTHROPIC_BASE_URL = 'https://standard';
-    expect(loadConfig(path).sdk.anthropicBaseUrl).toBe('https://standard');
-  });
-
   it('rejects an http:// (non-localhost) anthropicBaseUrl (SSRF protection)', () => {
     const path = writeConfig({
       botToken: 'bf_t',
@@ -541,42 +314,6 @@ describe('Q2: allowedTools wildcard', () => {
       sdk: { allowedTools: ['Read', 'Glob', 'Grep'] },
     });
     expect(loadConfig(path).sdk.allowedTools).toEqual(['Read', 'Glob', 'Grep']);
-  });
-
-  it('CC_OCTO_SDK_ALLOWED_TOOLS="*" maps to the wildcard sentinel', () => {
-    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
-    process.env.CC_OCTO_SDK_ALLOWED_TOOLS = '*';
-    expect(loadConfig(path).sdk.allowedTools).toBe('*');
-  });
-
-  it('CC_OCTO_SDK_ALLOWED_TOOLS=" * " (whitespace) still maps to wildcard', () => {
-    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
-    process.env.CC_OCTO_SDK_ALLOWED_TOOLS = ' * ';
-    expect(loadConfig(path).sdk.allowedTools).toBe('*');
-  });
-
-  it('CC_OCTO_SDK_ALLOWED_TOOLS with a "*" element anywhere maps to wildcard', () => {
-    // Regression: a CSV containing `*` must collapse to the wildcard sentinel
-    // rather than passing a literal `*` through as a (bogus) tool name.
-    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
-    process.env.CC_OCTO_SDK_ALLOWED_TOOLS = '*,Read';
-    expect(loadConfig(path).sdk.allowedTools).toBe('*');
-  });
-
-  it('CC_OCTO_SDK_ALLOWED_TOOLS without "*" stays a CSV array', () => {
-    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
-    process.env.CC_OCTO_SDK_ALLOWED_TOOLS = 'Read, Glob ,Grep';
-    expect(loadConfig(path).sdk.allowedTools).toEqual(['Read', 'Glob', 'Grep']);
-  });
-
-  it('env "*" overrides a config-file array', () => {
-    const path = writeConfig({
-      botToken: 'bf_t',
-      apiUrl: 'https://a',
-      sdk: { allowedTools: ['Read'] },
-    });
-    process.env.CC_OCTO_SDK_ALLOWED_TOOLS = '*';
-    expect(loadConfig(path).sdk.allowedTools).toBe('*');
   });
 });
 
@@ -644,28 +381,6 @@ describe('v0.3: tool progress toggle', () => {
     });
     expect(loadConfig(path).sdk.toolProgress).toBe(true);
   });
-
-  it.each(['true', '1', 'yes', 'on', 'TRUE', 'On'])(
-    'CC_OCTO_SDK_TOOL_PROGRESS=%s enables it',
-    (val) => {
-      const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
-      process.env.CC_OCTO_SDK_TOOL_PROGRESS = val;
-      expect(loadConfig(path).sdk.toolProgress).toBe(true);
-    },
-  );
-
-  it.each(['false', '0', 'no', 'off', ''])(
-    'CC_OCTO_SDK_TOOL_PROGRESS=%s disables it',
-    (val) => {
-      const path = writeConfig({
-        botToken: 'bf_t',
-        apiUrl: 'https://a',
-        sdk: { toolProgress: true },
-      });
-      process.env.CC_OCTO_SDK_TOOL_PROGRESS = val;
-      expect(loadConfig(path).sdk.toolProgress).toBe(false);
-    },
-  );
 });
 
 // ─── #100: derived skill dirs ──────────────────────────────────────────
@@ -847,20 +562,6 @@ describe('v0.3: persistent session toggle', () => {
     });
     expect(loadConfig(path).sdk.persistentSession).toBe(true);
   });
-
-  it.each(['true', '1', 'yes', 'on'])('CC_OCTO_SDK_PERSISTENT_SESSION=%s enables it', (val) => {
-    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
-    process.env.CC_OCTO_SDK_PERSISTENT_SESSION = val;
-    expect(loadConfig(path).sdk.persistentSession).toBe(true);
-  });
-
-  it.each(['false', '0', 'off', ''])('CC_OCTO_SDK_PERSISTENT_SESSION=%s disables it', (val) => {
-    const path = writeConfig({
-      botToken: 'bf_t', apiUrl: 'https://a', sdk: { persistentSession: true },
-    });
-    process.env.CC_OCTO_SDK_PERSISTENT_SESSION = val;
-    expect(loadConfig(path).sdk.persistentSession).toBe(false);
-  });
 });
 
 // ─── v1.0: groupConfigDir trust-boundary validation ────────────────────
@@ -900,12 +601,6 @@ describe('v1.0: groupConfigDir must be outside cwdBase', () => {
       groupConfigDir: `${tmpDir}/default/workspace/x/../groups`,
     }));
     expect(() => resolveBotConfigs(cfg)).toThrow(/Unsafe groupConfigDir/);
-  });
-
-  it('rejects nested groupConfigDir set via env (CC_OCTO_GROUP_CONFIG_DIR)', () => {
-    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
-    process.env.CC_OCTO_GROUP_CONFIG_DIR = `${tmpDir}/default/workspace/groups`;
-    expect(() => resolveBotConfigs(loadConfig(path))).toThrow(/Unsafe groupConfigDir/);
   });
 
   it('does not reject a sibling dir that shares a name prefix with the workspace', () => {
@@ -952,31 +647,6 @@ describe('v1.0: webhook transport', () => {
       botToken: 'bf_t', apiUrl: 'https://a', transport: 'websocket',
     }));
     expect(() => resolveBotConfigs(cfg)).not.toThrow();
-  });
-
-  it('env overrides: CC_OCTO_TRANSPORT + CC_OCTO_WEBHOOK_*', () => {
-    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
-    process.env.CC_OCTO_TRANSPORT = 'webhook';
-    process.env.CC_OCTO_WEBHOOK_PORT = '7000';
-    process.env.CC_OCTO_WEBHOOK_SECRET = 'envsecret';
-    const cfg = loadConfig(path);
-    expect(cfg.transport).toBe('webhook');
-    expect(cfg.webhook?.port).toBe(7000);
-    expect(cfg.webhook?.secret).toBe('envsecret');
-  });
-
-  it('env secret satisfies the webhook validation', () => {
-    const path = writeConfig({
-      botToken: 'bf_t', apiUrl: 'https://a', transport: 'webhook',
-    });
-    process.env.CC_OCTO_WEBHOOK_SECRET = 'envsecret';
-    expect(() => loadConfig(path)).not.toThrow();
-  });
-
-  it('ignores an invalid CC_OCTO_TRANSPORT value', () => {
-    const path = writeConfig({ botToken: 'bf_t', apiUrl: 'https://a' });
-    process.env.CC_OCTO_TRANSPORT = 'carrier-pigeon';
-    expect(loadConfig(path).transport).toBeUndefined();
   });
 });
 

--- a/src/__tests__/p2-polish.test.ts
+++ b/src/__tests__/p2-polish.test.ts
@@ -172,23 +172,16 @@ describe('Q36: heartbeat restart after token refresh', () => {
 describe('Q32: maxResponseChars config', () => {
   it('defaults to 524288 (512KB)', async () => {
     const { loadConfig } = await import('../config.js');
-    process.env.CC_OCTO_BOT_TOKEN = 'test';
-    process.env.CC_OCTO_API_URL = 'https://test';
-    const cfg = loadConfig('/nonexistent/config.json');
-    expect(cfg.maxResponseChars).toBe(524_288);
-    delete process.env.CC_OCTO_BOT_TOKEN;
-    delete process.env.CC_OCTO_API_URL;
-  });
+    const { writeFileSync, mkdtempSync } = await import('node:fs');
+    const { join } = await import('node:path');
+    const { tmpdir } = await import('node:os');
 
-  it('can be overridden via CC_OCTO_MAX_RESPONSE_CHARS env', async () => {
-    const { loadConfig } = await import('../config.js');
-    process.env.CC_OCTO_BOT_TOKEN = 'test';
-    process.env.CC_OCTO_API_URL = 'https://test';
-    process.env.CC_OCTO_MAX_RESPONSE_CHARS = '1000';
-    const cfg = loadConfig('/nonexistent/config.json');
-    expect(cfg.maxResponseChars).toBe(1000);
-    delete process.env.CC_OCTO_BOT_TOKEN;
-    delete process.env.CC_OCTO_API_URL;
-    delete process.env.CC_OCTO_MAX_RESPONSE_CHARS;
+    const dir = mkdtempSync(join(tmpdir(), 'p2-q32-'));
+    const cfgPath = join(dir, 'config.json');
+    // No maxResponseChars in the file → falls back to the default.
+    writeFileSync(cfgPath, JSON.stringify({ botToken: 'test', apiUrl: 'https://test' }));
+
+    const cfg = loadConfig(cfgPath);
+    expect(cfg.maxResponseChars).toBe(524_288);
   });
 });

--- a/src/__tests__/q13-q14-q17.test.ts
+++ b/src/__tests__/q13-q14-q17.test.ts
@@ -63,12 +63,10 @@ describe("SessionRouter global rate limit (Q13)", () => {
   });
 });
 
-// ─── Q14: parseIntStrict allows 0 ──────────────────────────────────────────
+// ─── Q14: 0 is a valid maxTurns / historyLimit ─────────────────────────────
 
 describe("parseIntStrict allows 0 (Q14)", () => {
-  it("accepts 0 for maxTurns", async () => {
-    // This is tested via config.test.ts 'accepts zero for maxTurns' test.
-    // Additional verification here: loadConfig with env var set to 0.
+  it("accepts 0 for maxTurns from the config file", async () => {
     const { loadConfig } = await import("../config.js");
     const { writeFileSync, mkdtempSync } = await import("node:fs");
     const { join } = await import("node:path");
@@ -76,18 +74,13 @@ describe("parseIntStrict allows 0 (Q14)", () => {
 
     const dir = mkdtempSync(join(tmpdir(), "q14-"));
     const cfgPath = join(dir, "config.json");
-    writeFileSync(cfgPath, JSON.stringify({ botToken: "bf_t", apiUrl: "https://a", cwdBase: "/test/cwdbase" }));
+    writeFileSync(cfgPath, JSON.stringify({ botToken: "bf_t", apiUrl: "https://a", sdk: { maxTurns: 0 } }));
 
-    process.env.CC_OCTO_SDK_MAX_TURNS = "0";
-    try {
-      const cfg = loadConfig(cfgPath);
-      expect(cfg.sdk.maxTurns).toBe(0);
-    } finally {
-      delete process.env.CC_OCTO_SDK_MAX_TURNS;
-    }
+    const cfg = loadConfig(cfgPath);
+    expect(cfg.sdk.maxTurns).toBe(0);
   });
 
-  it("accepts 0 for historyLimit", async () => {
+  it("accepts 0 for historyLimit from the config file", async () => {
     const { loadConfig } = await import("../config.js");
     const { writeFileSync, mkdtempSync } = await import("node:fs");
     const { join } = await import("node:path");
@@ -95,40 +88,10 @@ describe("parseIntStrict allows 0 (Q14)", () => {
 
     const dir = mkdtempSync(join(tmpdir(), "q14-"));
     const cfgPath = join(dir, "config.json");
-    writeFileSync(cfgPath, JSON.stringify({ botToken: "bf_t", apiUrl: "https://a", cwdBase: "/test/cwdbase" }));
+    writeFileSync(cfgPath, JSON.stringify({ botToken: "bf_t", apiUrl: "https://a", context: { historyLimit: 0 } }));
 
-    process.env.CC_OCTO_CONTEXT_HISTORY_LIMIT = "0";
-    try {
-      const cfg = loadConfig(cfgPath);
-      expect(cfg.context.historyLimit).toBe(0);
-    } finally {
-      delete process.env.CC_OCTO_CONTEXT_HISTORY_LIMIT;
-    }
-  });
-
-  it("still rejects negative and non-numeric", async () => {
-    const { loadConfig } = await import("../config.js");
-    const { writeFileSync, mkdtempSync } = await import("node:fs");
-    const { join } = await import("node:path");
-    const { tmpdir } = await import("node:os");
-
-    const dir = mkdtempSync(join(tmpdir(), "q14-"));
-    const cfgPath = join(dir, "config.json");
-    writeFileSync(cfgPath, JSON.stringify({ botToken: "bf_t", apiUrl: "https://a", cwdBase: "/test/cwdbase" }));
-
-    process.env.CC_OCTO_SDK_MAX_TURNS = "-1";
-    try {
-      expect(() => loadConfig(cfgPath)).toThrow(/Invalid integer/);
-    } finally {
-      delete process.env.CC_OCTO_SDK_MAX_TURNS;
-    }
-
-    process.env.CC_OCTO_SDK_MAX_TURNS = "abc";
-    try {
-      expect(() => loadConfig(cfgPath)).toThrow(/Invalid integer/);
-    } finally {
-      delete process.env.CC_OCTO_SDK_MAX_TURNS;
-    }
+    const cfg = loadConfig(cfgPath);
+    expect(cfg.context.historyLimit).toBe(0);
   });
 });
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -372,148 +372,6 @@ function mergeConfig(base: Config, override: PartialConfig): Config {
   };
 }
 
-function parseCsv(value: string): string[] {
-  return value
-    .split(',')
-    .map((s) => s.trim())
-    .filter((s) => s.length > 0);
-}
-
-function parseIntStrict(value: string, name: string, minValue = 1): number {
-  if (!/^\d+$/.test(value)) {
-    throw new Error(`Invalid integer for ${name}: ${value}`);
-  }
-  const n = Number(value);
-  if (!Number.isFinite(n) || n < minValue) {
-    throw new Error(`Invalid integer for ${name}: ${value} (must be >= ${minValue})`);
-  }
-  return n;
-}
-
-function applyEnv(cfg: Config): Config {
-  const env = process.env;
-  const next: Config = {
-    ...cfg,
-    sdk: { ...cfg.sdk },
-    rateLimit: { ...cfg.rateLimit },
-    context: { ...cfg.context },
-  };
-
-  // Fail loudly on REMOVED directory env vars instead of silently ignoring them.
-  // Dirs are now derived from baseDir (<baseDir>/<id>/{data,workspace,memory}),
-  // so a deploy that still sets e.g. CC_OCTO_DATA_DIR=/mnt/vol would otherwise
-  // write under ~/.cc-channel-octo and quietly miss its mounted volume.
-  const removedDirEnv = ['CC_OCTO_CWDBASE', 'CC_OCTO_CWD', 'CC_OCTO_DATA_DIR', 'CC_OCTO_MEMORY_BASE']
-    .filter((k) => env[k] !== undefined && env[k] !== '');
-  if (removedDirEnv.length > 0) {
-    throw new Error(
-      `Removed config env var(s): ${removedDirEnv.join(', ')}. Per-bot directories ` +
-      `are no longer configurable — they are derived as <baseDir>/<botId>/{data,` +
-      `workspace,memory}, where baseDir is the directory of ~/.cc-channel-octo/config.json. ` +
-      `Move data by relocating ~/.cc-channel-octo (e.g. a symlink to your volume) and ` +
-      `unset these variables.`,
-    );
-  }
-
-  if (env.CC_OCTO_BOT_TOKEN) next.botToken = env.CC_OCTO_BOT_TOKEN;
-  if (env.CC_OCTO_API_URL) next.apiUrl = env.CC_OCTO_API_URL;
-  if (env.CC_OCTO_GROUP_CONFIG_DIR) next.groupConfigDir = env.CC_OCTO_GROUP_CONFIG_DIR;
-  // v1.0 webhook transport env overrides.
-  if (env.CC_OCTO_TRANSPORT) {
-    const t = env.CC_OCTO_TRANSPORT.trim().toLowerCase();
-    if (t === 'websocket' || t === 'webhook') next.transport = t;
-  }
-  if (
-    env.CC_OCTO_WEBHOOK_HOST || env.CC_OCTO_WEBHOOK_PORT ||
-    env.CC_OCTO_WEBHOOK_PATH || env.CC_OCTO_WEBHOOK_SECRET
-  ) {
-    next.webhook = { ...next.webhook };
-    if (env.CC_OCTO_WEBHOOK_HOST) next.webhook.host = env.CC_OCTO_WEBHOOK_HOST;
-    if (env.CC_OCTO_WEBHOOK_PORT) {
-      next.webhook.port = parseIntStrict(env.CC_OCTO_WEBHOOK_PORT, 'CC_OCTO_WEBHOOK_PORT', 1);
-    }
-    if (env.CC_OCTO_WEBHOOK_PATH) next.webhook.path = env.CC_OCTO_WEBHOOK_PATH;
-    if (env.CC_OCTO_WEBHOOK_SECRET) next.webhook.secret = env.CC_OCTO_WEBHOOK_SECRET;
-  }
-
-  if (env.CC_OCTO_SDK_MODEL) next.sdk.model = env.CC_OCTO_SDK_MODEL;
-  if (env.CC_OCTO_SDK_ALLOWED_TOOLS) {
-    // Q2: a `*` token anywhere in the value means "allow every tool" — collapse
-    // to the wildcard sentinel rather than passing a literal `*` through as a
-    // (bogus) tool name. So `*`, ` * `, and `*,Read` all mean wildcard.
-    const tools = parseCsv(env.CC_OCTO_SDK_ALLOWED_TOOLS);
-    next.sdk.allowedTools = tools.includes('*') ? '*' : tools;
-  }
-  if (env.CC_OCTO_SDK_PERMISSION_MODE) {
-    next.sdk.permissionMode = env.CC_OCTO_SDK_PERMISSION_MODE;
-  }
-  if (env.CC_OCTO_SDK_MAX_TURNS) {
-    next.sdk.maxTurns = parseIntStrict(env.CC_OCTO_SDK_MAX_TURNS, 'CC_OCTO_SDK_MAX_TURNS', 0);
-  }
-  if (env.CC_OCTO_SDK_SYSTEM_PROMPT) next.sdk.systemPrompt = env.CC_OCTO_SDK_SYSTEM_PROMPT;
-  if (env.CC_OCTO_SDK_SETTING_SOURCES) {
-    next.sdk.settingSources = parseCsv(env.CC_OCTO_SDK_SETTING_SOURCES);
-  }
-  // v0.3: tool-progress messages. Accept the usual truthy spellings.
-  if (env.CC_OCTO_SDK_TOOL_PROGRESS !== undefined) {
-    next.sdk.toolProgress = /^(1|true|yes|on)$/i.test(env.CC_OCTO_SDK_TOOL_PROGRESS.trim());
-  }
-  // v0.3: persistent (v2) sessions.
-  if (env.CC_OCTO_SDK_PERSISTENT_SESSION !== undefined) {
-    next.sdk.persistentSession = /^(1|true|yes|on)$/i.test(env.CC_OCTO_SDK_PERSISTENT_SESSION.trim());
-  }
-  // Q1: ANTHROPIC_BASE_URL uses the Anthropic SDK standard variable name
-  // (no CC_OCTO_ prefix) so operators can reuse existing gateway configs.
-  if (env.ANTHROPIC_BASE_URL) {
-    next.sdk.anthropicBaseUrl = env.ANTHROPIC_BASE_URL;
-  }
-
-  if (env.CC_OCTO_RATE_LIMIT_MAX_PER_MINUTE) {
-    next.rateLimit.maxPerMinute = parseIntStrict(
-      env.CC_OCTO_RATE_LIMIT_MAX_PER_MINUTE,
-      'CC_OCTO_RATE_LIMIT_MAX_PER_MINUTE',
-      0,
-    );
-  }
-
-  if (env.CC_OCTO_CONTEXT_MAX_CHARS) {
-    next.context.maxContextChars = parseIntStrict(
-      env.CC_OCTO_CONTEXT_MAX_CHARS,
-      'CC_OCTO_CONTEXT_MAX_CHARS',
-      0,
-    );
-  }
-  if (env.CC_OCTO_CONTEXT_HISTORY_LIMIT) {
-    next.context.historyLimit = parseIntStrict(
-      env.CC_OCTO_CONTEXT_HISTORY_LIMIT,
-      'CC_OCTO_CONTEXT_HISTORY_LIMIT',
-      0,
-    );
-  }
-
-  if (env.CC_OCTO_BOT_BLOCKLIST) {
-    next.botBlocklist = parseCsv(env.CC_OCTO_BOT_BLOCKLIST);
-  }
-
-  if (env.CC_OCTO_ALLOWED_BOT_UIDS) {
-    next.allowedBotUids = parseCsv(env.CC_OCTO_ALLOWED_BOT_UIDS);
-  }
-
-  if (env.CC_OCTO_MENTION_FREE_GROUPS) {
-    next.mentionFreeGroups = parseCsv(env.CC_OCTO_MENTION_FREE_GROUPS);
-  }
-
-  if (env.CC_OCTO_MAX_RESPONSE_CHARS) {
-    next.maxResponseChars = parseIntStrict(
-      env.CC_OCTO_MAX_RESPONSE_CHARS,
-      'CC_OCTO_MAX_RESPONSE_CHARS',
-      1,
-    );
-  }
-
-  return next;
-}
-
 /**
  * SSRF protection for apiUrl: implemented in url-policy.ts (isAllowedApiUrl).
  * S6 fix: now rejects https://127.0.0.1 too — https doesn't make a private
@@ -534,8 +392,11 @@ export function loadConfig(configPath?: string): Config {
     );
   }
   const fileCfg = readConfigFile(path);
-  const merged = mergeConfig(defaults(), fileCfg);
-  const final = applyEnv(merged);
+  // Config comes ONLY from config.json (global + per-bot layers) — there is no
+  // environment-variable override path (#103). The sole exception that still
+  // *reads* the environment lives nowhere here: `sdk.anthropicBaseUrl` is set in
+  // config.json and forwarded to the SDK subprocess by agent-bridge.
+  const final = mergeConfig(defaults(), fileCfg);
 
   // baseDir = the directory containing the global config.json. Every bot's
   // subtree lives at <baseDir>/<botId>/…. resolveBotConfigs() derives the


### PR DESCRIPTION
Closes #103.

## What
Configuration now comes **only** from the two-layer config.json (global + per-bot). All environment-variable override paths are removed.

- Deleted `applyEnv()` + its `parseCsv`/`parseIntStrict` helpers from `src/config.ts`. `loadConfig` no longer touches `process.env`.
- Removes the **entire `CC_OCTO_*` surface** AND the `ANTHROPIC_BASE_URL` env read.
- `sdk.anthropicBaseUrl` **stays** a config.json field — agent-bridge still forwards it to the SDK subprocess as `ANTHROPIC_BASE_URL` (that's config→subprocess, not an input override path).

## Breaking change + migration
Old env vars are **silently ignored** (per agreed policy — no throw). The previous removed-dir-env migration error is also dropped. **Migrate** by moving any `CC_OCTO_*` / `ANTHROPIC_BASE_URL` values into `~/.cc-channel-octo/config.json` (or the per-bot file).

## Why
Single declarative source of truth — no env/file precedence confusion, smaller surface. Mirrors the file-based direction of the rest of the deploy layout.

## Tests
Removed all env-override describe blocks/cases across `config.test.ts`, `p2-polish.test.ts`, `q13-q14-q17.test.ts`. Boolean/int toggles (toolProgress, persistentSession, maxTurns=0, historyLimit=0) rewritten to config-file form; every config.json-based assertion kept. **936 tests**, lint (0 warnings), type-check, build all green.

## Docs
- README: dropped the Environment Variables section + the table's Env Var column; converted the gateway / groupConfigDir / webhook examples from `CC_OCTO_*=… npm start` to config.json.
- `config.example.json`: removed env mentions; also corrected a stale `settingSources` default (`[]` → `["project"]`, missed in #100).
- CHANGELOG: breaking-change entry + migration note.