### PR TITLE
feat(config): add generic sdk.env — inject declared env into agent subprocess

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,13 @@ While the major version is `0`, minor releases may carry breaking changes.
 
 ### Added
 
+- **`sdk.env` config** (#107) — declare extra environment variables, injected
+  verbatim into the agent's tool subprocess. Generic (cc doesn't interpret them)
+  and per-bot. Primary use: give a multi-bot deploy's shared CLI its identity
+  selector, e.g. `{ "sdk": { "env": { "OCTO_BOT_ID": "<robotId>" } } }` so each
+  bot's `octo-cli` calls pick the right stored profile (a bare call errors "no
+  bot selected" once ≥2 profiles exist).
+
 - **Agent skills — generic external tooling** (#100) — external CLIs (octo-cli,
   gh, anything on `PATH`) are integrated as DATA, not code. Drop a standard Claude
   skill (`SKILL.md` + optional `references/`/`scripts/`) into

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ configurable.
 | `sdk.settingSources` | `['project']` | Filesystem settings sources the SDK loads. Default `['project']` so it discovers skills symlinked into the session sandbox's `.claude/skills/` (see [Agent skills](#agent-skills)). Memory stays isolated regardless (inline auto-memory dir pin). Add `'user'` only to deliberately load the operator's real `~/.claude`. |
 | `groupConfigDir` | *(unset)* | Directory of per-group instruction files (`<groupId>.md`). A match is injected into the system prompt as trusted custom instructions for that group. See [Per-group instructions](#per-group-instructions). |
 | `sdk.anthropicBaseUrl` | *(unset)* | Override the upstream Claude API endpoint. See [Self-hosted gateway](#self-hosted-gateway) below. |
+| `sdk.env` | *(unset)* | Extra environment variables (`{ "KEY": "value" }`) injected verbatim into the agent's tool subprocess. Per-bot. Use to give a bot's skills what their CLIs need — e.g. `{ "OCTO_BOT_ID": "<robotId>" }` so a multi-bot deploy's `octo-cli` selects the right stored profile. See [Agent skills](#agent-skills). |
 | `rateLimit.maxPerMinute` | `5` | Max requests per minute per session |
 | `context.maxContextChars` | `6000` | Max characters of group context injected into prompts |
 | `context.historyLimit` | `40` | Max messages in session history window |
@@ -222,6 +223,12 @@ CLI a skill needs (`npm i -g @mininglamp-oss/octo-cli`, etc.) and authenticate i
 agent only runs the already-authenticated CLI. Skills are operator-owned and
 trusted (like `SOUL.md`/`GROUP.md`); since their contents are visible to the
 model, **never put secrets in a skill file**.
+
+**Multi-bot tool identity.** When several bots share one CLI whose credential
+store keys by identity (e.g. `octo-cli`, which needs `--bot-id`/`OCTO_BOT_ID` to
+pick among ≥2 stored profiles), give each bot its selector via `sdk.env` in its
+per-bot config.json — e.g. `{ "sdk": { "env": { "OCTO_BOT_ID": "<robotId>" } } }`.
+cc injects it into that bot's tool subprocess so the CLI acts as the right bot.
 
 ### Multi-bot
 

--- a/src/__tests__/agent-bridge-query.test.ts
+++ b/src/__tests__/agent-bridge-query.test.ts
@@ -471,3 +471,53 @@ describe('queryAgent', () => {
     expect(chunks).toEqual(['still streamed']);
   });
 });
+
+describe('queryAgent — sdk.env injection (#107)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  function drain(config: Config): Promise<void> {
+    mockQuery.mockReturnValue(createMockStream([
+      { type: 'assistant', session_id: 's', message: { content: [{ type: 'text', text: 'hi' }] } },
+    ]));
+    return (async () => {
+      for await (const _ of queryAgent('t', '', '', config)) { void _; }
+    })();
+  }
+
+  it('injects sdk.env into the subprocess env (preserving process.env)', async () => {
+    const config = makeConfig({
+      sdk: { allowedTools: '*', permissionMode: 'bypassPermissions', settingSources: [], env: { OCTO_BOT_ID: 'cli_x' } },
+    });
+    await drain(config);
+    const env = mockQuery.mock.calls[0][0].options.env;
+    expect(env.OCTO_BOT_ID).toBe('cli_x');
+    expect(env.PATH).toBe(process.env.PATH); // process.env preserved
+  });
+
+  it('merges sdk.env with anthropicBaseUrl (both present)', async () => {
+    const config = makeConfig({
+      sdk: {
+        allowedTools: '*', permissionMode: 'bypassPermissions', settingSources: [],
+        env: { OCTO_BOT_ID: 'cli_x', FOO: 'bar' }, anthropicBaseUrl: 'https://llm.example.com',
+      },
+    });
+    await drain(config);
+    const env = mockQuery.mock.calls[0][0].options.env;
+    expect(env.OCTO_BOT_ID).toBe('cli_x');
+    expect(env.FOO).toBe('bar');
+    expect(env.ANTHROPIC_BASE_URL).toBe('https://llm.example.com');
+  });
+
+  it('omits env entirely when neither sdk.env nor anthropicBaseUrl is set', async () => {
+    await drain(makeConfig());
+    expect(mockQuery.mock.calls[0][0].options).not.toHaveProperty('env');
+  });
+
+  it('omits env when sdk.env is an empty object', async () => {
+    const config = makeConfig({
+      sdk: { allowedTools: '*', permissionMode: 'bypassPermissions', settingSources: [], env: {} },
+    });
+    await drain(config);
+    expect(mockQuery.mock.calls[0][0].options).not.toHaveProperty('env');
+  });
+});

--- a/src/agent-bridge.ts
+++ b/src/agent-bridge.ts
@@ -300,15 +300,24 @@ export async function* queryAgent(
     if (sources.length > 0) linkSkillsIntoSandbox(cwd, sources);
   }
 
-  // Q1: forward ANTHROPIC_BASE_URL to the SDK subprocess via the scoped `env`
-  // option instead of mutating the gateway's global process.env. The SDK's
-  // `env` REPLACES the subprocess environment entirely, so spread process.env
-  // first to preserve PATH/HOME/ANTHROPIC_API_KEY. Scoping it here means the
-  // override never leaks across requests and never persists after the field is
-  // cleared (no stale-global problem). When unset, omit `env` so the subprocess
-  // simply inherits process.env.
-  const env = config.sdk.anthropicBaseUrl
-    ? { ...process.env, ANTHROPIC_BASE_URL: config.sdk.anthropicBaseUrl }
+  // Q1: forward scoped env to the SDK subprocess via the `env` option instead
+  // of mutating the gateway's global process.env. The SDK's `env` REPLACES the
+  // subprocess environment entirely, so spread process.env first to preserve
+  // PATH/HOME/ANTHROPIC_API_KEY. Scoping here means overrides never leak across
+  // requests. When nothing needs adding, omit `env` so the subprocess simply
+  // inherits process.env.
+  //   - sdk.env (#107): operator-declared extra vars (e.g. OCTO_BOT_ID so a
+  //     multi-bot deploy's octo-cli picks the right profile). Generic — cc does
+  //     not interpret them.
+  //   - ANTHROPIC_BASE_URL: model-gateway routing (set last so it wins).
+  const extraEnv = config.sdk.env;
+  const hasExtraEnv = extraEnv !== undefined && Object.keys(extraEnv).length > 0;
+  const env = config.sdk.anthropicBaseUrl || hasExtraEnv
+    ? {
+        ...process.env,
+        ...(hasExtraEnv ? extraEnv : {}),
+        ...(config.sdk.anthropicBaseUrl ? { ANTHROPIC_BASE_URL: config.sdk.anthropicBaseUrl } : {}),
+      }
     : undefined;
 
   const stream = sdkQuery({

--- a/src/config.ts
+++ b/src/config.ts
@@ -139,9 +139,18 @@ export interface Config {
     /**
      * Q1: Override the upstream Claude API endpoint (e.g. self-hosted gateway).
      * Forwarded to the SDK subprocess via the standard `ANTHROPIC_BASE_URL`
-     * environment variable. Env priority: `ANTHROPIC_BASE_URL` > this field.
+     * environment variable.
      */
     anthropicBaseUrl?: string;
+    /**
+     * #107: extra environment variables injected verbatim into the agent's SDK
+     * subprocess (on top of the inherited process.env). Generic and declarative
+     * — cc knows nothing about what they mean. Use it to give a bot's skills the
+     * env their external CLIs need, e.g. `{ "OCTO_BOT_ID": "<robotId>" }` so a
+     * multi-bot deploy's `octo-cli` calls select the right stored profile.
+     * Per-bot (set in `<baseDir>/<id>/config.json`).
+     */
+    env?: Record<string, string>;
   };
   rateLimit: {
     maxPerMinute: number;


### PR DESCRIPTION
Closes #107.

## Problem
Multi-bot deploys that share one credential-keyed CLI break. `octo-cli` stores one encrypted profile per bot and, once ≥2 exist, needs `--bot-id`/`OCTO_BOT_ID` to pick — a bare call errors **"no bot selected"**. Since #100 cc injects no tool-specific env, so the agent has no way to act as the right bot. (Hit live while setting up a second bot.)

## Solution — generic, declarative, zero-CLI-name
New `sdk.env: Record<string,string>` config field. The operator declares whatever env a bot's skills need; cc injects it **verbatim** into that bot's SDK subprocess. cc interprets nothing — reusable by any tool, no CLI name in code.

Per-bot, in `<baseDir>/<id>/config.json`:
```jsonc
{ "sdk": { "env": { "OCTO_BOT_ID": "<robotId>" } } }
```
→ that bot's `octo-cli` calls select its own profile.

## Implementation
- `config.ts`: add `sdk.env?` (flows through the existing `...override.sdk` merge). Also fixed a stale `anthropicBaseUrl` doc comment (env priority note — env reading was removed in #104).
- `agent-bridge.ts`: build the subprocess `env` when `sdk.env` **or** `anthropicBaseUrl` is set — spread `process.env` first (SDK env REPLACES), then `sdk.env`, then `ANTHROPIC_BASE_URL` (so it wins its own key). Omitted entirely when neither / `sdk.env` empty.

## Tests
sdk.env injected (process.env preserved); merged with anthropicBaseUrl; omitted when unset; omitted when `{}`. **918 tests**, lint (0 warnings), type-check, build green.