### PR TITLE
test: fix flaky e2e G1 (mock media-inbound) + sdk.skills load-path test

### DIFF
--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -451,6 +451,21 @@ describe('resolveBotConfigs (two-layer)', () => {
     expect(bot.sdk.model).toBe('file-model');
   });
 
+  it('#110: sdk.skills survives the per-bot config.json load path (per-bot selection)', () => {
+    const cfg = loadConfig(writeConfig({
+      apiUrl: 'https://a',
+      bots: [{ id: 'triage' }, { id: 'plain' }],
+    }));
+    // Each bot selects its own skill subset via its per-bot file.
+    writeBotConfig('triage', { botToken: 'bf_1', sdk: { skills: ['octo-messaging', 'github-issue-triage'] } });
+    writeBotConfig('plain', { botToken: 'bf_2', sdk: { skills: 'all' } });
+    const bots = resolveBotConfigs(cfg);
+    const triage = bots.find((b) => b.botId === 'triage')!;
+    const plain = bots.find((b) => b.botId === 'plain')!;
+    expect(triage.sdk.skills).toEqual(['octo-messaging', 'github-issue-triage']);
+    expect(plain.sdk.skills).toBe('all');
+  });
+
   it('inline bots[] fields apply when no per-bot file overrides them', () => {
     const cfg = loadConfig(writeConfig({
       apiUrl: 'https://a',

--- a/src/__tests__/e2e.test.ts
+++ b/src/__tests__/e2e.test.ts
@@ -47,6 +47,21 @@ vi.mock('../agent-bridge.js', async (importOriginal) => {
   };
 });
 
+// Mock the inbound-image downloader so the suite never does a real network
+// fetch (the #86 download path). Without this, G1 (a non-text DM with an image
+// URL) intermittently fails as `downloadInboundImage` tries a live HTTP request
+// and times out / errors. Preserve the real constants (e.g.
+// MAX_IMAGES_PER_MESSAGE, used by index.ts) via importOriginal; stub only the
+// network call to a deterministic error so the caller falls back to the URL
+// marker (`[图片] <url>`) — exactly the behavior G1 asserts.
+vi.mock('../media-inbound.js', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../media-inbound.js')>();
+  return {
+    ...original,
+    downloadInboundImage: vi.fn().mockResolvedValue({ error: 'mocked: no network in tests' }),
+  };
+});
+
 // --- Imports (after mocks) ---
 
 import { SessionStore } from '../session-store.js';


### PR DESCRIPTION
Closes #112.

## Flake fix
`e2e.test.ts > G1: non-text DM message is resolved` flaked because the suite mocked `octo/api.js` and `agent-bridge.js` but **not `media-inbound.js`** — so the #86 inbound-image path ran a **real network `fetch`** (`downloadInboundImage`), timing out nondeterministically (`下载失败: fetch failed`) → image unresolved → `queryAgent`-called assertion failed. ~2/3 of full-file runs failed; passed in isolation. (This is what tripped PR #111's pre-push.)

**Fix:** mock `media-inbound.js` (preserve real constants like `MAX_IMAGES_PER_MESSAGE` via `importOriginal`; stub `downloadInboundImage` → deterministic `{error}` so the caller falls back to the `[图片] <url>` marker — exactly what G1 asserts). **No production code change.** Verified: full e2e file **35/35 across repeated runs**; full suite 923/923 twice.

## Also
Adds the reviewer-suggested (PR #111) config test: `sdk.skills` survives the real `<baseDir>/<id>/config.json` load through `resolveBotConfigs()` (per-bot selection: one bot gets `['octo-messaging','github-issue-triage']`, another `'all'`).

**923 tests**, lint (0 warnings), type-check green. Pre-push hook passes (the flake it caught is now fixed).