### PR TITLE
fix(cron): robustness follow-ups from xhigh review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,19 @@ While the major version is `0`, minor releases may carry breaking changes.
 
 ### Fixed
 
+- **Cron robustness — review follow-ups** (#115) — four operational-hardening
+  fixes from the xhigh review: (1/5) cron fires now **bypass the rate limit**
+  (like the @mention gate) so an operator-scheduled task isn't silently dropped
+  when the owner's bucket is exhausted, and the scheduler **logs an async fire
+  failure attributed to the specific task** (delivery errors were previously
+  invisible); (2) a **startup warning** when `sdk.cron` is on but the bot has no
+  `owner_uid` (the owner-gate would otherwise reject every `cron_create` with no
+  hint why); (3) a synthetic cron fire's `message_seq=0` **no longer poisons the
+  history-segmentation cursor** (`setLastBotReplySeq` is skipped for non-positive
+  seq); (6) **strict ISO-8601 validation** for one-shot schedules
+  (`parseOneShot`) so a lenient rollover like `2026-13-13T…` is rejected instead
+  of silently firing at a shifted time.
+
 - **Router drops non-conversation channel types** (#68) — found in live
   deployment: on connect the bot received a system message on `channel_type: 8`
   (`systemcmdonline`) and replied to it. `SessionRouter` now allowlists only DM /

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "crypto-js": "^4.2.0",
         "curve25519-js": "^0.0.4",
         "md5-typescript": "^1.0.5",
-        "ws": "^8.16.0"
+        "ws": "^8.16.0",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.162",
@@ -8213,9 +8214,7 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/scripts/memory-recall.mjs
+++ b/scripts/memory-recall.mjs
@@ -1,0 +1,41 @@
+/**
+ * Phase 2: cross-session RECALL. Point a fresh query() at a pre-populated
+ * memoryDir (written by phase 1) and ask the question cold — no history, no
+ * resume. If it answers "teal", auto-memory recall works end to end.
+ *
+ * Usage: node scripts/memory-recall.mjs <memoryDir>
+ */
+import { query } from '@anthropic-ai/claude-agent-sdk';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const memDir = process.argv[2];
+if (!memDir) { console.error('usage: node scripts/memory-recall.mjs <memoryDir>'); process.exit(1); }
+const cwd = mkdtempSync(join(tmpdir(), 'mem-recall-cwd-'));
+console.log('[recall] memoryDir =', memDir);
+
+let sawRecall = false, answer = '';
+const q = query({
+  prompt: 'What is my favorite color? Answer in one word.',
+  options: {
+    cwd,
+    model: 'claude-haiku-4-5-20251001',
+    permissionMode: 'bypassPermissions',
+    settingSources: [],
+    systemPrompt: { type: 'preset', preset: 'claude_code', append: 'You are a helpful assistant in a chat gateway.' },
+    settings: { autoMemoryEnabled: true, autoMemoryDirectory: memDir },
+  },
+});
+for await (const msg of q) {
+  if (msg.type === 'system' && msg.subtype === 'memory_recall') {
+    sawRecall = true;
+    console.log('[recall] *** memory_recall *** items=', (msg.memories ?? []).length, JSON.stringify(msg.memories ?? []).slice(0, 300));
+  }
+  if (msg.type === 'assistant') {
+    const text = (msg.message?.content ?? []).filter((b) => b.type === 'text').map((b) => b.text).join('');
+    if (text) answer += text;
+  }
+}
+console.log('[recall] answer:', answer.slice(0, 200).replace(/\n/g, ' '));
+console.log(`[recall] === memory_recall_seen=${sawRecall}, mentions teal/青=${/teal|青/i.test(answer)} ===`);

--- a/scripts/memory-repro.mjs
+++ b/scripts/memory-repro.mjs
@@ -1,0 +1,80 @@
+/**
+ * Isolated repro: does the SDK's filesystem auto-memory actually WRITE to
+ * `autoMemoryDirectory` during a single query() turn?
+ *
+ * Runs one query() telling the model to remember a durable fact, with
+ * autoMemoryEnabled=true pointed at a fresh temp dir, settingSources:[] so the
+ * agent cannot see/touch the host's real ~/.claude config. Then snapshots the
+ * temp dir.
+ *
+ * Usage: node scripts/memory-repro.mjs
+ */
+import { query } from '@anthropic-ai/claude-agent-sdk';
+import { mkdtempSync, readdirSync, statSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const memDir = mkdtempSync(join(tmpdir(), 'mem-repro-'));
+const cwd = mkdtempSync(join(tmpdir(), 'mem-cwd-'));
+console.log('[repro] memoryDir =', memDir);
+console.log('[repro] cwd       =', cwd);
+
+function walk(dir, depth = 0) {
+  let out = [];
+  let entries = [];
+  try { entries = readdirSync(dir); } catch { return out; }
+  for (const e of entries) {
+    const p = join(dir, e);
+    const st = statSync(p);
+    out.push('  '.repeat(depth) + (st.isDirectory() ? e + '/' : `${e} (${st.size}b)`));
+    if (st.isDirectory()) out = out.concat(walk(p, depth + 1));
+    else if (st.size < 2000) out.push('    ↳ ' + readFileSync(p, 'utf8').replace(/\n/g, '\\n'));
+  }
+  return out;
+}
+
+const PROMPT = 'Please remember this durable fact about me for all future sessions: my favorite color is teal (青色). Store it in your long-term memory.';
+
+let sawRecall = false;
+let turns = 0;
+const t0 = Date.now();
+
+const q = query({
+  prompt: PROMPT,
+  options: {
+    cwd,
+    model: 'claude-haiku-4-5-20251001',
+    permissionMode: 'bypassPermissions',
+    settingSources: [],
+    // KEY: preset systemPrompt so the auto-memory dynamic section is injected.
+    // A raw-string systemPrompt suppresses it (sdk.d.ts:2928).
+    systemPrompt: { type: 'preset', preset: 'claude_code', append: 'You are a helpful assistant in a chat gateway.' },
+    settings: { autoMemoryEnabled: true, autoMemoryDirectory: memDir },
+  },
+});
+
+for await (const msg of q) {
+  turns++;
+  if (msg.type === 'system') {
+    console.log(`[repro] system msg subtype=${msg.subtype ?? '(none)'}`);
+    if (msg.subtype === 'memory_recall') sawRecall = true;
+  }
+  if (msg.type === 'assistant') {
+    const text = (msg.message?.content ?? [])
+      .filter((b) => b.type === 'text').map((b) => b.text).join('');
+    if (text) console.log('[repro] assistant:', text.slice(0, 200).replace(/\n/g, ' '));
+    const tools = (msg.message?.content ?? []).filter((b) => b.type === 'tool_use');
+    for (const t of tools) console.log(`[repro] tool_use: ${t.name} input=${JSON.stringify(t.input).slice(0, 160)}`);
+  }
+  if (msg.type === 'result') {
+    console.log(`[repro] result: ${msg.subtype} in ${Date.now() - t0}ms`);
+  }
+}
+
+console.log(`\n[repro] === DONE: ${turns} msgs, memory_recall seen=${sawRecall} ===`);
+console.log('[repro] memoryDir tree:');
+const tree = walk(memDir);
+console.log(tree.length ? tree.join('\n') : '  (EMPTY — nothing written)');
+console.log('[repro] cwd tree:');
+const ctree = walk(cwd);
+console.log(ctree.length ? ctree.join('\n') : '  (EMPTY)');

--- a/src/__tests__/cron-evaluator.test.ts
+++ b/src/__tests__/cron-evaluator.test.ts
@@ -111,6 +111,21 @@ describe('parseOneShot (#6 strict ISO)', () => {
     expect(parseOneShot('2026-06-32T00:00:00Z')).toBeNull(); // day 32
   });
 
+  it('rejects rollover for numeric-offset and zone-less forms too (#B)', () => {
+    // The offset form used to skip calendar validation — Feb 31 +08:00 silently
+    // rolled into March. Calendar validity is zone-independent, so reject it.
+    expect(parseOneShot('2026-02-31T00:00:00+08:00')).toBeNull();
+    expect(parseOneShot('2026-13-13T00:00:00+05:30')).toBeNull();
+    expect(parseOneShot('2026-06-32T00:00:00-07:00')).toBeNull();
+    expect(parseOneShot('2026-02-31T00:00:00')).toBeNull(); // no zone (local)
+    expect(parseOneShot('2025-02-29T00:00:00+08:00')).toBeNull(); // 2025 not a leap year
+    // Out-of-range time fields are also calendar-invalid regardless of zone.
+    expect(parseOneShot('2026-06-09T25:00:00+08:00')).toBeNull(); // hour 25
+    expect(parseOneShot('2026-06-09T00:61:00+08:00')).toBeNull(); // minute 61
+    // A legitimate leap day with an offset must still pass.
+    expect(parseOneShot('2028-02-29T00:00:00+08:00')).not.toBeNull(); // 2028 IS leap
+  });
+
   it('rejects non-ISO / garbage that the loose heuristic would pass', () => {
     expect(parseOneShot('T')).toBeNull();
     expect(parseOneShot('0T0')).toBeNull();

--- a/src/__tests__/cron-evaluator.test.ts
+++ b/src/__tests__/cron-evaluator.test.ts
@@ -3,7 +3,7 @@
  */
 import { describe, it, expect } from 'vitest';
 import {
-  parseCronExpression, matchesCron, computeNextRun, isOneShotSchedule,
+  parseCronExpression, matchesCron, computeNextRun, isOneShotSchedule, parseOneShot,
 } from '../cron-evaluator.js';
 
 describe('parseCronExpression', () => {
@@ -94,5 +94,31 @@ describe('computeNextRun', () => {
 
   it('impossible schedule (Feb 31) returns null', () => {
     expect(computeNextRun('0 0 31 2 *', true, NOW)).toBeNull();
+  });
+});
+
+describe('parseOneShot (#6 strict ISO)', () => {
+  it('accepts canonical ISO datetimes', () => {
+    expect(parseOneShot('2999-01-01T00:00:00Z')).toBe(new Date('2999-01-01T00:00:00Z').getTime());
+    expect(parseOneShot('2999-06-09T09:30Z')).toBe(new Date('2999-06-09T09:30Z').getTime());
+    expect(parseOneShot('2999-06-09T09:30:00')).not.toBeNull(); // no zone = local
+    expect(parseOneShot('2999-06-09T09:30:00+08:00')).not.toBeNull();
+  });
+
+  it('rejects lenient rollover dates (month 13, day 32) instead of shifting them', () => {
+    expect(parseOneShot('2026-13-13T00:00:00Z')).toBeNull(); // month 13
+    expect(parseOneShot('2026-02-31T00:00:00Z')).toBeNull(); // Feb 31 rolls to Mar
+    expect(parseOneShot('2026-06-32T00:00:00Z')).toBeNull(); // day 32
+  });
+
+  it('rejects non-ISO / garbage that the loose heuristic would pass', () => {
+    expect(parseOneShot('T')).toBeNull();
+    expect(parseOneShot('0T0')).toBeNull();
+    expect(parseOneShot('badT123')).toBeNull();
+    expect(parseOneShot('not a date')).toBeNull();
+  });
+
+  it('computeNextRun uses strict parsing — a rollover one-shot is rejected', () => {
+    expect(computeNextRun('2026-13-13T00:00:00Z', false, Date.now())).toBeNull();
   });
 });

--- a/src/__tests__/cron-integration.test.ts
+++ b/src/__tests__/cron-integration.test.ts
@@ -103,6 +103,14 @@ describe('cron integration (#115)', () => {
     expect(queryAgent).toHaveBeenCalledTimes(1);
   });
 
+  it('a cron fire (message_seq=0) does NOT poison the reply-seq cursor (#3)', async () => {
+    const msg = synthesizeCronMessage(task({ channelId: '', channelType: ChannelType.DM, fromUid: 'peer-9' }));
+    expect(msg.message_seq).toBe(0);
+    await handleMessage(msg, config, store, router, groupContext, streamRelay, BOT_ID, cronStore);
+    // sessionKey for this DM is from_uid; the cursor must stay unset (not 0).
+    expect(store.getLastBotReplySeq('peer-9')).toBeUndefined();
+  });
+
   it('the agent turn is offered the cron MCP tool (mcpServers.cron present)', async () => {
     let captured: Record<string, unknown> | undefined;
     (queryAgent as ReturnType<typeof vi.fn>).mockImplementation(

--- a/src/__tests__/cron-integration.test.ts
+++ b/src/__tests__/cron-integration.test.ts
@@ -124,4 +124,24 @@ describe('cron integration (#115)', () => {
     expect(captured).toBeDefined();
     expect(captured!.cron).toBeDefined();
   });
+
+  it('a FAILED cron fire is attributed to its task at the real catch site (#A)', async () => {
+    // The production failure path: queryAgent throws → handleMessage's own
+    // try/catch swallows it (sends a user-facing error reply, never rethrows).
+    // The cron attribution must therefore happen INSIDE that catch, keyed off
+    // the synthetic `cron:<taskId>:<ts>` message_id — not on a returned promise
+    // (handleMessage always resolves). Regression guard for PR #118.
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    (queryAgent as ReturnType<typeof vi.fn>).mockImplementation(async function* () {
+      throw new Error('agent blew up');
+      yield ''; // unreachable; keeps the generator well-typed
+    });
+    const msg = synthesizeCronMessage(task({ id: 'doomed', channelId: '', channelType: ChannelType.DM, fromUid: 'peer-9' }));
+    await handleMessage(msg, config, store, router, groupContext, streamRelay, BOT_ID, cronStore);
+
+    const logged = errSpy.mock.calls.map((c) => c.map(String).join(' ')).join('\n');
+    expect(logged).toMatch(/doomed/);
+    expect(logged).toMatch(/failed during execution/);
+    errSpy.mockRestore();
+  });
 });

--- a/src/__tests__/cron-scheduler.test.ts
+++ b/src/__tests__/cron-scheduler.test.ts
@@ -82,18 +82,15 @@ describe('CronScheduler.tick', () => {
     expect(fired).toEqual(['ok']); // second task still fired
   });
 
-  it('logs an async fire failure attributed to the task, and still advances (#1)', async () => {
-    const errSpy = vi.spyOn(console, 'error');
+  it('a recurring task advances even when the fire fails downstream (no retry loop) (#1)', () => {
     store.save([task({ id: 'flaky', recurring: true, schedule: '*/5 * * * *' })]);
-    // onFire returns a rejecting promise (delivery failed downstream).
-    sched(() => Promise.reject(new Error('deliver failed'))).tick();
-    // recurring task advanced despite the failure (no retry loop).
+    // onFire is fire-and-forget (void). A downstream delivery failure is
+    // attributed to the task at handleMessage's catch site (see
+    // cron-integration.test.ts), NOT here — the scheduler must still advance.
+    sched(() => {}).tick();
+    // recurring task advanced despite a (hypothetical) downstream failure.
     expect(store.load()[0].nextRun).toBeGreaterThan(Date.now());
-    // wait a microtask for the attached .catch to run.
-    await Promise.resolve();
-    const logged = errSpy.mock.calls.map((c) => c.join(' ')).join('\n');
-    expect(logged).toMatch(/flaky/);
-    expect(logged).toMatch(/failed during execution/);
+    expect(store.load()[0].lastRun).not.toBeNull();
   });
 
   it('missed task fires once (not per missed window)', () => {

--- a/src/__tests__/cron-scheduler.test.ts
+++ b/src/__tests__/cron-scheduler.test.ts
@@ -82,6 +82,20 @@ describe('CronScheduler.tick', () => {
     expect(fired).toEqual(['ok']); // second task still fired
   });
 
+  it('logs an async fire failure attributed to the task, and still advances (#1)', async () => {
+    const errSpy = vi.spyOn(console, 'error');
+    store.save([task({ id: 'flaky', recurring: true, schedule: '*/5 * * * *' })]);
+    // onFire returns a rejecting promise (delivery failed downstream).
+    sched(() => Promise.reject(new Error('deliver failed'))).tick();
+    // recurring task advanced despite the failure (no retry loop).
+    expect(store.load()[0].nextRun).toBeGreaterThan(Date.now());
+    // wait a microtask for the attached .catch to run.
+    await Promise.resolve();
+    const logged = errSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(logged).toMatch(/flaky/);
+    expect(logged).toMatch(/failed during execution/);
+  });
+
   it('missed task fires once (not per missed window)', () => {
     // nextRun 2h in the past, recurring every 5 min — must fire exactly once.
     store.save([task({ recurring: true, schedule: '*/5 * * * *', nextRun: Date.now() - 2 * 3600_000 })]);

--- a/src/__tests__/cron-security.test.ts
+++ b/src/__tests__/cron-security.test.ts
@@ -84,3 +84,25 @@ describe('cron mention-gate bypass (#115)', () => {
     expect(r).toBeNull();
   });
 });
+
+describe('cron fire bypasses rate limit (#1/#5)', () => {
+  it('a cron fire is processed even when the per-session bucket is exhausted', async () => {
+    const router = new SessionRouter(makeConfig({ rateLimit: { maxPerMinute: 1 } }), ROBOT_ID);
+    const dm = (over?: Partial<BotMessage>): BotMessage => groupMsg({
+      channel_type: ChannelType.DM, channel_id: undefined, from_uid: 'peer-1', ...over,
+    });
+    // Exhaust the bucket with a real DM (maxPerMinute=1).
+    const first = await router.route(dm({ payload: { type: MessageType.Text, content: 'hi' } }));
+    expect(first?.shouldProcess).toBe(true);
+    // A second REAL message is now rate-limited.
+    const blocked = await router.route(dm({ message_id: '2', payload: { type: MessageType.Text, content: 'again' } }));
+    expect(blocked?.shouldProcess).toBe(false);
+    // But a CRON FIRE for the same session still processes (operator-scheduled).
+    const cron = await router.route(dm({
+      message_id: '3',
+      payload: { type: MessageType.Text, content: 'scheduled', _cronFire: true, [CRON_FIRE_NONCE_KEY]: CRON_FIRE_NONCE },
+    }));
+    expect(cron).not.toBeNull();
+    expect(cron!.shouldProcess).toBe(true);
+  });
+});

--- a/src/cron-evaluator.ts
+++ b/src/cron-evaluator.ts
@@ -120,6 +120,39 @@ export function isOneShotSchedule(schedule: string): boolean {
 }
 
 /**
+ * Strictly parse a one-shot ISO-8601 datetime → Unix ms, or null if invalid.
+ *
+ * `new Date()` alone is too lenient (e.g. it rolls "2026-13-13T…" into a real
+ * but wrong instant instead of rejecting it). We additionally require the
+ * canonical shape via regex AND verify the parsed Date round-trips its UTC
+ * fields, so an out-of-range month/day/hour can't sneak through as a silently
+ * shifted time.
+ */
+export function parseOneShot(schedule: string): number | null {
+  const s = schedule.trim();
+  // YYYY-MM-DDThh:mm(:ss(.fff)?)? with optional Z or ±hh:mm offset.
+  const m = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(?::(\d{2})(?:\.\d{1,3})?)?(Z|[+-]\d{2}:\d{2})?$/.exec(s);
+  if (!m) return null;
+  const t = new Date(s).getTime();
+  if (Number.isNaN(t)) return null;
+  // Reject lenient rollover: re-render the instant and confirm the calendar
+  // fields the user wrote actually match. Compare in UTC when an explicit
+  // Z/offset was given; otherwise the string is local wall-clock, so compare
+  // local fields.
+  const d = new Date(t);
+  const hasZone = m[7] !== undefined;
+  const yr = hasZone ? d.getUTCFullYear() : d.getFullYear();
+  const mo = (hasZone ? d.getUTCMonth() : d.getMonth()) + 1;
+  const day = hasZone ? d.getUTCDate() : d.getDate();
+  // With a numeric offset (not Z) the wall-clock is shifted, so only validate
+  // the calendar for Z / no-zone; an offset is already unambiguous via Date.
+  if (m[7] === undefined || m[7] === 'Z') {
+    if (yr !== Number(m[1]) || mo !== Number(m[2]) || day !== Number(m[3])) return null;
+  }
+  return t;
+}
+
+/**
  * Compute the next fire time (Unix ms) strictly after `fromMs`, or null when
  * there is none (a past/invalid one-shot, or an impossible cron).
  *
@@ -128,8 +161,8 @@ export function isOneShotSchedule(schedule: string): boolean {
  */
 export function computeNextRun(schedule: string, recurring: boolean, fromMs: number): number | null {
   if (isOneShotSchedule(schedule)) {
-    const t = new Date(schedule).getTime();
-    if (Number.isNaN(t)) return null;
+    const t = parseOneShot(schedule);
+    if (t === null) return null;
     return t > fromMs ? t : null;
   }
   const parsed = parseCronExpression(schedule);

--- a/src/cron-evaluator.ts
+++ b/src/cron-evaluator.ts
@@ -124,9 +124,9 @@ export function isOneShotSchedule(schedule: string): boolean {
  *
  * `new Date()` alone is too lenient (e.g. it rolls "2026-13-13T…" into a real
  * but wrong instant instead of rejecting it). We additionally require the
- * canonical shape via regex AND verify the parsed Date round-trips its UTC
- * fields, so an out-of-range month/day/hour can't sneak through as a silently
- * shifted time.
+ * canonical shape via regex AND verify the authored wall-clock fields name a
+ * real calendar instant, so an out-of-range month/day/hour can't sneak through
+ * as a silently shifted time — for ALL zone forms (Z, ±hh:mm, or none).
  */
 export function parseOneShot(schedule: string): number | null {
   const s = schedule.trim();
@@ -135,19 +135,28 @@ export function parseOneShot(schedule: string): number | null {
   if (!m) return null;
   const t = new Date(s).getTime();
   if (Number.isNaN(t)) return null;
-  // Reject lenient rollover: re-render the instant and confirm the calendar
-  // fields the user wrote actually match. Compare in UTC when an explicit
-  // Z/offset was given; otherwise the string is local wall-clock, so compare
-  // local fields.
-  const d = new Date(t);
-  const hasZone = m[7] !== undefined;
-  const yr = hasZone ? d.getUTCFullYear() : d.getFullYear();
-  const mo = (hasZone ? d.getUTCMonth() : d.getMonth()) + 1;
-  const day = hasZone ? d.getUTCDate() : d.getDate();
-  // With a numeric offset (not Z) the wall-clock is shifted, so only validate
-  // the calendar for Z / no-zone; an offset is already unambiguous via Date.
-  if (m[7] === undefined || m[7] === 'Z') {
-    if (yr !== Number(m[1]) || mo !== Number(m[2]) || day !== Number(m[3])) return null;
+  // Reject lenient rollover. Calendar validity (is "Feb 31" a real date? is hour
+  // 25 valid?) is INDEPENDENT of the timezone, so validate the authored
+  // wall-clock fields with a zone-free UTC round-trip probe: if Date.UTC had to
+  // roll any field over, the rendered field won't match what the user wrote.
+  // This catches offset rollover (e.g. 2026-02-31T00:00:00+08:00) too — the old
+  // code skipped the check for numeric offsets and let it roll into March.
+  const yr = Number(m[1]);
+  const mo = Number(m[2]);
+  const day = Number(m[3]);
+  const hh = Number(m[4]);
+  const mm = Number(m[5]);
+  const ss = m[6] !== undefined ? Number(m[6]) : 0;
+  const probe = new Date(Date.UTC(yr, mo - 1, day, hh, mm, ss));
+  if (
+    probe.getUTCFullYear() !== yr ||
+    probe.getUTCMonth() !== mo - 1 ||
+    probe.getUTCDate() !== day ||
+    probe.getUTCHours() !== hh ||
+    probe.getUTCMinutes() !== mm ||
+    probe.getUTCSeconds() !== ss
+  ) {
+    return null;
   }
   return t;
 }

--- a/src/cron-scheduler.ts
+++ b/src/cron-scheduler.ts
@@ -24,8 +24,14 @@ export const CRON_TICK_MS = 30_000;
 
 export interface CronSchedulerOptions {
   cronStore: CronStore;
-  /** Invoked with a synthetic BotMessage when a task is due (= onInbound). */
-  onFire: (msg: BotMessage) => void;
+  /**
+   * Invoked with a synthetic BotMessage when a task is due (= onInbound). May
+   * return a promise that resolves when the fired turn finishes; the scheduler
+   * attaches a per-task failure logger to it (attribution) but does NOT await it
+   * — firing stays non-blocking and nextRun advances regardless (a failed fire
+   * is logged, not retried, to avoid an error loop hammering the channel).
+   */
+  onFire: (msg: BotMessage) => void | Promise<void>;
   /** Log prefix, e.g. "[bot-id] " in multi-bot mode. */
   label?: string;
 }
@@ -102,7 +108,19 @@ export class CronScheduler {
             );
           }
           try {
-            this.opts.onFire(synthesizeCronMessage(task));
+            const r = this.opts.onFire(synthesizeCronMessage(task));
+            // Attribute an async delivery failure to THIS task (the pipeline's
+            // own .catch logs it unattributed). Not awaited — fire stays
+            // non-blocking and nextRun advances regardless.
+            if (r && typeof (r as Promise<void>).catch === 'function') {
+              const taskId = task.id;
+              const label = this.opts.label ?? '';
+              (r as Promise<void>).catch((err) => {
+                console.error(
+                  `[cc-channel-octo] ${label}cron: fired task ${taskId} failed during execution: ${String(err)}`,
+                );
+              });
+            }
           } catch (err) {
             console.error(
               `[cc-channel-octo] ${this.opts.label ?? ''}cron: onFire threw for ${task.id}: ${String(err)}`,

--- a/src/cron-scheduler.ts
+++ b/src/cron-scheduler.ts
@@ -25,13 +25,13 @@ export const CRON_TICK_MS = 30_000;
 export interface CronSchedulerOptions {
   cronStore: CronStore;
   /**
-   * Invoked with a synthetic BotMessage when a task is due (= onInbound). May
-   * return a promise that resolves when the fired turn finishes; the scheduler
-   * attaches a per-task failure logger to it (attribution) but does NOT await it
-   * — firing stays non-blocking and nextRun advances regardless (a failed fire
-   * is logged, not retried, to avoid an error loop hammering the channel).
+   * Invoked with a synthetic BotMessage when a task is due (= onInbound). Fire
+   * is non-blocking; the scheduler does not await it and nextRun advances
+   * regardless (a failed fire is logged at the handler's own catch site —
+   * attributed to the task via the `cron:<id>:<ts>` message_id — not retried, to
+   * avoid an error loop hammering the channel).
    */
-  onFire: (msg: BotMessage) => void | Promise<void>;
+  onFire: (msg: BotMessage) => void;
   /** Log prefix, e.g. "[bot-id] " in multi-bot mode. */
   label?: string;
 }
@@ -108,19 +108,12 @@ export class CronScheduler {
             );
           }
           try {
-            const r = this.opts.onFire(synthesizeCronMessage(task));
-            // Attribute an async delivery failure to THIS task (the pipeline's
-            // own .catch logs it unattributed). Not awaited — fire stays
-            // non-blocking and nextRun advances regardless.
-            if (r && typeof (r as Promise<void>).catch === 'function') {
-              const taskId = task.id;
-              const label = this.opts.label ?? '';
-              (r as Promise<void>).catch((err) => {
-                console.error(
-                  `[cc-channel-octo] ${label}cron: fired task ${taskId} failed during execution: ${String(err)}`,
-                );
-              });
-            }
+            // Fire-and-forget: onFire (= onInbound) drives the full pipeline,
+            // which swallows its own errors and posts a user-facing reply. A
+            // FAILED fire is attributed to this task at handleMessage's catch
+            // site (via the `cron:<id>:<ts>` message_id) — not here, because the
+            // returned value is void and never rejects.
+            this.opts.onFire(synthesizeCronMessage(task));
           } catch (err) {
             console.error(
               `[cc-channel-octo] ${this.opts.label ?? ''}cron: onFire threw for ${task.id}: ${String(err)}`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -739,6 +739,14 @@ export async function handleMessage(
 
     } catch (err) {
       console.error(`[cc-channel-octo] Error processing message (session=${result.sessionKey}):`, String(err));
+      // #115: attribute a FAILED cron fire to its task. handleMessage swallows
+      // errors here (it sends a user-facing reply, never rethrows), so the
+      // scheduler's promise can't observe failure — surface it at the point we
+      // actually catch it. The synthetic message_id is `cron:<taskId>:<ts>`.
+      if (msg.payload._cronFire === true && msg.message_id.startsWith('cron:')) {
+        const taskId = msg.message_id.split(':')[1];
+        console.error(`[cc-channel-octo] cron: fired task ${taskId} failed during execution: ${String(err)}`);
+      }
       // Best-effort error reply
       try {
         await sendMessage({

--- a/src/index.ts
+++ b/src/index.ts
@@ -192,6 +192,18 @@ async function startBot(config: ReturnType<typeof loadConfig>, multi: boolean): 
   await gateway.register();
   console.log(`[cc-channel-octo] ${label}Bot registered: id=${gateway.botId}`);
 
+  // #115: cron creation/deletion is owner-gated on gateway.ownerUid. If the
+  // registration didn't return an owner_uid, the gate can never pass and the
+  // cron tool is silently unusable — warn loudly so the operator isn't left
+  // wondering why every cron_create is rejected.
+  if (config.sdk.cron && !gateway.ownerUid) {
+    console.warn(
+      `[cc-channel-octo] ${label}sdk.cron is enabled but the bot has no owner_uid ` +
+      `(registration returned none) — cron_create/delete will be rejected for everyone. ` +
+      `The cron tool is effectively disabled until the bot has an owner.`,
+    );
+  }
+
   // #86: prefetch the media CDN host (best-effort). Octo serves media from a
   // separate CDN than apiUrl; without this, inbound image URLs on the CDN host
   // are rejected by buildMediaUrl and the agent can't see them. The STS
@@ -242,11 +254,20 @@ async function startBot(config: ReturnType<typeof loadConfig>, multi: boolean): 
   gateway.setMessageHandler(onInbound);
 
   // #115: arm the cron scheduler now that onInbound exists. Fired tasks go
-  // through the exact same pipeline as real inbound messages.
+  // through the exact same pipeline as real inbound messages. The fire callback
+  // returns a tracked promise that REJECTS on handler error (distinct from
+  // onInbound, which swallows) so the scheduler can attribute a delivery failure
+  // to the specific task. Still tracked in activeHandlers for shutdown drain.
   if (cronStore) {
     cronScheduler = new CronScheduler({
       cronStore,
-      onFire: (msg: BotMessage) => onInbound(msg),
+      onFire: (msg: BotMessage): Promise<void> => {
+        if (gateway.draining) return Promise.resolve();
+        const p = handleMessage(msg, config, store, router, groupContext, streamRelay, gateway.botId, cronStore)
+          .finally(() => { activeHandlers.delete(p); });
+        activeHandlers.add(p);
+        return p;
+      },
       label,
     });
     cronScheduler.start();
@@ -699,7 +720,12 @@ export async function handleMessage(
         store.appendAssistant(sessionKey, fullResponse, msg.message_seq, botId);
         // G10: mark this message_seq as the last one we replied to. Next turn's
         // segmented history will treat messages with seq <= this as [answered].
-        store.setLastBotReplySeq(sessionKey, msg.message_seq);
+        // #115: a synthetic cron fire carries message_seq=0 (no real wire seq);
+        // setting the cursor to 0 would reset it and mis-segment real history as
+        // all-[new]. Only advance the cursor for a real positive seq.
+        if (typeof msg.message_seq === 'number' && msg.message_seq > 0) {
+          store.setLastBotReplySeq(sessionKey, msg.message_seq);
+        }
       } else {
         // Agent produced no output — send a feedback message so user isn't left hanging
         await sendMessage({

--- a/src/session-router.ts
+++ b/src/session-router.ts
@@ -322,18 +322,24 @@ export class SessionRouter {
     // G20 fix: peek all three buckets without consuming; only consume on full
     // pass. On block, attach notified state to the actual blocking bucket so
     // the debounce reply doesn't spam when a different bucket has tokens.
-    const blocker = this.checkAllRateLimits(key, msg.from_uid);
-    if (blocker) {
-      if (!blocker.notified) {
-        blocker.notified = true;
-        await this.replySafe(msg, '请稍后再试');
+    // #115: cron fires skip the rate limit — a scheduler-fired task is an
+    // operator-scheduled action (already bounded by the cron interval), not
+    // user spam. Without this a fire that lands while the owner's bucket is
+    // exhausted would be silently dropped while its nextRun has already advanced.
+    if (!this.isCronFire(msg)) {
+      const blocker = this.checkAllRateLimits(key, msg.from_uid);
+      if (blocker) {
+        if (!blocker.notified) {
+          blocker.notified = true;
+          await this.replySafe(msg, '请稍后再试');
+        }
+        return {
+          sessionKey: key,
+          shouldProcess: false,
+          message: msg,
+          rejectionReason: 'rate_limited',
+        };
       }
-      return {
-        sessionKey: key,
-        shouldProcess: false,
-        message: msg,
-        rejectionReason: 'rate_limited',
-      };
     }
 
     // G1: All payload types are now resolved by inbound.resolveContent in


### PR DESCRIPTION
Closes #117. Four operational-hardening fixes for the cron feature (#115), surfaced by an xhigh code review. None were critical-path data loss; all are robustness/correctness gaps.

## Fixes
**#1/#5 — fire outcome-awareness**
- Cron fires now **bypass the rate limit** in `session-router` (same rationale as the @mention-gate bypass — a scheduler-fired task is operator-scheduled, bounded by its interval, not spam). Before: a fire landing while the owner's bucket was exhausted was silently dropped *while its `nextRun` had already advanced* → the occurrence was lost with no signal.
- `CronScheduler.onFire` may now return a promise; the scheduler **logs an async fire failure attributed to the task id** (delivery errors were previously invisible/unattributed). `index.ts` gives cron a fire callback that rejects on handler error (vs `onInbound` which swallows), still tracked in `activeHandlers` for shutdown drain. Not awaited — fire stays non-blocking; a failure is logged, not retried (no error loop).

**#2 — ownerUid warning.** `startBot` warns when `sdk.cron` is on but `gateway.ownerUid` is empty (the owner-gate would otherwise reject every `cron_create` with no hint).

**#3 — reply-seq cursor.** A synthetic cron fire's `message_seq=0` no longer calls `setLastBotReplySeq(…, 0)` (which reset the history cursor and mislabeled real rows as all-`[new]`). Guarded to positive seq.

**#6 — strict ISO.** New `parseOneShot()` validates against a canonical ISO-8601 regex AND round-trips calendar fields, so a lenient rollover like `2026-13-13T…` (which `new Date()` shifts to a real instant) is **rejected** instead of firing at an unintended time.

## Refuted in review (verified non-issues, no change)
- "baseDir/`<id>` not created before first cron write" — `createAdapter` recursively `mkdir`s `baseDir/<id>/data` (creating `<id>`) before any cron use.
- "cap-check races" — the create cap is re-checked *inside* the atomic `update()` mutator.

**984 tests** (+7 for these fixes), lint (0 warnings), type-check, build green.