### PR TITLE
fix(session): correct group-context cursor data loss + resume/cap edge cases

### DIFF
--- a/src/__tests__/agent-bridge-query.test.ts
+++ b/src/__tests__/agent-bridge-query.test.ts
@@ -531,8 +531,8 @@ describe('queryAgent', () => {
     // The current request survives WHOLE at the end; the fallback was front-truncated.
     expect(retryPrompt.endsWith('THE REQUEST')).toBe(true);
     expect(retryPrompt).toContain('[… earlier context truncated]');
-    // Retry prompt stays within the 96 KB payload budget (+ small marker slack).
-    expect(Buffer.byteLength(retryPrompt, 'utf-8')).toBeLessThanOrEqual(98_304 + 64);
+    // Retry prompt stays within the 96 KB payload budget (marker bytes reserved).
+    expect(Buffer.byteLength(retryPrompt, 'utf-8')).toBeLessThanOrEqual(98_304);
   });
 
   it('does NOT recover (rethrows) when the error is unrelated to resume', async () => {
@@ -551,9 +551,10 @@ describe('queryAgent', () => {
     expect(mockQuery).toHaveBeenCalledTimes(1); // no retry
   });
 
-  it('does NOT retry if the stale error arrives AFTER output (no double reply)', async () => {
+  it('does NOT retry if the stale error arrives AFTER output (no double reply) but DOES clear the stale id', async () => {
     // Emit a chunk, THEN throw a resume-shaped error: recovery must not fire
-    // (we already streamed a partial reply; a retry would duplicate it).
+    // (we already streamed a partial reply; a retry would duplicate it). But the
+    // stale id is still cleared so the NEXT turn can recover (PR #120 review #4).
     const partial = createMockStream([]);
     partial[Symbol.asyncIterator] = async function* () {
       yield { type: 'assistant', session_id: 's', message: { content: [{ type: 'text', text: 'partial' }] } };
@@ -561,31 +562,36 @@ describe('queryAgent', () => {
     };
     mockQuery.mockReturnValue(partial);
     const chunks: string[] = [];
+    let resumeFailed = false;
     await expect(async () => {
       for await (const chunk of queryAgent('hi', makeConfig(), undefined, undefined, {
-        resume: 'sid', onResumeFailed: () => {},
+        resume: 'sid', onResumeFailed: () => { resumeFailed = true; },
       })) { chunks.push(chunk); }
     }).rejects.toThrow('No conversation found');
     expect(chunks).toEqual(['partial']);
     expect(mockQuery).toHaveBeenCalledTimes(1); // no retry after partial output
+    expect(resumeFailed).toBe(true); // but the stale id was cleared
   });
 
-  it('does NOT retry after a tool_use block then a resume error (no duplicated side effect)', async () => {
+  it('does NOT retry after a tool_use block then a resume error (no duplicated side effect) but DOES clear the stale id', async () => {
     // A tool_use is a side effect — if the stream throws a resume-shaped error
     // after it, retrying from scratch would re-run the tool. emitted.any must be
     // set on ANY assistant content, not just text (PR #120 review, non-blocking).
+    // The stale id is still cleared so the next turn recovers (PR #120 review #4).
     const partial = createMockStream([]);
     partial[Symbol.asyncIterator] = async function* () {
       yield { type: 'assistant', session_id: 's', message: { content: [{ type: 'tool_use', name: 'Bash', input: {} }] } };
       throw new Error('No conversation found with session ID: x');
     };
     mockQuery.mockReturnValue(partial);
+    let resumeFailed = false;
     await expect(async () => {
       for await (const _ of queryAgent('hi', makeConfig(), undefined, undefined, {
-        resume: 'sid', onResumeFailed: () => {},
+        resume: 'sid', onResumeFailed: () => { resumeFailed = true; },
       })) { void _; }
     }).rejects.toThrow('No conversation found');
     expect(mockQuery).toHaveBeenCalledTimes(1); // no retry after a tool_use side effect
+    expect(resumeFailed).toBe(true); // but the stale id was cleared
   });
 });
 

--- a/src/__tests__/file-inline-wrap.test.ts
+++ b/src/__tests__/file-inline-wrap.test.ts
@@ -289,8 +289,9 @@ describe('assembleUserMessage (PR #120: current message must always reach the mo
     expect(out.endsWith(body)).toBe(true);
     // Context was front-truncated with a marker.
     expect(out).toContain('[… earlier context truncated]');
-    // Within budget (+ small marker slack).
-    expect(Buffer.byteLength(out, 'utf-8')).toBeLessThanOrEqual(98_304 + 64);
+    // Within budget — the marker bytes are reserved, so the cap holds strictly
+    // (PR #120 review #5: previously overshot by the marker length).
+    expect(Buffer.byteLength(out, 'utf-8')).toBeLessThanOrEqual(98_304);
   });
 
   it('drops context entirely when the body alone meets/exceeds the budget', () => {

--- a/src/__tests__/group-context.test.ts
+++ b/src/__tests__/group-context.test.ts
@@ -341,6 +341,37 @@ describe('GroupContext consumption cursor', () => {
     const ctx2 = new GroupContext(adapter, 6000);
     expect(ctx2.getContextCursor('ch1')).toBe(42);
   });
+
+  it('buildContextSince keeps the NEWEST messages (not oldest) when the budget is tight (PR #120 review)', () => {
+    // A small budget that fits ~2 short lines. With the old ASC fetch + newest-
+    // within-budget loop the cursor would still advance past everything, dropping
+    // recent lines; the newest-first fetch makes the budget keep the latest ones.
+    const small = new GroupContext(adapter, 40);
+    for (let i = 1; i <= 6; i++) {
+      small.pushMessage('ch1', `u${i}`, 'A', `m${i}`, i);
+    }
+    const out = small.buildContextSince('ch1', 0);
+    // The most-recent message must be present; the oldest must be the one dropped.
+    expect(out.text).toContain('A：m6');
+    expect(out.text).not.toContain('A：m1');
+    // Cursor advances past the whole delta (highest existing id), so dropped-oldest
+    // lines are never re-shown on a later turn.
+    expect(out.lastId).toBe(small.getMaxMessageId('ch1'));
+  });
+
+  it('buildContextSince advances lastId past a backlog larger than the fetch limit', () => {
+    // maxWindowSize=100: with >100 unseen, the newest-first fetch returns the
+    // latest 100; lastId is the highest existing id so the cursor jumps past the
+    // entire backlog (the oldest beyond-window messages are intentionally skipped).
+    for (let i = 1; i <= 130; i++) {
+      ctx.pushMessage('ch1', 'u', 'A', `m${i}`, i);
+    }
+    const out = ctx.buildContextSince('ch1', 0);
+    // Newest message reaches the model.
+    expect(out.text).toContain('A：m130');
+    // lastId reflects the true max in the channel, not just the last fetched row.
+    expect(out.lastId).toBe(ctx.getMaxMessageId('ch1'));
+  });
 });
 
 // ─── G23: robot flag tracking ───────────────────────────────────────────────────────────────

--- a/src/agent-bridge.ts
+++ b/src/agent-bridge.ts
@@ -303,10 +303,11 @@ export async function* queryAgent(
 
   const stream = runStream(opts?.resume, userMessage);
 
-  // Drain one SDK stream, yielding assistant text. `suppressSessionId` skips the
-  // onSessionId report (used on the FIRST attempt only matters; on a recovery
-  // retry we DO want to capture+persist the fresh id). Tracks whether any text
-  // was emitted so the caller can decide if a mid-stream failure is recoverable.
+  // Drain one SDK stream, yielding assistant text. Reports the SDK session id once
+  // (the first message that carries one) via opts.onSessionId — on a recovery retry
+  // this captures+persists the fresh id. Sets `emitted.any` true once ANY assistant
+  // content block (text OR tool_use) is seen, so the caller can tell whether a
+  // mid-stream failure is still recoverable (recovery is only safe before output).
   async function* drainStream(
     s: ReturnType<typeof runStream>,
     emitted: { any: boolean },
@@ -401,6 +402,18 @@ export async function* queryAgent(
       const retryEmitted = { any: false };
       yield* drainStream(runStream(undefined, retryPrompt), retryEmitted);
       return;
+    }
+    // Resume error that surfaced AFTER output (emitted.any) — we must NOT retry
+    // (a tool_use side effect may already have run; a retry could duplicate it).
+    // But the stored id is still stale, so clear it here too: otherwise the next
+    // turn would resume the same dead id and fail again. Clearing lets the next
+    // turn start fresh and recover via fallbackHistoryBlock (PR #120 review #4).
+    if (opts?.resume && isResumeError(err)) {
+      try {
+        opts.onResumeFailed?.();
+      } catch (cbErr) {
+        console.error(`[cc-channel-octo] onResumeFailed callback threw: ${String(cbErr)}`);
+      }
     }
     throw err;
   }

--- a/src/file-inline-wrap.ts
+++ b/src/file-inline-wrap.ts
@@ -204,13 +204,22 @@ export function assembleUserMessage(context: string, body: string, maxBytes: num
   if (ctxBytes <= contextBudget) {
     return context + body;
   }
-  // Truncate context from the FRONT (keep the most-recent tail). Slice the buffer
-  // to the last `contextBudget` bytes; a leading partial UTF-8 sequence decodes to
+  // Truncate context from the FRONT (keep the most-recent tail). A truncation
+  // marker is prepended, so reserve its byte size from the budget too — otherwise
+  // the result would exceed maxBytes by the marker length (PR #120 review). Slice
+  // the buffer to the remaining bytes; a leading partial UTF-8 sequence decodes to
   // a replacement char which we strip so we never emit U+FFFD.
+  const marker = '[… earlier context truncated]\n';
+  const markerBytes = Buffer.byteLength(marker, 'utf-8');
+  const tailBudget = contextBudget - markerBytes;
+  if (tailBudget <= 0) {
+    // No room for any context once the marker is accounted for — drop it entirely.
+    return body;
+  }
   const ctxBuf = Buffer.from(context, 'utf-8');
-  const tail = ctxBuf.subarray(ctxBuf.length - contextBudget);
+  const tail = ctxBuf.subarray(ctxBuf.length - tailBudget);
   const decoded = new TextDecoder('utf-8').decode(tail).replace(/^�+/, '');
-  return '[… earlier context truncated]\n' + decoded + body;
+  return marker + decoded + body;
 }
 
 /** Exported for tests. */

--- a/src/group-context.ts
+++ b/src/group-context.ts
@@ -96,10 +96,14 @@ export class GroupContext {
     this.deleteOldMessages = this.adapter.prepare(
       'DELETE FROM group_messages WHERE channel_id = ? AND id NOT IN (SELECT id FROM group_messages WHERE channel_id = ? ORDER BY id DESC LIMIT ?)',
     );
-    // Cursor delta: messages strictly newer than the cursor, oldest-first, with
-    // their rowid so the caller can advance the cursor to the last included id.
+    // Cursor delta: messages strictly newer than the cursor, NEWEST-first so a
+    // backlog larger than the fetch limit keeps the most-recent messages (the
+    // relevant ones) rather than ancient ones. LIMIT (maxWindowSize=100) is <=
+    // deleteOldMessages' retained 200, so every fetchable row survives trimming.
+    // buildContextSince re-sorts the budget-selected slice into chronological
+    // order for display. Mirrors the in-memory buildContext rolling-window.
     this.selectMessagesSince = this.adapter.prepare(
-      'SELECT id, from_name, content FROM group_messages WHERE channel_id = ? AND id > ? ORDER BY id ASC LIMIT ?',
+      'SELECT id, from_name, content FROM group_messages WHERE channel_id = ? AND id > ? ORDER BY id DESC LIMIT ?',
     );
     this.selectMaxId = this.adapter.prepare(
       'SELECT MAX(id) AS maxId FROM group_messages WHERE channel_id = ?',
@@ -303,13 +307,17 @@ export class GroupContext {
 
   /**
    * Build a group-context block from messages NEWER than `sinceId` (the delta the
-   * model hasn't seen yet), oldest-first, within `maxContextChars`. Returns the
-   * block text (same `[Recent group messages]` format as buildContext) and the
-   * highest id included so the caller can advance the cursor. Empty text + the
+   * model hasn't seen yet), within `maxContextChars`. Returns the block text (same
+   * `[Recent group messages]` format as buildContext) and the highest id that
+   * EXISTS in the channel above `sinceId` (so the caller advances the cursor past
+   * the whole delta, including any oldest lines the char budget dropped — those
+   * are the least-relevant and are intentionally not re-shown). Empty text + the
    * unchanged cursor when there's nothing new.
    *
-   * Unlike buildContext (in-memory rolling window), this reads from the DB so the
-   * cursor delta is exact even across restarts / window eviction.
+   * Rows are fetched newest-first (so a backlog larger than the budget keeps the
+   * most-recent messages); the selected slice is reversed back to chronological
+   * order for display. Unlike buildContext (in-memory rolling window), this reads
+   * from the DB so the cursor delta is exact even across restarts / window eviction.
    */
   buildContextSince(channelId: string, sinceId: number): { text: string; lastId: number } {
     let rows: Array<{ id: number; from_name: string; content: string }>;
@@ -325,17 +333,19 @@ export class GroupContext {
     }
     if (rows.length === 0) return { text: '', lastId: sinceId };
 
+    // rows are newest-first; the highest id is the first row. Advance the cursor to
+    // it regardless of what the budget keeps, so we never re-show a line.
+    const lastId = rows[0].id;
+
     const header = '[Recent group messages]\n';
     const trailer = '\n';
     const budget = this.maxContextChars - header.length - trailer.length;
-    if (budget <= 0) return { text: '', lastId: sinceId };
+    if (budget <= 0) return { text: '', lastId };
 
-    // Keep the NEWEST messages within budget (walk newest→oldest), but advance
-    // the cursor to the newest included id regardless so we never re-show a line.
-    const lastId = rows[rows.length - 1].id;
+    // Walk newest→oldest (rows[0] is newest) keeping lines within budget.
     const selected: string[] = [];
     let used = 0;
-    for (let i = rows.length - 1; i >= 0; i--) {
+    for (let i = 0; i < rows.length; i++) {
       const line = `${rows[i].from_name}：${rows[i].content}`;
       const cost = line.length + (selected.length > 0 ? 1 : 0);
       if (used + cost > budget) break;
@@ -343,7 +353,7 @@ export class GroupContext {
       used += cost;
     }
     if (selected.length === 0) return { text: '', lastId };
-    selected.reverse();
+    selected.reverse(); // chronological order for display
     return { text: `${header}${selected.join('\n')}${trailer}`, lastId };
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -640,9 +640,18 @@ export async function handleMessage(
       // string from the end (as a naive single cap would) could drop the new
       // request entirely when prior history is large (review #120: oversized
       // firstTurnHistory). assembleUserMessage budgets context, preserving body.
+      //
+      // On the FIRST turn the injected history already covers recent group chatter
+      // (for a cold-start group, G4 backfill seeds the same messages the delta
+      // reads from group_messages), so adding the delta too would duplicate it
+      // (review #120). Prefer history on the first turn; fall back to the delta
+      // only when there is no history. Later turns carry only the delta. The
+      // cursor was already advanced above, so dropping the delta here does not
+      // strand messages — history covers them and they must not be re-shown.
+      const injectedContext = firstTurnHistory ? firstTurnHistory : groupContextBlock;
       const MAX_USER_LLM_BYTES = 98_304; // 96 KB
       const userContentForLLM = assembleUserMessage(
-        firstTurnHistory + groupContextBlock,
+        injectedContext,
         userBody,
         MAX_USER_LLM_BYTES,
       );


### PR DESCRIPTION
Follow-up review of #120 (frozen system prompt + SDK-session-owned conversation history) surfaced six defects in the new session-management / message-assembly paths. All fixed here.

## Findings & fixes

| # | Finding | Fix |
|---|---------|-----|
| **1+2** | **Group-context delta dropped recent messages.** `selectMessagesSince` fetched the *oldest* 100 unseen rows (`ORDER BY id ASC`), so the char-budget loop surfaced ancient backlog while genuinely-recent messages (beyond row 100, or beyond the ~6KB budget) were never fetched — then the cursor advanced past them, losing them permanently. `deleteOldMessages` (retains 200) could also delete un-injected rows. | Fetch **newest-first** (`ORDER BY id DESC`), matching the in-memory `buildContext` rolling-window. Budget now keeps the most-recent messages; `LIMIT 100 ≤ retained 200` so no fetchable row is trimmed prematurely; `lastId` reflects the true channel max. |
| **3** | **First group turn double-injected the same messages** — G4 SQLite backfill (history) and the group-context delta both carried them into one user message. | Prefer history on the first turn; use the delta only when there is no history. Cursor is already advanced, so nothing is stranded. |
| **4** | **Stale SDK session id leaked** when a resume error surfaced *after* output (`emitted.any`): `queryAgent` rethrew without clearing the dead id, forcing the next turn to fail too. | Clear the id via `onResumeFailed` for any resume-shaped error before rethrowing (still no retry — avoids duplicating a tool side effect — but the next turn recovers cleanly). |
| **5** | **`assembleUserMessage` overshot `maxBytes`** by the truncation marker's length (prepended without reserving its bytes). | Reserve the marker bytes from the context budget so the cap holds strictly. |
| **6** | **Stale `drainStream` docstring** referenced a nonexistent `suppressSessionId` param. | Rewritten to match the real `(s, emitted)` signature. |

One sweep candidate was dropped as a false positive: the group delta is **not** lost on stale-resume recovery — on a non-first turn it is part of `userMessage`, which the retry re-uses verbatim.

## Tests
- +4 regression cases: cursor newest-first within a tight budget, backlog larger than the fetch limit, stale-id clear on both no-retry paths (after-text and after-tool_use).
- Tightened cap assertions to strict `≤ 98_304` (previously `+64` slack).
- Full suite green: **996 passed**. `lint` + `type-check` + `build` clean.

## Files
- `src/group-context.ts` — DESC fetch + `buildContextSince` rework
- `src/index.ts` — first-turn history-vs-delta selection
- `src/agent-bridge.ts` — clear stale id on no-retry resume error + docstring
- `src/file-inline-wrap.ts` — reserve marker bytes in `assembleUserMessage`
- tests: `group-context`, `agent-bridge-query`, `file-inline-wrap`

🤖 Generated with [Claude Code](https://claude.com/claude-code)