### PR TITLE
fix(security): protocol + SSRF-adjacent hardening (review #2–#5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,28 @@ While the major version is `0`, minor releases may carry breaking changes.
 
 ## [Unreleased]
 
+### Security
+
+- **WebSocket transport must be `wss://`** — the WuKongIM payload layer is
+  AES-CBC without an auth tag, so transport integrity is the only tamper guarantee.
+  `gateway.connect()` now refuses a plaintext `ws://` endpoint for any non-loopback
+  host (`isAllowedWsUrl` in `url-policy.ts`); `ws://localhost` stays allowed for
+  local dev / a co-located TLS-terminating proxy.
+- **Binary protocol decoder bounds-checked** — `Decoder` (`octo/socket.ts`) now
+  throws `RangeError` on any over-read (truncated packet, or a string length field
+  exceeding the remaining buffer) instead of silently reading `undefined`
+  (→ 0/NaN coercion → corrupt parses, wrong messageID/seq → ack mismatch). The
+  packet-decode loop already catches and reconnects, so a malformed packet now
+  fails cleanly.
+- **Partial agent output no longer lost on stream error** — if the agent stream
+  throws mid-delivery, `StreamRelay.deliver` now flushes the already-accumulated
+  text to the channel before re-throwing, instead of dropping a real partial reply.
+- **`@all` / `@所有人` broadcast detection tightened** — the trailing-boundary
+  check used `[^\w]`, so `@all-members` / `@all.foo` wrongly triggered a
+  broadcast-to-everyone. It now excludes name-continuation chars (`-`, `.`, CJK),
+  while still matching a standalone token followed by space, CJK punctuation, or
+  end-of-string.
+
 ### Changed
 
 - **Frozen system prompt + SDK-session-owned history** — the bot's

--- a/src/__tests__/mention-utils.test.ts
+++ b/src/__tests__/mention-utils.test.ts
@@ -200,6 +200,20 @@ describe('resolveMentions', () => {
     expect(result.mentionAll).toBe(true);
   });
 
+  it('does NOT treat @all-foo / @all.x as a broadcast (boundary fix)', () => {
+    // Hyphen/dot are name-continuation chars; `@all-members` is a literal name,
+    // not the broadcast token. Previously `[^\w]` matched and spammed everyone.
+    expect(resolveMentions('notify @all-members now').mentionAll).toBe(false);
+    expect(resolveMentions('see @all.hands doc').mentionAll).toBe(false);
+    expect(resolveMentions('@allen replied').mentionAll).toBe(false);
+  });
+
+  it('still detects @all followed by non-name punctuation (incl. CJK)', () => {
+    expect(resolveMentions('@all, please review').mentionAll).toBe(true);
+    expect(resolveMentions('@所有人，注意').mentionAll).toBe(true);
+    expect(resolveMentions('@all').mentionAll).toBe(true);
+  });
+
   it('returns empty entities when no memberMap and no structured', () => {
     const result = resolveMentions('@Alice hi');
     expect(result.mentionUids).toEqual([]);

--- a/src/__tests__/q34-q37-q38.test.ts
+++ b/src/__tests__/q34-q37-q38.test.ts
@@ -117,6 +117,57 @@ describe("encodeVariableLength(0) (Q37)", () => {
   });
 });
 
+// Decoder bounds checks (PR review — protocol hardening):
+// a truncated/malformed packet must THROW (RangeError) instead of silently
+// reading `undefined` (→ 0/NaN coercion → corrupt parses, wrong messageID/seq).
+describe("Decoder bounds guards", () => {
+  it("readByte throws past the end", async () => {
+    const { Decoder } = await import("../octo/socket.js");
+    const dec = new Decoder(new Uint8Array([]));
+    expect(() => dec.readByte()).toThrow(RangeError);
+  });
+
+  it("readInt16 throws on a 1-byte buffer", async () => {
+    const { Decoder } = await import("../octo/socket.js");
+    const dec = new Decoder(new Uint8Array([0x01]));
+    expect(() => dec.readInt16()).toThrow(/out-of-bounds/);
+  });
+
+  it("readInt32 throws on a 2-byte buffer", async () => {
+    const { Decoder } = await import("../octo/socket.js");
+    const dec = new Decoder(new Uint8Array([0x01, 0x02]));
+    expect(() => dec.readInt32()).toThrow(/out-of-bounds/);
+  });
+
+  it("readInt64String throws on a 4-byte buffer", async () => {
+    const { Decoder } = await import("../octo/socket.js");
+    const dec = new Decoder(new Uint8Array([0x01, 0x02, 0x03, 0x04]));
+    expect(() => dec.readInt64String()).toThrow(/out-of-bounds/);
+  });
+
+  it("readString throws when the declared length exceeds the remaining buffer", async () => {
+    const { Decoder } = await import("../octo/socket.js");
+    // length prefix 0xFFFF (65535) but only 2 bytes of body follow → over-read.
+    const dec = new Decoder(new Uint8Array([0xFF, 0xFF, 0x61, 0x62]));
+    expect(() => dec.readString()).toThrow(/out-of-bounds/);
+  });
+
+  it("readString still returns a correctly-sized string", async () => {
+    const { Decoder } = await import("../octo/socket.js");
+    // length 2 + "hi"
+    const dec = new Decoder(new Uint8Array([0x00, 0x02, 0x68, 0x69]));
+    expect(dec.readString()).toBe("hi");
+  });
+
+  it("readByte/readInt16/readInt32 read correctly within bounds", async () => {
+    const { Decoder } = await import("../octo/socket.js");
+    const dec = new Decoder(new Uint8Array([0x07, 0x01, 0x02, 0x00, 0x00, 0x01, 0x00]));
+    expect(dec.readByte()).toBe(0x07);
+    expect(dec.readInt16()).toBe(0x0102);
+    expect(dec.readInt32()).toBe(0x00000100);
+  });
+});
+
 // Q38 aesIV salt length warning:
 // Q1 cleanup — the placeholder `expect(true).toBe(true)` test that previously
 // lived here is removed. The warning is now exercised by

--- a/src/__tests__/stream-relay.test.ts
+++ b/src/__tests__/stream-relay.test.ts
@@ -269,7 +269,7 @@ describe("StreamRelay", () => {
     }
   });
 
-  it("cleans up typing timer when source iterable throws", async () => {
+  it("flushes partial output and re-throws when the source iterable throws mid-stream", async () => {
     async function* throwingChunks(): AsyncIterable<string> {
       yield "partial";
       throw new Error("source exploded");
@@ -281,11 +281,14 @@ describe("StreamRelay", () => {
     await vi.runAllTimersAsync();
     await guarded;
 
+    // The error still propagates so the caller's error path runs…
     await expect(promise).rejects.toThrow("source exploded");
 
-    // No sendMessage should have been called (source threw before accumulation completed).
+    // …but the partial output accumulated before the throw is NOT dropped — it is
+    // flushed to the channel (PR review: previously a real partial reply was lost).
     const sendCalls = mockState.calls.filter((c) => c.fn === "sendMessage");
-    expect(sendCalls.length).toBe(0);
+    expect(sendCalls.length).toBe(1);
+    expect(sendCalls[0].args.content).toBe("partial");
 
     // Typing timer should be cleaned up.
     const countAfter = mockState.calls.filter((c) => c.fn === "sendTyping").length;

--- a/src/__tests__/url-policy.test.ts
+++ b/src/__tests__/url-policy.test.ts
@@ -7,6 +7,7 @@ import {
   isPrivateOrLocalAddress,
   assertPublicUrl,
   isAllowedApiUrl,
+  isAllowedWsUrl,
 } from '../url-policy.js';
 
 describe('isPrivateOrLocalAddress (S5 hex v4-mapped fix)', () => {
@@ -162,5 +163,36 @@ describe('isAllowedApiUrl (S6)', () => {
     ['not-a-url', false],
   ])('%s → %s', (url, expected) => {
     expect(isAllowedApiUrl(url)).toBe(expected);
+  });
+});
+
+describe('isAllowedWsUrl (unauthenticated-payload transport guard)', () => {
+  it.each([
+    // wss to public hosts — allowed
+    ['wss://im.example.com', true],
+    ['wss://im.example.com:443/ws', true],
+    ['wss://8.8.8.8/', true],
+    // ws to localhost — allowed for local dev / co-located TLS proxy
+    ['ws://localhost', true],
+    ['ws://127.0.0.1', true],
+    ['ws://[::1]', true],
+    ['ws://localhost:5200/ws', true],
+    // ws to any other host — rejected (plaintext + unauthenticated payload = MITM)
+    ['ws://im.example.com', false],
+    ['ws://8.8.8.8/', false],
+    // wss to a PRIVATE IP — rejected (suspicious, mirrors isAllowedApiUrl)
+    ['wss://127.0.0.1/', false],
+    ['wss://10.0.0.1/', false],
+    ['wss://169.254.169.254/', false],
+    ['wss://[::1]/', false],
+    // http(s)/ftp/file — rejected (not a ws scheme)
+    ['https://im.example.com/', false],
+    ['http://localhost/', false],
+    ['ftp://example.com/', false],
+    // malformed — rejected
+    ['', false],
+    ['not-a-url', false],
+  ])('%s → %s', (url, expected) => {
+    expect(isAllowedWsUrl(url)).toBe(expected);
   });
 });

--- a/src/gateway.ts
+++ b/src/gateway.ts
@@ -4,6 +4,7 @@
 
 import { WKSocket } from './octo/socket.js';
 import { registerBot, sendHeartbeat } from './octo/api.js';
+import { isAllowedWsUrl } from './url-policy.js';
 import type { Config } from './config.js';
 import type { BotMessage } from './octo/types.js';
 import { existsSync, writeFileSync, unlinkSync, readFileSync, mkdirSync } from 'node:fs';
@@ -119,6 +120,17 @@ export class OctoGateway {
       throw new Error('OctoGateway.connect() called before register()');
     }
     const reg = this.registration;
+    // SECURITY: the AES-CBC payload layer is unauthenticated, so transport
+    // integrity is the only tamper guarantee. Refuse a plaintext ws:// endpoint
+    // for any non-loopback host (a MITM could bit-flip ciphertext undetected).
+    // wss:// is required in production; ws://localhost is allowed for local dev.
+    if (!isAllowedWsUrl(reg.ws_url)) {
+      throw new Error(
+        `OctoGateway.connect(): refusing insecure WebSocket URL "${reg.ws_url}" — ` +
+        `wss:// is required (ws:// permitted only for localhost). The message layer ` +
+        `is unauthenticated, so an unencrypted transport allows undetected tampering.`,
+      );
+    }
     this.socket = this.createSocket(reg.ws_url, reg.robot_id, reg.im_token);
     this.socket.connect();
     this.startServices();

--- a/src/mention-utils.ts
+++ b/src/mention-utils.ts
@@ -238,8 +238,17 @@ export function resolveMentions(
   entities.sort((a, b) => a.offset - b.offset);
   const mentionUids = entities.map(e => e.uid);
 
-  // @all / @所有人 detection.
-  const mentionAll = /(?:^|(?<=\s))@(?:all|所有人)(?=\s|[^\w]|$)/i.test(finalContent);
+  // @all / @所有人 detection. The trailing boundary must be a NON-name char (or
+  // end-of-string), NOT a generic `[^\w]`. The old `[^\w]` treated `@all-members`
+  // / `@allen`… wait, `@allen` was already blocked by `[^\w]` (e is `\w`); the
+  // real false positive was `@all-foo` / `@all.x` (hyphen/dot are `[^\w]`),
+  // wrongly broadcasting to everyone in a large group. Excluding the name-char
+  // class (which includes `-` and `.`) fixes that while still matching a real
+  // standalone token followed by space, CJK punctuation (`@所有人，`), `!`, or EOS.
+  const mentionAll = new RegExp(
+    `(?:^|(?<=\\s))@(?:all|所有人)(?!${NAME_CHAR_RE.source})`,
+    'i',
+  ).test(finalContent);
 
   return { finalContent, mentionUids, mentionEntities: entities, mentionAll };
 }

--- a/src/octo/socket.ts
+++ b/src/octo/socket.ts
@@ -83,15 +83,32 @@ export class Decoder {
   private offset = 0;
   constructor(private data: Uint8Array) {}
 
-  readByte(): number { return this.data[this.offset++]; }
+  /**
+   * Bounds guard: every reader calls this before touching the buffer so a
+   * truncated/malformed packet throws a typed error instead of silently reading
+   * `undefined` (which coerces to 0/NaN and produces corrupt parses — wrong
+   * messageID/seq → ack mismatch, message loss/dup). The packet-decode caller
+   * wraps decode in try/catch, so a throw cleanly rejects the bad packet.
+   */
+  private require(n: number): void {
+    if (this.offset + n > this.data.length) {
+      throw new RangeError(
+        `WKDecoder: out-of-bounds read (need ${n} byte(s) at offset ${this.offset}, have ${this.data.length})`,
+      );
+    }
+  }
+
+  readByte(): number { this.require(1); return this.data[this.offset++]; }
 
   readInt16(): number {
+    this.require(2);
     const v = (this.data[this.offset] << 8) | this.data[this.offset + 1];
     this.offset += 2;
     return v;
   }
 
   readInt32(): number {
+    this.require(4);
     const v =
       (this.data[this.offset] << 24) |
       (this.data[this.offset + 1] << 16) |
@@ -103,6 +120,7 @@ export class Decoder {
 
   readInt64String(): string {
     // Read 8 bytes as a big-endian unsigned integer string
+    this.require(8);
     let n = BigInt(0);
     for (let i = 0; i < 8; i++) {
       n = (n << 8n) | BigInt(this.data[this.offset + i]);
@@ -112,6 +130,7 @@ export class Decoder {
   }
 
   readInt64BigInt(): bigint {
+    this.require(8);
     let n = BigInt(0);
     for (let i = 0; i < 8; i++) {
       n = (n << 8n) | BigInt(this.data[this.offset + i]);
@@ -123,6 +142,10 @@ export class Decoder {
   readString(): string {
     const len = this.readInt16();
     if (len <= 0) return "";
+    // Guard the declared length against the remaining buffer so an oversized
+    // length field can't over-read (slice() would silently short-return and
+    // leave the offset past the end, corrupting every subsequent field).
+    this.require(len);
     const slice = this.data.slice(this.offset, this.offset + len);
     this.offset += len;
     return uintToString(Array.from(slice));

--- a/src/stream-relay.ts
+++ b/src/stream-relay.ts
@@ -178,20 +178,30 @@ export class StreamRelay {
       // Accumulate all chunks, with truncation guard (Q32).
       let accumulated = "";
       let truncated = false;
-      for await (const chunk of chunks) {
-        accumulated += chunk;
-        // Q32: Stop accumulating once limit is reached to prevent unbounded memory.
-        if (accumulated.length > maxResponseChars) {
-          // P1-6: cut at code-unit boundary, but back off if it lands inside
-          // a surrogate pair (would produce an orphan high surrogate = invalid
-          // Unicode). Mirrors splitMessage's hard-cut surrogate guard.
-          let cutAt = maxResponseChars;
-          const code = accumulated.charCodeAt(cutAt - 1);
-          if (code >= 0xD800 && code <= 0xDBFF) cutAt--;
-          accumulated = accumulated.slice(0, cutAt) + TRUNCATION_SUFFIX;
-          truncated = true;
-          break;
+      // If the agent stream throws mid-way (network blip, non-recoverable SDK
+      // error after partial output), we still want to deliver what we have
+      // instead of dropping a real partial reply on the floor — then re-throw so
+      // the caller's error path still runs. Capture the error and flush below.
+      let streamError: unknown;
+      try {
+        for await (const chunk of chunks) {
+          accumulated += chunk;
+          // Q32: Stop accumulating once limit is reached to prevent unbounded memory.
+          if (accumulated.length > maxResponseChars) {
+            // P1-6: cut at code-unit boundary, but back off if it lands inside
+            // a surrogate pair (would produce an orphan high surrogate = invalid
+            // Unicode). Mirrors splitMessage's hard-cut surrogate guard.
+            let cutAt = maxResponseChars;
+            const code = accumulated.charCodeAt(cutAt - 1);
+            if (code >= 0xD800 && code <= 0xDBFF) cutAt--;
+            accumulated = accumulated.slice(0, cutAt) + TRUNCATION_SUFFIX;
+            truncated = true;
+            break;
+          }
         }
+      } catch (err) {
+        streamError = err;
+        console.error(`[stream-relay] agent stream threw after ${accumulated.length} char(s); flushing partial output: ${String(err)}`);
       }
       if (truncated) {
         console.warn(`[stream-relay] Response truncated at ${maxResponseChars} chars`);
@@ -265,6 +275,11 @@ export class StreamRelay {
         }
       }
       // If accumulated is empty, the agent produced no output — nothing to send.
+      // If the stream threw mid-way, we've now flushed whatever partial text was
+      // accumulated; re-throw so the caller's error handling still runs (it will
+      // not double-send — the partial was delivered here, the caller only logs /
+      // surfaces the failure).
+      if (streamError !== undefined) throw streamError;
     } finally {
       clearInterval(typingTimer);
     }

--- a/src/url-policy.ts
+++ b/src/url-policy.ts
@@ -274,3 +274,33 @@ export function isAllowedApiUrl(url: string): boolean {
     return false;
   }
 }
+
+/**
+ * Boot-time WebSocket URL validation — the transport-integrity counterpart to
+ * isAllowedApiUrl.
+ *
+ * The WuKongIM payload layer is AES-CBC WITHOUT an authentication tag, so message
+ * integrity rests entirely on the transport. An unencrypted `ws://` link lets a
+ * network attacker bit-flip ciphertext undetected (silent corruption / DoS).
+ * Require `wss://` for any non-loopback host; permit plaintext `ws://` only to an
+ * explicit localhost form (local dev / a co-located reverse proxy that terminates
+ * TLS). Mirrors the http→localhost-only carve-out in isAllowedApiUrl.
+ */
+export function isAllowedWsUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    const host = parsed.hostname.toLowerCase();
+    const bareHost = host.startsWith("[") && host.endsWith("]") ? host.slice(1, -1) : host;
+
+    if (parsed.protocol === "wss:") {
+      if (isIP(bareHost) && isPrivateOrLocalAddress(bareHost)) return false;
+      return true;
+    }
+    if (parsed.protocol === "ws:") {
+      return host === "localhost" || host === "127.0.0.1" || host === "[::1]";
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Why

Hardening batch from the full-codebase review. (#1 — the Card/File prompt-injection fix — ships separately in #128.) None of these are exploitable in the current happy path, but they close real gaps at the top-tier-OSS bar.

## Changes

### #2 — WebSocket transport must be `wss://`
The WuKongIM payload layer is **AES-CBC without an authentication tag**, so transport integrity is the *only* tamper guarantee. A plaintext `ws://` link lets a network MITM bit-flip ciphertext undetected (silent corruption / DoS). `gateway.connect()` now refuses `ws://` for any non-loopback host via a new `isAllowedWsUrl` in `url-policy.ts`; `ws://localhost` stays allowed for local dev / a co-located TLS-terminating proxy. Mirrors the `http→localhost-only` carve-out in `isAllowedApiUrl`.

### #3 — Binary `Decoder` bounds checks
Every reader now calls a `require(n)` guard that throws `RangeError` on over-read; `readString` also validates the declared length against the remaining buffer. Previously a truncated/malformed packet read `undefined` → `0`/`NaN` coercion → corrupt parses (wrong messageID/seq → ack mismatch, message loss/dup). The packet-decode loop already catches and reconnects, so a bad packet now fails cleanly.

### #5 — Partial agent output no longer lost on stream error
If the agent stream throws mid-delivery, `StreamRelay.deliver` now flushes the already-accumulated text to the channel **before** re-throwing (the caller's error path still runs), instead of silently dropping a real partial reply.

### #4 — `@all` / `@所有人` broadcast detection tightened
The trailing-boundary check used `[^\w]`, so `@all-members` / `@all.foo` wrongly triggered broadcast-to-everyone. Now excludes name-continuation chars (`-`, `.`, CJK) while still matching a standalone token followed by space, CJK punctuation (`@所有人，`), or end-of-string.

## Deferred: #6 (DNS-rebinding IP pinning)
A correct fix needs undici's custom dispatcher to pin the validated IP while preserving TLS SNI — `undici` isn't importable as a bare specifier in this Node build, so connecting to an IP literal would break `https` cert validation. That's a standalone change (new dependency + dispatcher + tests). The existing **per-hop re-validation** in `fetchWithRedirectGuard` + the documented residual-risk note remain in place. Tracking for a follow-up.

## Tests
+Decoder bounds suite, +`isAllowedWsUrl` table, +`@all` boundary cases; updated the stream-relay throw test to assert partial-flush. Full suite green: **962 passed**. type-check + lint + build clean. (All existing `ws_url` test fixtures are `wss://` or `ws://localhost` — none regress.)

Refs #91.

🤖 Generated with [Claude Code](https://claude.com/claude-code)