### PR TITLE
chore: single-source byte cap + trim redundant work in user-message assembly

### DIFF
--- a/src/file-inline-wrap.ts
+++ b/src/file-inline-wrap.ts
@@ -177,6 +177,14 @@ export function truncateUtf8ByBytes(input: string, maxBytes: number): {
 }
 
 /**
+ * Hard cap on the assembled user-role payload (96 KB). Lives next to
+ * `assembleUserMessage`, the function it governs, so callers import one shared
+ * value instead of re-declaring the literal (it previously appeared in both
+ * index.ts and agent-bridge.ts).
+ */
+export const MAX_USER_LLM_BYTES = 98_304; // 96 KB
+
+/**
  * Assemble a user-role message from injected `context` (first-turn history +
  * group-context delta, or a stale-resume fallback history block) and the current
  * message `body`, byte-capped at `maxBytes`.
@@ -188,10 +196,20 @@ export function truncateUtf8ByBytes(input: string, maxBytes: number): {
  * dropped entirely and the body is byte-capped as a last resort. This prevents a
  * large prior-history block from evicting the current message (PR #120 review).
  */
+/**
+ * Byte-cap the body alone as a last resort, appending a truncation notice when it
+ * was actually cut. Used by the two assembleUserMessage paths where context is
+ * dropped entirely (no context supplied, or the body alone fills the budget) so
+ * the current message still reaches the model.
+ */
+function capBodyToBudget(body: string, maxBytes: number): string {
+  const { truncated, wasTruncated } = truncateUtf8ByBytes(body, maxBytes);
+  return wasTruncated ? truncated + '\n[… user input truncated to cap]' : body;
+}
+
 export function assembleUserMessage(context: string, body: string, maxBytes: number): string {
   if (!context) {
-    const { truncated, wasTruncated } = truncateUtf8ByBytes(body, maxBytes);
-    return wasTruncated ? truncated + '\n[… user input truncated to cap]' : body;
+    return capBodyToBudget(body, maxBytes);
   }
   // Positive anchor (#132): the background context above is READ-ONLY; this line
   // demarcates the actual new request so the model responds to it ONLY and does
@@ -205,8 +223,7 @@ export function assembleUserMessage(context: string, body: string, maxBytes: num
   if (bodyBytes >= maxBytes) {
     // Pathological: the body alone fills/overflows the budget. Drop context
     // entirely and cap the body — the current message still gets through.
-    const { truncated, wasTruncated } = truncateUtf8ByBytes(body, maxBytes);
-    return wasTruncated ? truncated + '\n[… user input truncated to cap]' : body;
+    return capBodyToBudget(body, maxBytes);
   }
   const contextBudget = maxBytes - bodyBytes;
   const ctxBytes = Buffer.byteLength(context, 'utf-8');

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ import { loadGroupConfig } from './group-config.js';
 import { CronStore } from './cron-store.js';
 import { CronScheduler } from './cron-scheduler.js';
 import { createCronToolServer, CRON_TOOL_SERVER_NAME, type CronSessionCoords } from './cron-tool.js';
-import { buildInlinedFileBody, truncateUtf8ByBytes, assembleUserMessage } from './file-inline-wrap.js';
+import { buildInlinedFileBody, truncateUtf8ByBytes, assembleUserMessage, MAX_USER_LLM_BYTES } from './file-inline-wrap.js';
 import { join } from 'node:path';
 import { mkdirSync } from 'node:fs';
 import { pathToFileURL } from 'node:url';
@@ -656,7 +656,6 @@ export async function handleMessage(
       // cursor was already advanced above, so dropping the delta here does not
       // strand messages — history covers them and they must not be re-shown.
       const injectedContext = firstTurnHistory ? firstTurnHistory : groupContextBlock;
-      const MAX_USER_LLM_BYTES = 98_304; // 96 KB
       const userContentForLLM = assembleUserMessage(
         injectedContext,
         userBody,
@@ -673,11 +672,11 @@ export async function handleMessage(
       // anchor, reviving #132 on the recovery path (PR #133 review: Jerry-Xin /
       // Steve / yujiawei, all reproduced). Assembled the same way as a first turn:
       // history is the context, userBody is the anchored body — one clean anchor.
-      const fallbackRetryPrompt = assembleUserMessage(
-        historyBlock,
-        userBody,
-        MAX_USER_LLM_BYTES,
-      );
+      // Only built when resuming — it's the sole consumer (sessionOpts below), so a
+      // first turn (no resume) would otherwise assemble it just to discard it.
+      const fallbackRetryPrompt = resume
+        ? assembleUserMessage(historyBlock, userBody, MAX_USER_LLM_BYTES)
+        : undefined;
 
       // --- Query agent with structural role separation (Q3 fix) ---
       // userContentForLLM → user role (prompt), history + context → system role (systemPrompt)


### PR DESCRIPTION
Closes #135

## What & why

Quality-only follow-up to #133 (issue #132). A `/simplify` pass over the merged user-message-assembly path surfaced three behavior-preserving cleanups. **No functional change** — 975 tests pass unchanged.

## Changes

1. **Single-source `MAX_USER_LLM_BYTES`.** The 96 KB cap was a magic literal re-declared locally in `index.ts` (its sibling copy in `agent-bridge.ts` was already removed by #133). Exported it from `file-inline-wrap.ts` — next to `assembleUserMessage`, the function it governs, alongside the existing `MAX_INLINE_WRAP_BYTES` — and import it in `index.ts`.

2. **Gate `fallbackRetryPrompt` on `resume`.** It is only consumed inside the `resume ? {...}` branch of `sessionOpts`, but was assembled unconditionally — so every first turn (no resume) built it just to discard it. Now `resume ? assembleUserMessage(...) : undefined`, skipping a full assemble on the cold-start path. Behavior-identical (sole consumer is resume-only).

3. **Extract `capBodyToBudget()`.** The no-context and body-overflow paths of `assembleUserMessage` shared an identical "truncate body, append notice" block. Pulled into a 4-line helper. Byte-budget semantics unchanged.

## Testing
- `npm test` → **975 passed (50 files)**
- `npm run type-check` clean · `npm run lint` (`--max-warnings 0`) clean

## Deliberately NOT in scope (follow-up)
The `/simplify` review's biggest finding — **marker-name drift**: `SECURITY_PROMPT_PREFIX` in `agent-bridge.ts` still names `[Group context]`/`[Conversation history]` while renderers now emit `[Recent group messages]`/`[Prior conversation history]` (pre-existing from the #120 refactor). The right-altitude fix (a shared marker registry that drives both `SECTION_MARKER_RE` and the system prompt) touches the load-bearing security regex and is a correctness-of-instruction change — out of scope for a quality-only PR. Tracking separately.
