### PR TITLE
feat(release): publish to npm as @mininglamp-oss/cc-channel-octo

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,94 @@
+name: npm Publish
+
+# Publishes the package to the public npm registry.
+#
+# Trigger: when a GitHub Release is published (the release-publish workflow flips
+# the draft to published, which fires `release: published`), or manually via
+# workflow_dispatch with an explicit tag.
+#
+# Auth: uses the NPM_TOKEN repository secret (an npm automation/granular token
+# with publish rights on the @mininglamp-oss scope). Provenance is attached via
+# OIDC (`id-token: write` + publishConfig.provenance:true in package.json), so
+# the published version carries a verifiable build-origin attestation.
+#
+# Safety: the job refuses to publish unless the tag's `vX.Y.Z` matches the
+# version in package.json, so a mismatched tag can never push a wrong version.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to publish (e.g. v1.0.0). Must be an existing tag."
+        required: true
+        type: string
+
+permissions: {}
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write # required for npm provenance (OIDC)
+    steps:
+      - name: Resolve tag
+        id: tag
+        env:
+          EVENT_TAG: ${{ github.event.release.tag_name }}
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          TAG="${EVENT_TAG:-$INPUT_TAG}"
+          if [ -z "$TAG" ]; then
+            echo "::error::No tag resolved from release event or dispatch input."
+            exit 1
+          fi
+          # Strict semver tag (mirrors the org release-publish regex).
+          if ! printf '%s' "$TAG" | grep -Eq \
+            '^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*))?([+][0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'; then
+            echo "::error::Tag '$TAG' is not strict semver (vMAJOR.MINOR.PATCH[-prerelease])"
+            exit 1
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "Resolved tag: $TAG"
+
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ steps.tag.outputs.tag }}
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '22'
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Verify tag matches package.json version
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          EXPECTED="v${PKG_VERSION}"
+          if [ "$TAG" != "$EXPECTED" ]; then
+            echo "::error::Tag '$TAG' does not match package.json version '$EXPECTED'. Refusing to publish."
+            exit 1
+          fi
+          echo "Tag matches package.json: $EXPECTED"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm test
+
+      - name: Publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish

--- a/README.md
+++ b/README.md
@@ -38,6 +38,23 @@ Users talk to a bot in Octo (DM or group @mention). The bot sends messages to Cl
 
 ### Install & Run
 
+**Option A — install from npm (recommended):**
+
+```bash
+npm install -g @mininglamp-oss/cc-channel-octo
+# or run without installing:
+npx @mininglamp-oss/cc-channel-octo
+```
+
+This installs the `cc-channel-octo` command (prebuilt — no compile step). Skip
+straight to creating the config files below, then run `cc-channel-octo`.
+
+To use it as a library instead, `npm install @mininglamp-oss/cc-channel-octo`
+and import from it; the Claude Agent SDK is a peer dependency, so install
+`@anthropic-ai/claude-agent-sdk` alongside it.
+
+**Option B — build from source:**
+
 ```bash
 git clone https://github.com/Mininglamp-OSS/cc-channel-octo.git
 cd cc-channel-octo
@@ -94,7 +111,9 @@ Per-bot `~/.cc-channel-octo/default/config.json`:
 Start the gateway:
 
 ```bash
-npm start
+npm start                      # from source (Option B)
+# or, if installed from npm (Option A):
+cc-channel-octo
 ```
 
 The bot is now online. Send it a DM or @mention it in a group.

--- a/package.json
+++ b/package.json
@@ -1,11 +1,34 @@
 {
-  "name": "cc-channel-octo",
+  "name": "@mininglamp-oss/cc-channel-octo",
   "version": "1.0.0",
   "description": "Bridge Claude Code (via Claude Agent SDK) to Octo IM — independent Node.js gateway",
   "license": "Apache-2.0",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "bin": {
+    "cc-channel-octo": "dist/index.js"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "CHANGELOG.md",
+    "LICENSE",
+    "config.example.json",
+    "config.bot.example.json"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Mininglamp-OSS/cc-channel-octo.git"
+  },
+  "homepage": "https://github.com/Mininglamp-OSS/cc-channel-octo#readme",
+  "bugs": {
+    "url": "https://github.com/Mininglamp-OSS/cc-channel-octo/issues"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
@@ -15,6 +38,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
+    "prepublishOnly": "npm run build",
     "prepare": "husky || true"
   },
   "dependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 /**
  * cc-channel-octo — Entry point.
  * Bridge Claude Code (via Claude Agent SDK) to Octo IM.
@@ -30,8 +31,8 @@ import { CronScheduler } from './cron-scheduler.js';
 import { createCronToolServer, CRON_TOOL_SERVER_NAME, type CronSessionCoords } from './cron-tool.js';
 import { buildInlinedFileBody, truncateUtf8ByBytes, assembleUserMessage, MAX_USER_LLM_BYTES } from './file-inline-wrap.js';
 import { join } from 'node:path';
-import { mkdirSync } from 'node:fs';
-import { pathToFileURL } from 'node:url';
+import { mkdirSync, realpathSync } from 'node:fs';
+import { pathToFileURL, fileURLToPath } from 'node:url';
 
 async function main(): Promise<void> {
   // --- Q8: Global unhandled rejection handler ---
@@ -982,12 +983,28 @@ function seedHistoryFromApi(
 }
 
 // Only auto-start the gateway when this module is run directly (production
-// entrypoint), NOT when it is imported (e.g. tests importing handleMessage).
+// entrypoint or the installed `cc-channel-octo` bin), NOT when it is imported
+// (e.g. tests importing handleMessage).
 // `process.argv[1]` is undefined under `node -e`/`--input-type`, so guard it.
+// When invoked via the bin, `process.argv[1]` is a symlink under
+// `node_modules/.bin/` whose href would NOT equal the resolved module url —
+// so canonicalize both sides with realpath before comparing.
 const entrypoint = process.argv[1];
-if (entrypoint && import.meta.url === pathToFileURL(entrypoint).href) {
+if (entrypoint && isMainModule(entrypoint)) {
   main().catch((err) => {
     console.error('[cc-channel-octo] Fatal error:', String(err));
     process.exit(1);
   });
+}
+
+function isMainModule(argvPath: string): boolean {
+  try {
+    const resolvedArgv = pathToFileURL(realpathSync(argvPath)).href;
+    const resolvedSelf = pathToFileURL(realpathSync(fileURLToPath(import.meta.url))).href;
+    return resolvedArgv === resolvedSelf;
+  } catch {
+    // Fall back to a direct href comparison if realpath fails (e.g. the file
+    // was unlinked after launch). Better to under-trigger than to crash.
+    return import.meta.url === pathToFileURL(argvPath).href;
+  }
 }


### PR DESCRIPTION
## Summary

Makes the package installable via `npm install` / `npx` — today only a GitHub Release (source tag) is produced and nothing is published to any registry, so `npm install` cannot work.

## Changes

- **`package.json`**
  - Scoped name `@mininglamp-oss/cc-channel-octo` (aligns with `@mininglamp-oss/octo-cli`)
  - **`files` allowlist** — `dist/` is in `.gitignore`, and npm falls back to `.gitignore` when there's no `.npmignore`, so a bare `npm publish` would have shipped a package **without the compiled output** (`main`/`types` point into `dist/`). The allowlist forces `dist` in.
  - `bin: { "cc-channel-octo": "dist/index.js" }` for the CLI
  - `publishConfig: { access: "public", provenance: true }`
  - `repository` / `bugs` / `homepage`; `prepublishOnly: npm run build`
- **`src/index.ts`**
  - Add `#!/usr/bin/env node` shebang (tsc preserves it into `dist/index.js`)
  - Make the main-module guard **symlink-aware** (realpath both sides). The installed bin is a symlink under `node_modules/.bin/`, whose path would not equal the resolved module URL — so `main()` would never fire when launched via the bin (the gateway would silently do nothing). Verified by invoking through a symlink.
- **`.github/workflows/npm-publish.yml`** — publish on `release: published` (chained after the GitHub Release the existing release-publish flow creates) + manual `workflow_dispatch`. Verifies the tag matches `package.json` version, runs `npm ci` + build + test, then `npm publish` with OIDC provenance.
- **`README.md`** — document `npm install -g` / `npx` usage + peer-dependency note.

## Required before first publish (repo setup — not in this PR)

1. **`NPM_TOKEN` secret** — an npm automation/granular token with publish rights on the `@mininglamp-oss` scope, added as a repository secret. (Or switch to npm Trusted Publishing/OIDC entirely and drop the token.)
2. The `@mininglamp-oss/cc-channel-octo` name is currently unclaimed on npm — first publish claims it.

## Verification

- `npm run type-check` ok, `npm run lint` (zero warnings) ok, `npm test` — 975 passing
- `npm pack --dry-run` — tarball contains `dist/` + docs, no test files, 203 kB
- `actionlint .github/workflows/npm-publish.yml` ok
- Invoked the built `dist/index.js` through a symlink (simulating the bin) — `main()` fires and loads config (vs. silently exiting before the fix)

After merge: the next `vX.Y.Z` tag + published Release will trigger npm-publish automatically (once `NPM_TOKEN` is set).