### PR TITLE
ci(release): tag-push npm publish, sync lockfile, fix badges

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -2,21 +2,28 @@ name: npm Publish
 
 # Publishes the package to the public npm registry.
 #
-# Trigger: when a GitHub Release is published (the release-publish workflow flips
-# the draft to published, which fires `release: published`), or manually via
-# workflow_dispatch with an explicit tag.
+# Trigger: on a pushed stable version tag `vX.Y.Z` (NOT pre-releases like
+# `vX.Y.Z-rc.1`), or manually via workflow_dispatch with an explicit tag.
+#
+# Why tag-push instead of `release: published`: the release-publish workflow
+# creates the GitHub Release with the built-in GITHUB_TOKEN, and GitHub does not
+# cascade workflow triggers from GITHUB_TOKEN-produced events (anti-recursion),
+# so a `release: published` trigger never fires automatically. A tag push is not
+# subject to that block.
 #
 # Auth: uses the NPM_TOKEN repository secret (an npm automation/granular token
 # with publish rights on the @mininglamp-oss scope). Provenance is attached via
 # OIDC (`id-token: write` + publishConfig.provenance:true in package.json), so
 # the published version carries a verifiable build-origin attestation.
 #
-# Safety: the job refuses to publish unless the tag's `vX.Y.Z` matches the
-# version in package.json, so a mismatched tag can never push a wrong version.
+# Safety: the job refuses to publish unless (a) the tag is strict semver, (b) the
+# tagged commit is an ancestor of origin/main (no publishing off-branch code),
+# and (c) the tag's `vX.Y.Z` matches the version in package.json.
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - 'v*.*.*'
   workflow_dispatch:
     inputs:
       tag:
@@ -38,13 +45,13 @@ jobs:
       - name: Resolve tag
         id: tag
         env:
-          EVENT_TAG: ${{ github.event.release.tag_name }}
+          REF_TAG: ${{ github.ref_type == 'tag' && github.ref_name || '' }}
           INPUT_TAG: ${{ inputs.tag }}
         run: |
           set -euo pipefail
-          TAG="${EVENT_TAG:-$INPUT_TAG}"
+          TAG="${REF_TAG:-$INPUT_TAG}"
           if [ -z "$TAG" ]; then
-            echo "::error::No tag resolved from release event or dispatch input."
+            echo "::error::No tag resolved from tag push or dispatch input."
             exit 1
           fi
           # Strict semver tag (mirrors the org release-publish regex).
@@ -53,20 +60,46 @@ jobs:
             echo "::error::Tag '$TAG' is not strict semver (vMAJOR.MINOR.PATCH[-prerelease])"
             exit 1
           fi
+          # Skip pre-release tags on automatic (tag-push) runs so they never land
+          # on npm 'latest'. A maintainer can still force one via workflow_dispatch.
+          if printf '%s' "$TAG" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+-'; then
+            if [ "${{ github.event_name }}" = "push" ]; then
+              echo "::notice::Tag '$TAG' is a pre-release; skipping automatic npm publish. Use workflow_dispatch to publish a pre-release deliberately."
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+            fi
+          fi
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "Resolved tag: $TAG"
 
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        if: steps.tag.outputs.skip != 'true'
         with:
           ref: ${{ steps.tag.outputs.tag }}
+          fetch-depth: 0 # need history for the ancestor check
+
+      - name: Verify tagged commit is on main
+        if: steps.tag.outputs.skip != 'true'
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin main
+          TAG_SHA=$(git rev-list -n 1 "$TAG")
+          if ! git merge-base --is-ancestor "$TAG_SHA" origin/main; then
+            echo "::error::Tag '$TAG' ($TAG_SHA) is not an ancestor of origin/main. Refusing to publish off-branch code."
+            exit 1
+          fi
+          echo "Tag commit $TAG_SHA is reachable from origin/main ✓"
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        if: steps.tag.outputs.skip != 'true'
         with:
           node-version: '22'
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Verify tag matches package.json version
+        if: steps.tag.outputs.skip != 'true'
         env:
           TAG: ${{ steps.tag.outputs.tag }}
         run: |
@@ -80,15 +113,19 @@ jobs:
           echo "Tag matches package.json: $EXPECTED"
 
       - name: Install dependencies
+        if: steps.tag.outputs.skip != 'true'
         run: npm ci
 
       - name: Build
+        if: steps.tag.outputs.skip != 'true'
         run: npm run build
 
       - name: Test
+        if: steps.tag.outputs.skip != 'true'
         run: npm test
 
       - name: Publish
+        if: steps.tag.outputs.skip != 'true'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 
 <p align="center">
   <a href="https://github.com/Mininglamp-OSS/cc-channel-octo/actions"><img src="https://github.com/Mininglamp-OSS/cc-channel-octo/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <a href="https://www.npmjs.com/package/cc-channel-octo"><img src="https://img.shields.io/npm/v/cc-channel-octo" alt="npm version"></a>
+  <a href="https://www.npmjs.com/package/@mininglamp-oss/cc-channel-octo"><img src="https://img.shields.io/npm/v/@mininglamp-oss/cc-channel-octo" alt="npm version"></a>
   <a href="./LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-blue" alt="License"></a>
-  <img src="https://img.shields.io/node/v/cc-channel-octo" alt="Node.js version">
+  <img src="https://img.shields.io/node/v/@mininglamp-oss/cc-channel-octo" alt="Node.js version">
 </p>
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "cc-channel-octo",
-  "version": "0.2.0",
+  "name": "@mininglamp-oss/cc-channel-octo",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "cc-channel-octo",
-      "version": "0.2.0",
+      "name": "@mininglamp-oss/cc-channel-octo",
+      "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "better-sqlite3": "^12.10.0",
@@ -15,6 +15,9 @@
         "md5-typescript": "^1.0.5",
         "ws": "^8.16.0",
         "zod": "^4.4.3"
+      },
+      "bin": {
+        "cc-channel-octo": "dist/index.js"
       },
       "devDependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.162",


### PR DESCRIPTION
Closes #139. Release-plane follow-ups after v1.0.0 / v1.0.1.

## 1. npm-publish trigger → tag push (+ pre-release skip)

`npm-publish.yml` triggered on `release: published`, but `release-publish` creates the Release with `GITHUB_TOKEN`, and GitHub doesn't cascade workflow triggers from `GITHUB_TOKEN`-produced events — so it never fired automatically (v1.0.1 was published by manual dispatch).

- Trigger is now `push: tags: ['v*.*.*']` (not subject to the recursion block). `workflow_dispatch` retained as manual fallback.
- Pre-release tags (`vX.Y.Z-rc.1`, …) are **skipped on automatic runs** so they never land on npm `latest`; a maintainer can still publish one deliberately via dispatch.

## 4. Tag-reachability hardening

Added a `git merge-base --is-ancestor <tag-sha> origin/main` guard (with `fetch-depth: 0`) — refuses to publish a tag whose commit isn't reachable from `main`, closing the off-branch-publish gap. (Item 4 from the issue, included here.)

## 2. Sync `package-lock.json`

Was stale at `cc-channel-octo@0.2.0` while `package.json` is `@mininglamp-oss/cc-channel-octo@1.0.1` — `npm ci` requires the lock to match. Regenerated (top-level + `packages[""]` name/version).

## 3. Badges → scoped name

README npm + node badges and the npm link used the old unscoped `cc-channel-octo`, which 404s on npm. Repointed to `@mininglamp-oss/cc-channel-octo`. Verified both shields.io endpoints resolve (`v1.0.1`, `>=22`).

## Verification

- `actionlint .github/workflows/npm-publish.yml` ok · no tabs
- `npm run type-check` ok · `npm run lint` (zero warnings) ok · `npm test` 975 passing
- `npm ci --dry-run` consistent with the regenerated lockfile
- shields.io badge JSON endpoints return correct values for the scoped name

Note: the next stable `vX.Y.Z` tag push will exercise the new auto-publish path end to end.