### PR TITLE
fix(router): per-message dispatch timeout to unblock hung sessions

### DIFF
--- a/src/__tests__/session-router.test.ts
+++ b/src/__tests__/session-router.test.ts
@@ -469,6 +469,112 @@ describe('routeAndHandle concurrency', () => {
   });
 });
 
+// ─── #141: Dispatch timeout ────────────────────────────────────────────────
+
+describe('dispatch timeout (#141)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('a hung handler does not block the next message on the same session', async () => {
+    const router = new SessionRouter(
+      makeConfig({ rateLimit: { maxPerMinute: 100 }, dispatchTimeoutMs: 50 }),
+      ROBOT_ID,
+    );
+    const completed: number[] = [];
+
+    // Message 1: handler never resolves (simulates a hung agent turn).
+    const p1 = router.routeAndHandle(
+      makeMsg({ message_id: '1', channel_type: ChannelType.DM, from_uid: 'same-user' }),
+      () => new Promise<void>(() => { /* never resolves */ }),
+    );
+
+    // Message 2: a normal fast handler on the SAME session. Without the
+    // timeout it would be blocked forever behind message 1's session lock.
+    const p2 = router.routeAndHandle(
+      makeMsg({ message_id: '2', channel_type: ChannelType.DM, from_uid: 'same-user' }),
+      async () => { completed.push(2); },
+    );
+
+    await Promise.all([p1, p2]);
+
+    // Message 2 ran — the lock was released after message 1 timed out.
+    expect(completed).toEqual([2]);
+  });
+
+  it('sends a single bounded apology on timeout', async () => {
+    const router = new SessionRouter(
+      makeConfig({ rateLimit: { maxPerMinute: 100 }, dispatchTimeoutMs: 30 }),
+      ROBOT_ID,
+    );
+
+    await router.routeAndHandle(
+      makeMsg({ message_id: '1', channel_type: ChannelType.DM, from_uid: 'u1' }),
+      () => new Promise<void>(() => { /* never resolves */ }),
+    );
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(sendMessage).mock.calls[0][0]).toMatchObject({
+      content: expect.stringContaining('处理超时'),
+    });
+  });
+
+  it('does not fire for a normal fast handler', async () => {
+    const router = new SessionRouter(
+      makeConfig({ rateLimit: { maxPerMinute: 100 }, dispatchTimeoutMs: 1000 }),
+      ROBOT_ID,
+    );
+    let ran = false;
+
+    await router.routeAndHandle(
+      makeMsg({ message_id: '1', channel_type: ChannelType.DM, from_uid: 'u1' }),
+      async () => { ran = true; },
+    );
+
+    expect(ran).toBe(true);
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it('disabled (0) runs the handler unguarded', async () => {
+    const router = new SessionRouter(
+      makeConfig({ rateLimit: { maxPerMinute: 100 }, dispatchTimeoutMs: 0 }),
+      ROBOT_ID,
+    );
+    let ran = false;
+
+    await router.routeAndHandle(
+      makeMsg({ message_id: '1', channel_type: ChannelType.DM, from_uid: 'u1' }),
+      async () => { ran = true; },
+    );
+
+    expect(ran).toBe(true);
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it('a rejecting handler does not wedge the session (next message still runs)', async () => {
+    const router = new SessionRouter(
+      makeConfig({ rateLimit: { maxPerMinute: 100 }, dispatchTimeoutMs: 1000 }),
+      ROBOT_ID,
+    );
+    const completed: number[] = [];
+
+    // Message 1: handler rejects fast (a real handler error, not a timeout).
+    await router.routeAndHandle(
+      makeMsg({ message_id: '1', channel_type: ChannelType.DM, from_uid: 'same-user' }),
+      async () => { throw new Error('boom'); },
+    );
+    // Message 2: same session — must still run (lock released, no timeout apology).
+    await router.routeAndHandle(
+      makeMsg({ message_id: '2', channel_type: ChannelType.DM, from_uid: 'same-user' }),
+      async () => { completed.push(2); },
+    );
+
+    expect(completed).toEqual([2]);
+    // A non-timeout error must NOT trigger the timeout apology.
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+});
+
 // ─── Q10: Message length limit ─────────────────────────────────────────────
 
 describe('Message length limit (Q10)', () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -174,6 +174,15 @@ export interface Config {
   };
   /** Maximum response length in chars before truncation (Q32). */
   maxResponseChars: number;
+  /**
+   * Per-message dispatch timeout in ms (#141). Bounds the full handler
+   * pipeline (agent query + stream) under the per-session lock. If a turn
+   * hangs past this, the session lock is released (a hung turn would otherwise
+   * block every subsequent message on that session forever) and the user gets
+   * a one-shot apology. Does NOT cancel the in-flight turn — only unblocks the
+   * queue. Default 5 minutes.
+   */
+  dispatchTimeoutMs: number;
   botBlocklist?: string[];
   /**
    * G14: Bots in this list are allowed to DM the bot even if their uid matches
@@ -247,6 +256,7 @@ type PartialConfig = {
   rateLimit?: Partial<Config['rateLimit']>;
   context?: Partial<Config['context']>;
   maxResponseChars?: number;
+  dispatchTimeoutMs?: number;
   botBlocklist?: string[];
   allowedBotUids?: string[];
   mentionFreeGroups?: string[];
@@ -282,6 +292,7 @@ function defaults(): Config {
       historyLimit: 40,
     },
     maxResponseChars: 524_288, // 512 KB (Q32)
+    dispatchTimeoutMs: 300_000, // 5 min (#141)
   };
 }
 
@@ -345,6 +356,7 @@ function mergeConfig(base: Config, override: PartialConfig): Config {
       ...(override.context ?? {}),
     },
     maxResponseChars: override.maxResponseChars ?? base.maxResponseChars,
+    dispatchTimeoutMs: override.dispatchTimeoutMs ?? base.dispatchTimeoutMs,
     botBlocklist: override.botBlocklist ?? base.botBlocklist,
     allowedBotUids: override.allowedBotUids ?? base.allowedBotUids,
     mentionFreeGroups: override.mentionFreeGroups ?? base.mentionFreeGroups,

--- a/src/session-router.ts
+++ b/src/session-router.ts
@@ -128,10 +128,76 @@ export class SessionRouter {
     return this.withSessionLock(key, async () => {
       const result = await this.processMessage(msg, key);
       if (result && result.shouldProcess) {
-        await handler(result);
+        await this.runHandlerWithTimeout(result, handler);
       }
       return result;
     });
+  }
+
+  /**
+   * #141: Run the handler under a dispatch timeout so a hung turn (a stuck SDK
+   * query, a wedged tool subprocess, a stalled stream) cannot block the session
+   * forever. The handler runs inside withSessionLock — if it never returns, the
+   * lock's gate never resolves and EVERY subsequent message for this session is
+   * stuck permanently (silent). Racing the handler against a timeout guarantees
+   * the lock releases.
+   *
+   * Scope (mirrors openclaw #75): we do NOT cancel the in-flight turn — the SDK
+   * query keeps running to completion in the background; we only unblock the
+   * queue. Worst case is a delayed real reply arriving after the apology.
+   *
+   * `timeoutError` is a per-invocation Error so the catch identifies OUR timeout
+   * by reference equality, never by string comparison (a same-text upstream
+   * error must not be misclassified).
+   */
+  private async runHandlerWithTimeout(
+    result: RouteResult,
+    handler: (result: RouteResult) => Promise<void>,
+  ): Promise<void> {
+    const timeoutMs = this.config.dispatchTimeoutMs;
+    if (!timeoutMs || timeoutMs <= 0) {
+      // Timeout disabled — run unguarded.
+      await handler(result);
+      return;
+    }
+
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+    const timeoutError = new Error(`dispatch timed out after ${timeoutMs}ms`);
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      timeoutHandle = setTimeout(() => reject(timeoutError), timeoutMs);
+    });
+
+    // The handler keeps running after a timeout (we don't cancel the in-flight
+    // turn — see scope note above). Once the race settles on timeoutError, that
+    // orphaned promise is no longer awaited; attach a no-op catch so a late
+    // rejection from a handler that doesn't self-contain its errors can't surface
+    // as an unhandledRejection. Today's caller (index.ts) is fully try/caught, so
+    // this is defense-in-depth for future callers.
+    const handlerPromise = handler(result);
+    handlerPromise.catch(() => { /* swallow late rejection after timeout */ });
+
+    try {
+      await Promise.race([handlerPromise, timeoutPromise]);
+    } catch (err) {
+      if (err === timeoutError) {
+        console.warn(
+          `session-router: dispatch hung past ${timeoutMs}ms, releasing session lock (session=${result.sessionKey})`,
+        );
+        // Bounded apology — replySafe swallows its own errors, and the
+        // underlying sendMessage in octo/api.ts is itself time-bounded, so a
+        // sick Octo API can't re-hang us here.
+        await this.replySafe(result.message, '⚠️ 处理超时，请稍后重试。');
+        return; // swallow: the lock releases, the queue advances
+      }
+      // A real handler error — index.ts's handler already catches and replies
+      // internally, so reaching here is unexpected. Swallow to keep the lock
+      // release path identical (never let an error wedge the queue).
+      console.error(
+        `session-router: handler error (session=${result.sessionKey}): ${String(err)}`,
+      );
+    } finally {
+      if (timeoutHandle) clearTimeout(timeoutHandle);
+    }
   }
 
   async route(msg: BotMessage): Promise<RouteResult | null> {


### PR DESCRIPTION
Closes #141.

## Problem

`SessionRouter.withSessionLock` serializes per-session handling via a Promise chain — each message awaits the previous one's `gate`, which only resolves after `handler()` returns. `handler` runs the full pipeline including `queryAgent()` + `streamRelay.deliver()`. **If an agent turn hangs** (stuck SDK `query()`, wedged tool subprocess, stalled stream), `handler` never returns, the gate never resolves, and **every subsequent message on that session is blocked forever** — silent permanent stuck. cc had no per-turn timeout (only individual HTTP calls are bounded).

This is the P0 stability gap from the GAP analysis vs `openclaw-channel-octo` (which guards against it in its issue #75).

## Fix

Race `handler(result)` against a configurable timeout in `routeAndHandle` so the session lock always releases:

- **`config.dispatchTimeoutMs`** (default `300_000` = 5 min), tunable per-bot; `0`/negative disables the guard.
- On timeout: warn-log attributed to the `sessionKey`, send a **bounded** one-shot apology (`⚠️ 处理超时，请稍后重试。`) via the existing `replySafe` (itself error-swallowing + the underlying `sendMessage` is time-bounded), then let the lock release so the queue advances.
- **Per-invocation `Error`** identifies our timeout by **reference equality**, never string comparison (a same-text upstream error can't be misclassified).
- **Scope (mirrors openclaw #75):** we do NOT cancel the in-flight turn — the SDK query keeps running to completion in the background; we only unblock the queue. Worst case is a delayed real reply arriving after the apology.
- The orphaned `handler` promise gets a no-op `.catch` so a late rejection (from a future caller whose handler isn't self-contained) can't surface as an `unhandledRejection`. Today's caller (`index.ts`) is fully try/caught — defense-in-depth.

## Tests (5 new, 980 total)

- A hung handler no longer blocks the next message on the same session.
- Timeout sends exactly one apology containing `处理超时`.
- A normal fast handler doesn't trigger the timeout.
- `dispatchTimeoutMs: 0` runs the handler unguarded.
- A *rejecting* (non-timeout) handler doesn't wedge the session and does NOT send the timeout apology.

## Verification

- `npm run type-check` ok · `npm run lint` (zero warnings) ok · `npm test` — 980 passing
- `code-review` skill (high effort) run; the one PLAUSIBLE finding (orphaned-promise unhandled rejection) was addressed with the defensive `.catch`.