### PR TITLE
fix(mentions): validate outbound @uid against live group members

### DIFF
--- a/src/__tests__/group-context.test.ts
+++ b/src/__tests__/group-context.test.ts
@@ -170,6 +170,24 @@ describe('GroupContext', () => {
     expect(ctx.resolveMentions('@Alice and @Alice again', 'ch1')).toEqual(['u1']);
   });
 
+  // --- A8 (#143): outbound mention validation getters ---
+
+  it('isMember reflects the live member list per channel', () => {
+    ctx.learnMember('ch1', 'u1', 'Alice');
+    expect(ctx.isMember('ch1', 'u1')).toBe(true);
+    expect(ctx.isMember('ch1', 'ghost')).toBe(false);
+    // Isolation: a member of ch1 is not a member of ch2.
+    expect(ctx.isMember('ch2', 'u1')).toBe(false);
+  });
+
+  it('getNameToUidMap exposes the displayName→uid map for outbound @name', () => {
+    ctx.learnMember('ch1', 'u1', 'Alice');
+    const map = ctx.getNameToUidMap('ch1');
+    expect(map.get('Alice')).toBe('u1');
+    // Unknown channel → empty (not undefined).
+    expect(ctx.getNameToUidMap('nope').size).toBe(0);
+  });
+
   // --- refreshMembers ---
 
   it('refreshMembers throttles within 1h', async () => {

--- a/src/__tests__/mention-utils.test.ts
+++ b/src/__tests__/mention-utils.test.ts
@@ -236,6 +236,40 @@ describe('resolveMentions', () => {
     expect(result.mentionEntities[1].uid).toBe('u1');
     expect(result.mentionUids).toEqual(['u2', 'u1']);
   });
+
+  // A8 (#143): membership validation of outbound structured @[uid:name]
+  describe('isValidUid membership guard', () => {
+    it('keeps a structured mention whose uid passes the predicate', () => {
+      const members = new Set(['u1']);
+      const result = resolveMentions('@[u1:Alice] hi', undefined, (uid) => members.has(uid));
+      expect(result.finalContent).toBe('@Alice hi');
+      expect(result.mentionUids).toEqual(['u1']);
+      expect(result.mentionEntities).toHaveLength(1);
+    });
+
+    it('downgrades a hallucinated uid to plain text (drops entity, keeps @name)', () => {
+      const members = new Set(['u1']);
+      const result = resolveMentions('@[deadbeef:Ghost] hi', undefined, (uid) => members.has(uid));
+      // @name text survives, but no entity/uid is emitted → no bogus notify.
+      expect(result.finalContent).toBe('@Ghost hi');
+      expect(result.mentionUids).toEqual([]);
+      expect(result.mentionEntities).toEqual([]);
+    });
+
+    it('keeps real members and drops hallucinated ones in the same message', () => {
+      const members = new Set(['u1']);
+      const result = resolveMentions('@[u1:Alice] and @[fake:Bob]', undefined, (uid) => members.has(uid));
+      expect(result.finalContent).toBe('@Alice and @Bob');
+      expect(result.mentionUids).toEqual(['u1']);
+      expect(result.mentionEntities).toHaveLength(1);
+      expect(result.mentionEntities[0].uid).toBe('u1');
+    });
+
+    it('without a predicate, trusts every structured uid (legacy behavior)', () => {
+      const result = resolveMentions('@[whatever:Ghost] hi');
+      expect(result.mentionUids).toEqual(['whatever']);
+    });
+  });
 });
 
 describe('patterns', () => {

--- a/src/group-context.ts
+++ b/src/group-context.ts
@@ -392,6 +392,24 @@ export class GroupContext {
     return this.robotFlags.get(channelId)?.get(uid);
   }
 
+  /**
+   * A8 (#143): true iff `uid` is a current member of `channelId` per the live
+   * member list (refreshed on every inbound group message). Used by the outbound
+   * mention sanitizer to drop hallucinated @uids that aren't real members.
+   */
+  isMember(channelId: string, uid: string): boolean {
+    return this.memberMapByChannel.get(channelId)?.has(uid) ?? false;
+  }
+
+  /**
+   * A8 (#143): the channel's displayName→uid map, for v1 `@name` outbound
+   * resolution in StreamRelay.deliver. Returns the live map (empty if the
+   * channel has no cached members yet). Read-only use by callers.
+   */
+  getNameToUidMap(channelId: string): Map<string, string> {
+    return this.getNameToUid(channelId);
+  }
+
   loadMembersFromDb(channelId: string): void {
     try {
       const rows = this.selectMembers.all(channelId) as MemberRow[];

--- a/src/index.ts
+++ b/src/index.ts
@@ -782,7 +782,15 @@ export async function handleMessage(
       }
 
       // --- Stream output to Octo ---
-      await streamRelay.deliver(channelId, channelType, teeChunks(), config.apiUrl, config.botToken, config.maxResponseChars);
+      // A8 (#143): in groups, resolve v1 @name against the live member list and
+      // validate v2 @[uid:name] uids against membership — a hallucinated uid not
+      // in the group is downgraded to plain text (no bogus @ notify). DMs have no
+      // member list and no @ semantics, so both args stay undefined (skip).
+      const outboundNameToUid = isGroup ? groupContext.getNameToUidMap(channelId) : undefined;
+      const isValidMentionUid = isGroup
+        ? (uid: string): boolean => groupContext.isMember(channelId, uid)
+        : undefined;
+      await streamRelay.deliver(channelId, channelType, teeChunks(), config.apiUrl, config.botToken, config.maxResponseChars, outboundNameToUid, isValidMentionUid);
 
       // G8: Send read receipt after processing (fire-and-forget)
       if (msg.message_id && msg.channel_id && msg.channel_type !== undefined) {

--- a/src/mention-utils.ts
+++ b/src/mention-utils.ts
@@ -203,11 +203,20 @@ export function buildEntitiesFromFallback(
  *
  * @param content Raw text possibly containing @[uid:name] and/or @name
  * @param memberMap Optional displayName→uid map for @name resolution
+ * @param isValidUid Optional A8 (#143) membership predicate. When provided, a
+ *   structured `@[uid:name]` whose uid fails the predicate (e.g. a hallucinated
+ *   uid not in the group's live member list) is DOWNGRADED to plain text: the
+ *   human-readable `@name` stays in the body (convertStructuredMentions already
+ *   replaced `@[uid:name]` with `@name`), but no entity/uid is emitted, so no
+ *   bogus notification is sent. Omit it (DMs, or to preserve legacy behavior) to
+ *   trust every structured uid. v1 `@name` entities are inherently members (they
+ *   come from memberMap) so they are not re-checked.
  * @returns finalContent (with @[uid:name] replaced by @name) + entities + uids + mentionAll
  */
 export function resolveMentions(
   content: string,
   memberMap?: Map<string, string>,
+  isValidUid?: (uid: string) => boolean,
 ): {
   finalContent: string;
   mentionUids: string[];
@@ -222,7 +231,12 @@ export function resolveMentions(
   if (structured.length > 0) {
     const converted = convertStructuredMentions(finalContent, structured);
     finalContent = converted.content;
-    entities = [...converted.entities];
+    // A8 (#143): drop entities for uids that aren't real members — the `@name`
+    // text is already in finalContent, so dropping the entity downgrades a
+    // hallucinated mention to harmless plain text instead of a bogus @ notify.
+    entities = isValidUid
+      ? converted.entities.filter((e) => isValidUid(e.uid))
+      : [...converted.entities];
   }
 
   // v1: @name fallback via memberMap (skip offsets already covered by v2)

--- a/src/stream-relay.ts
+++ b/src/stream-relay.ts
@@ -165,6 +165,7 @@ export class StreamRelay {
     botToken: string,
     maxResponseChars: number = DEFAULT_MAX_RESPONSE_CHARS,
     memberMap?: Map<string, string>,
+    isValidUid?: (uid: string) => boolean,
   ): Promise<void> {
     // --- Typing heartbeat ---
     const typingParams = { apiUrl, botToken, channelId, channelType };
@@ -219,7 +220,7 @@ export class StreamRelay {
           finalContent,
           mentionEntities: globalEntities,
           mentionAll,
-        } = resolveMentions(accumulated, memberMap);
+        } = resolveMentions(accumulated, memberMap, isValidUid);
 
         const protectedRanges = globalEntities.map(e => ({
           start: e.offset,


### PR DESCRIPTION
Closes #143. Gap **A8** from the openclaw comparison.

## Problem

cc converts the LLM's `@[uid:displayName]` structured mentions into wire `MentionEntity` (uid + offset + length) before send, **without validating the uid**. A hallucinated uid (a plausible hex not in the group, a guessed handle) was forwarded to Octo as a real @ notification — @-ing a non-member or firing a bogus notify.

## Approach — membership validation, stronger than openclaw's port

This is **group/thread only**: DMs have no member list and no @ semantics, so they skip the sanitizer entirely. cc runs `GroupContext.refreshMembers()` on **every inbound group message** (`index.ts:383`), so the member list is **fresh at send time** — which lets cc validate actual **membership** rather than openclaw's format-only (32-hex) check. No `trustedUids` cold-start escape hatch is needed.

Per your call, the miss path is simply: **uid ∉ members → downgrade to plain text** (no re-fetch — the list was just refreshed on inbound, so a miss is authoritative).

## Changes

- **`group-context.ts`** — expose `isMember(channelId, uid)` and `getNameToUidMap(channelId)` (reuse the existing private maps).
- **`mention-utils.ts`** — `resolveMentions` gains an optional `isValidUid` predicate. A v2 `@[uid:name]` whose uid fails it is **downgraded to plain text**: `convertStructuredMentions` already replaced `@[uid:name]` with `@name`, so dropping the entity leaves harmless `@name` text and emits no entity/uid. v1 `@name` entities come from the member map so they're inherently members (not re-checked). **Backward compatible**: no predicate → legacy behavior.
- **`stream-relay.ts`** — `deliver` threads `isValidUid` through to `resolveMentions`.
- **`index.ts`** — wire the maps at the send site: groups pass name→uid + the membership predicate, DMs pass neither. This also **activates the previously-dead v1 `@name` resolution** — `deliver`'s `memberMap` param existed but was never passed before, so plain `@name` the bot wrote never resolved. Now it does, membership-gated (can't notify non-members).

## Tests (6 new, 986 total)

- v2 uid passes predicate → entity kept.
- v2 hallucinated uid → downgraded to plain `@name`, no entity/uid.
- mixed real + hallucinated in one message → only the real one survives.
- no predicate → trusts every uid (legacy).
- `isMember` channel isolation; `getNameToUidMap` exposes name→uid + empty for unknown channel.

## Verification

- `npm run type-check` ok · `npm run lint` (zero warnings) ok · `npm test` — 986 passing
- `code-review` skill (medium) run — scrutinized the drop+v1-rebind interaction (produces correct behavior: a dropped `@[ghost:Alice]` where Alice is a real member correctly rebinds to the real Alice; non-members stay plain) and the v1 activation (intended, membership-gated). No actionable findings.