### PR TITLE
fix(mentions): authoritative member set for outbound @uid validation (reworks #144)

### DIFF
--- a/src/__tests__/group-context.test.ts
+++ b/src/__tests__/group-context.test.ts
@@ -413,4 +413,97 @@ describe('G23: robot flag', () => {
     expect(ctx.isRobot('ch1', 'shared')).toBe(true);
     expect(ctx.isRobot('ch2', 'shared')).toBe(false);
   });
+
+  // --- A8 (#143): authoritative membership + outbound validation getters ---
+
+  it('isMember / getNameToUidMap reflect a learned member', () => {
+    ctx.learnMember('ch1', 'u1', 'Alice');
+    expect(ctx.isMember('ch1', 'u1')).toBe(true);
+    expect(ctx.isMember('ch1', 'ghost')).toBe(false);
+    expect(ctx.isMember('ch2', 'u1')).toBe(false); // per-channel isolation
+    expect(ctx.getNameToUidMap('ch1').get('Alice')).toBe('u1');
+    expect(ctx.getNameToUidMap('nope').size).toBe(0);
+  });
+
+  it('refreshMembers prunes a departed member (Jerry-Xin 🔴): memory + reverse map', async () => {
+    // First authoritative refresh: u1 + u2 present.
+    (getGroupMembers as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce([
+        { uid: 'u1', name: 'Alice', role: 0 },
+        { uid: 'u2', name: 'Bob', role: 0 },
+      ])
+      .mockResolvedValueOnce([{ uid: 'u1', name: 'Alice', role: 0 }]); // u2 left
+    await ctx.refreshMembers('ch-prune', 'https://api', 'token');
+    expect(ctx.isMember('ch-prune', 'u1')).toBe(true);
+    expect(ctx.isMember('ch-prune', 'u2')).toBe(true);
+
+    // Bypass the 1h throttle so the second refresh is effective.
+    vi.useFakeTimers();
+    vi.setSystemTime(Date.now() + 61 * 60 * 1000);
+    try {
+      await ctx.refreshMembers('ch-prune', 'https://api', 'token');
+    } finally {
+      vi.useRealTimers();
+    }
+    // Guard: the second refresh actually ran (not silently throttled).
+    expect(getGroupMembers).toHaveBeenCalledTimes(2);
+
+    // u2 left → must no longer be a member, and its reverse name entry is gone.
+    expect(ctx.isMember('ch-prune', 'u1')).toBe(true);
+    expect(ctx.isMember('ch-prune', 'u2')).toBe(false);
+    expect(ctx.getNameToUidMap('ch-prune').get('Bob')).toBeUndefined();
+    expect(ctx.getNameToUidMap('ch-prune').get('Alice')).toBe('u1');
+  });
+
+  it('refreshMembers pruning removes the persisted DB row for a departed member', async () => {
+    // Roster shrinks from {gone, keep} → {keep}. A non-empty response is trusted
+    // as authoritative, so `gone` is pruned from memory AND the DB.
+    (getGroupMembers as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce([
+        { uid: 'gone', name: 'Ghost', role: 0 },
+        { uid: 'keep', name: 'Keeper', role: 0 },
+      ])
+      .mockResolvedValueOnce([{ uid: 'keep', name: 'Keeper', role: 0 }]);
+    await ctx.refreshMembers('ch-db', 'https://api', 'token');
+    expect(ctx.isMember('ch-db', 'gone')).toBe(true);
+
+    vi.useFakeTimers();
+    vi.setSystemTime(Date.now() + 61 * 60 * 1000);
+    try {
+      await ctx.refreshMembers('ch-db', 'https://api', 'token');
+    } finally {
+      vi.useRealTimers();
+    }
+    expect(ctx.isMember('ch-db', 'gone')).toBe(false);
+    expect(ctx.isMember('ch-db', 'keep')).toBe(true);
+
+    // A fresh GroupContext loading from the same DB must NOT resurrect the row.
+    const ctx2 = new GroupContext(adapter, 6000);
+    ctx2.loadMembersFromDb('ch-db');
+    expect(ctx2.isMember('ch-db', 'gone')).toBe(false);
+    expect(ctx2.isMember('ch-db', 'keep')).toBe(true);
+  });
+
+  it('refreshMembers does NOT mass-prune on an empty roster response (transient-quirk guard)', async () => {
+    (getGroupMembers as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce([
+        { uid: 'u1', name: 'Alice', role: 0 },
+        { uid: 'u2', name: 'Bob', role: 0 },
+      ])
+      .mockResolvedValueOnce([]); // empty: treated as a quirk, not "everyone left"
+    await ctx.refreshMembers('ch-empty', 'https://api', 'token');
+    expect(ctx.isMember('ch-empty', 'u1')).toBe(true);
+
+    vi.useFakeTimers();
+    vi.setSystemTime(Date.now() + 61 * 60 * 1000);
+    try {
+      await ctx.refreshMembers('ch-empty', 'https://api', 'token');
+    } finally {
+      vi.useRealTimers();
+    }
+    expect(getGroupMembers).toHaveBeenCalledTimes(2);
+    // Prior roster is kept — an empty response does not wipe everyone.
+    expect(ctx.isMember('ch-empty', 'u1')).toBe(true);
+    expect(ctx.isMember('ch-empty', 'u2')).toBe(true);
+  });
 });

--- a/src/__tests__/group-context.test.ts
+++ b/src/__tests__/group-context.test.ts
@@ -170,24 +170,6 @@ describe('GroupContext', () => {
     expect(ctx.resolveMentions('@Alice and @Alice again', 'ch1')).toEqual(['u1']);
   });
 
-  // --- A8 (#143): outbound mention validation getters ---
-
-  it('isMember reflects the live member list per channel', () => {
-    ctx.learnMember('ch1', 'u1', 'Alice');
-    expect(ctx.isMember('ch1', 'u1')).toBe(true);
-    expect(ctx.isMember('ch1', 'ghost')).toBe(false);
-    // Isolation: a member of ch1 is not a member of ch2.
-    expect(ctx.isMember('ch2', 'u1')).toBe(false);
-  });
-
-  it('getNameToUidMap exposes the displayName→uid map for outbound @name', () => {
-    ctx.learnMember('ch1', 'u1', 'Alice');
-    const map = ctx.getNameToUidMap('ch1');
-    expect(map.get('Alice')).toBe('u1');
-    // Unknown channel → empty (not undefined).
-    expect(ctx.getNameToUidMap('nope').size).toBe(0);
-  });
-
   // --- refreshMembers ---
 
   it('refreshMembers throttles within 1h', async () => {

--- a/src/__tests__/mention-utils.test.ts
+++ b/src/__tests__/mention-utils.test.ts
@@ -236,40 +236,6 @@ describe('resolveMentions', () => {
     expect(result.mentionEntities[1].uid).toBe('u1');
     expect(result.mentionUids).toEqual(['u2', 'u1']);
   });
-
-  // A8 (#143): membership validation of outbound structured @[uid:name]
-  describe('isValidUid membership guard', () => {
-    it('keeps a structured mention whose uid passes the predicate', () => {
-      const members = new Set(['u1']);
-      const result = resolveMentions('@[u1:Alice] hi', undefined, (uid) => members.has(uid));
-      expect(result.finalContent).toBe('@Alice hi');
-      expect(result.mentionUids).toEqual(['u1']);
-      expect(result.mentionEntities).toHaveLength(1);
-    });
-
-    it('downgrades a hallucinated uid to plain text (drops entity, keeps @name)', () => {
-      const members = new Set(['u1']);
-      const result = resolveMentions('@[deadbeef:Ghost] hi', undefined, (uid) => members.has(uid));
-      // @name text survives, but no entity/uid is emitted → no bogus notify.
-      expect(result.finalContent).toBe('@Ghost hi');
-      expect(result.mentionUids).toEqual([]);
-      expect(result.mentionEntities).toEqual([]);
-    });
-
-    it('keeps real members and drops hallucinated ones in the same message', () => {
-      const members = new Set(['u1']);
-      const result = resolveMentions('@[u1:Alice] and @[fake:Bob]', undefined, (uid) => members.has(uid));
-      expect(result.finalContent).toBe('@Alice and @Bob');
-      expect(result.mentionUids).toEqual(['u1']);
-      expect(result.mentionEntities).toHaveLength(1);
-      expect(result.mentionEntities[0].uid).toBe('u1');
-    });
-
-    it('without a predicate, trusts every structured uid (legacy behavior)', () => {
-      const result = resolveMentions('@[whatever:Ghost] hi');
-      expect(result.mentionUids).toEqual(['whatever']);
-    });
-  });
 });
 
 describe('patterns', () => {

--- a/src/__tests__/mention-utils.test.ts
+++ b/src/__tests__/mention-utils.test.ts
@@ -236,6 +236,39 @@ describe('resolveMentions', () => {
     expect(result.mentionEntities[1].uid).toBe('u1');
     expect(result.mentionUids).toEqual(['u2', 'u1']);
   });
+
+  // A8 (#143): membership validation of outbound structured @[uid:name]
+  describe('isValidUid membership guard', () => {
+    it('keeps a structured mention whose uid passes the predicate', () => {
+      const members = new Set(['u1']);
+      const result = resolveMentions('@[u1:Alice] hi', undefined, (uid) => members.has(uid));
+      expect(result.finalContent).toBe('@Alice hi');
+      expect(result.mentionUids).toEqual(['u1']);
+      expect(result.mentionEntities).toHaveLength(1);
+    });
+
+    it('downgrades a hallucinated uid to plain text (drops entity, keeps @name)', () => {
+      const members = new Set(['u1']);
+      const result = resolveMentions('@[deadbeef:Ghost] hi', undefined, (uid) => members.has(uid));
+      expect(result.finalContent).toBe('@Ghost hi');
+      expect(result.mentionUids).toEqual([]);
+      expect(result.mentionEntities).toEqual([]);
+    });
+
+    it('keeps real members and drops hallucinated ones in the same message', () => {
+      const members = new Set(['u1']);
+      const result = resolveMentions('@[u1:Alice] and @[fake:Bob]', undefined, (uid) => members.has(uid));
+      expect(result.finalContent).toBe('@Alice and @Bob');
+      expect(result.mentionUids).toEqual(['u1']);
+      expect(result.mentionEntities).toHaveLength(1);
+      expect(result.mentionEntities[0].uid).toBe('u1');
+    });
+
+    it('without a predicate, trusts every structured uid (legacy behavior)', () => {
+      const result = resolveMentions('@[whatever:Ghost] hi');
+      expect(result.mentionUids).toEqual(['whatever']);
+    });
+  });
 });
 
 describe('patterns', () => {

--- a/src/group-context.ts
+++ b/src/group-context.ts
@@ -392,24 +392,6 @@ export class GroupContext {
     return this.robotFlags.get(channelId)?.get(uid);
   }
 
-  /**
-   * A8 (#143): true iff `uid` is a current member of `channelId` per the live
-   * member list (refreshed on every inbound group message). Used by the outbound
-   * mention sanitizer to drop hallucinated @uids that aren't real members.
-   */
-  isMember(channelId: string, uid: string): boolean {
-    return this.memberMapByChannel.get(channelId)?.has(uid) ?? false;
-  }
-
-  /**
-   * A8 (#143): the channel's displayName→uid map, for v1 `@name` outbound
-   * resolution in StreamRelay.deliver. Returns the live map (empty if the
-   * channel has no cached members yet). Read-only use by callers.
-   */
-  getNameToUidMap(channelId: string): Map<string, string> {
-    return this.getNameToUid(channelId);
-  }
-
   loadMembersFromDb(channelId: string): void {
     try {
       const rows = this.selectMembers.all(channelId) as MemberRow[];

--- a/src/group-context.ts
+++ b/src/group-context.ts
@@ -36,6 +36,7 @@ export class GroupContext {
   private readonly maxWindowSize: number;
 
   private upsertMember!: PreparedStatement;
+  private deleteMember!: PreparedStatement;
   private selectMembers!: PreparedStatement;
   private insertMessage!: PreparedStatement;
   private selectRecentMessages!: PreparedStatement;
@@ -83,6 +84,9 @@ export class GroupContext {
 
     this.upsertMember = this.adapter.prepare(
       'INSERT INTO group_members (group_id, uid, name, updated_at) VALUES (?, ?, ?, ?) ON CONFLICT(group_id, uid) DO UPDATE SET name = excluded.name, updated_at = excluded.updated_at',
+    );
+    this.deleteMember = this.adapter.prepare(
+      'DELETE FROM group_members WHERE group_id = ? AND uid = ?',
     );
     this.selectMembers = this.adapter.prepare(
       'SELECT uid, name FROM group_members WHERE group_id = ?',
@@ -202,8 +206,23 @@ export class GroupContext {
       this.lastRefresh.set(channelId, now); // Record only on success
       const memberMap = this.getMemberMap(channelId);
       const nameMap = this.getNameToUid(channelId);
+
+      // A8 (#143, take 2): the server response is AUTHORITATIVE — it is the full
+      // current roster, not a delta. Upserting returned members WITHOUT pruning
+      // departed ones (the original #144 bug, Jerry-Xin's 🔴) left a user who
+      // left the group cached forever, so isMember() kept accepting them and the
+      // outbound mention guard let a stale @uid through. Track who the server
+      // returned, then drop anyone cached/persisted who is no longer present.
+      //
+      // Best-effort caveat: this is only as fresh as the last successful refresh,
+      // which is throttled to REFRESH_INTERVAL_MS (1h) and seeded from DB on
+      // restart. A membership change inside that window is not reflected until
+      // the next refresh — the outbound guard is defense-in-depth, not a
+      // real-time authority. The server still enforces real permissions.
+      const present = new Set<string>();
       for (const m of members) {
         if (!m.uid || !m.name) continue;
+        present.add(m.uid);
         const oldName = memberMap.get(m.uid);
         if (oldName && oldName !== m.name && nameMap.get(oldName) === m.uid) {
           nameMap.delete(oldName);
@@ -223,6 +242,39 @@ export class GroupContext {
           this.upsertMember.run(channelId, m.uid, m.name, now);
         } catch (err) {
           console.error(`group-context: upsert member failed: ${String(err)}`);
+        }
+      }
+
+      // Prune members no longer in the authoritative roster (memory + DB + robot
+      // flags). Iterate a snapshot of uids since we mutate the map in the loop.
+      //
+      // Guard: skip pruning when the roster came back EMPTY. getGroupMembers
+      // returns [] not only for a genuinely empty group but also for a
+      // malformed/unexpected-shape 200 response (data.members not an array →
+      // silently []). A group the bot is in always has ≥1 member, so an empty
+      // roster is far more likely a transient quirk than "everyone left".
+      // Mass-pruning on it would wipe the whole roster — and since lastRefresh
+      // was already set on this "success", it wouldn't re-fetch for an hour,
+      // downgrading every mention to plain text in that window. Keep the prior
+      // snapshot instead; a real emptying still prunes member-by-member as the
+      // roster shrinks across non-empty responses.
+      if (present.size > 0) {
+        const rfMap = this.robotFlags.get(channelId);
+        for (const uid of [...memberMap.keys()]) {
+          if (present.has(uid)) continue;
+          const staleName = memberMap.get(uid);
+          memberMap.delete(uid);
+          // Only remove the reverse entry if it still points at THIS uid (a rename
+          // may have already re-pointed the name to someone else).
+          if (staleName !== undefined && nameMap.get(staleName) === uid) {
+            nameMap.delete(staleName);
+          }
+          rfMap?.delete(uid);
+          try {
+            this.deleteMember.run(channelId, uid);
+          } catch (err) {
+            console.error(`group-context: delete stale member failed: ${String(err)}`);
+          }
         }
       }
     } catch (err) {
@@ -390,6 +442,28 @@ export class GroupContext {
   /** G23: Check the server-authoritative robot flag for a group member. */
   isRobot(channelId: string, uid: string): boolean | undefined {
     return this.robotFlags.get(channelId)?.get(uid);
+  }
+
+  /**
+   * A8 (#143): true iff `uid` is a current member of `channelId` per the cached
+   * member list. The list is kept authoritative by refreshMembers (it prunes
+   * departed members, not just upserts) — but it is only best-effort fresh:
+   * refresh is throttled to REFRESH_INTERVAL_MS and seeded from DB on restart,
+   * so a membership change inside that window may not be reflected yet. Used by
+   * the outbound mention guard as defense-in-depth (the server still enforces
+   * real permissions), NOT as a real-time authority.
+   */
+  isMember(channelId: string, uid: string): boolean {
+    return this.memberMapByChannel.get(channelId)?.has(uid) ?? false;
+  }
+
+  /**
+   * A8 (#143): the channel's displayName→uid map, for v1 `@name` outbound
+   * resolution in StreamRelay.deliver. Returns the live map (empty if the
+   * channel has no cached members yet). Read-only use by callers.
+   */
+  getNameToUidMap(channelId: string): Map<string, string> {
+    return this.getNameToUid(channelId);
   }
 
   loadMembersFromDb(channelId: string): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -782,15 +782,7 @@ export async function handleMessage(
       }
 
       // --- Stream output to Octo ---
-      // A8 (#143): in groups, resolve v1 @name against the live member list and
-      // validate v2 @[uid:name] uids against membership — a hallucinated uid not
-      // in the group is downgraded to plain text (no bogus @ notify). DMs have no
-      // member list and no @ semantics, so both args stay undefined (skip).
-      const outboundNameToUid = isGroup ? groupContext.getNameToUidMap(channelId) : undefined;
-      const isValidMentionUid = isGroup
-        ? (uid: string): boolean => groupContext.isMember(channelId, uid)
-        : undefined;
-      await streamRelay.deliver(channelId, channelType, teeChunks(), config.apiUrl, config.botToken, config.maxResponseChars, outboundNameToUid, isValidMentionUid);
+      await streamRelay.deliver(channelId, channelType, teeChunks(), config.apiUrl, config.botToken, config.maxResponseChars);
 
       // G8: Send read receipt after processing (fire-and-forget)
       if (msg.message_id && msg.channel_id && msg.channel_type !== undefined) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -782,7 +782,17 @@ export async function handleMessage(
       }
 
       // --- Stream output to Octo ---
-      await streamRelay.deliver(channelId, channelType, teeChunks(), config.apiUrl, config.botToken, config.maxResponseChars);
+      // A8 (#143): in groups, resolve v1 @name against the member list and
+      // validate v2 @[uid:name] uids against membership — a hallucinated uid not
+      // in the group is downgraded to plain text (no bogus @ notify). The member
+      // list is kept authoritative by refreshMembers (prunes departed members),
+      // best-effort fresh (1h refresh throttle). DMs have no member list and no
+      // @ semantics, so both args stay undefined (skip).
+      const outboundNameToUid = isGroup ? groupContext.getNameToUidMap(channelId) : undefined;
+      const isValidMentionUid = isGroup
+        ? (uid: string): boolean => groupContext.isMember(channelId, uid)
+        : undefined;
+      await streamRelay.deliver(channelId, channelType, teeChunks(), config.apiUrl, config.botToken, config.maxResponseChars, outboundNameToUid, isValidMentionUid);
 
       // G8: Send read receipt after processing (fire-and-forget)
       if (msg.message_id && msg.channel_id && msg.channel_type !== undefined) {

--- a/src/mention-utils.ts
+++ b/src/mention-utils.ts
@@ -203,11 +203,21 @@ export function buildEntitiesFromFallback(
  *
  * @param content Raw text possibly containing @[uid:name] and/or @name
  * @param memberMap Optional displayName→uid map for @name resolution
+ * @param isValidUid Optional A8 (#143) membership predicate. When provided, a
+ *   structured `@[uid:name]` whose uid fails the predicate (e.g. a hallucinated
+ *   uid not in the group's member list) is DOWNGRADED to plain text: the
+ *   human-readable `@name` stays in the body (convertStructuredMentions already
+ *   replaced `@[uid:name]` with `@name`), but no entity/uid is emitted, so no
+ *   bogus notification is sent. Omit it (DMs, or to preserve legacy behavior) to
+ *   trust every structured uid. v1 `@name` entities are inherently members (they
+ *   come from memberMap) so they are not re-checked. Best-effort: only as fresh
+ *   as the caller's member snapshot (see GroupContext.isMember).
  * @returns finalContent (with @[uid:name] replaced by @name) + entities + uids + mentionAll
  */
 export function resolveMentions(
   content: string,
   memberMap?: Map<string, string>,
+  isValidUid?: (uid: string) => boolean,
 ): {
   finalContent: string;
   mentionUids: string[];
@@ -222,7 +232,12 @@ export function resolveMentions(
   if (structured.length > 0) {
     const converted = convertStructuredMentions(finalContent, structured);
     finalContent = converted.content;
-    entities = [...converted.entities];
+    // A8 (#143): drop entities for uids that aren't real members — the `@name`
+    // text is already in finalContent, so dropping the entity downgrades a
+    // hallucinated mention to harmless plain text instead of a bogus @ notify.
+    entities = isValidUid
+      ? converted.entities.filter((e) => isValidUid(e.uid))
+      : [...converted.entities];
   }
 
   // v1: @name fallback via memberMap (skip offsets already covered by v2)

--- a/src/mention-utils.ts
+++ b/src/mention-utils.ts
@@ -203,20 +203,11 @@ export function buildEntitiesFromFallback(
  *
  * @param content Raw text possibly containing @[uid:name] and/or @name
  * @param memberMap Optional displayName→uid map for @name resolution
- * @param isValidUid Optional A8 (#143) membership predicate. When provided, a
- *   structured `@[uid:name]` whose uid fails the predicate (e.g. a hallucinated
- *   uid not in the group's live member list) is DOWNGRADED to plain text: the
- *   human-readable `@name` stays in the body (convertStructuredMentions already
- *   replaced `@[uid:name]` with `@name`), but no entity/uid is emitted, so no
- *   bogus notification is sent. Omit it (DMs, or to preserve legacy behavior) to
- *   trust every structured uid. v1 `@name` entities are inherently members (they
- *   come from memberMap) so they are not re-checked.
  * @returns finalContent (with @[uid:name] replaced by @name) + entities + uids + mentionAll
  */
 export function resolveMentions(
   content: string,
   memberMap?: Map<string, string>,
-  isValidUid?: (uid: string) => boolean,
 ): {
   finalContent: string;
   mentionUids: string[];
@@ -231,12 +222,7 @@ export function resolveMentions(
   if (structured.length > 0) {
     const converted = convertStructuredMentions(finalContent, structured);
     finalContent = converted.content;
-    // A8 (#143): drop entities for uids that aren't real members — the `@name`
-    // text is already in finalContent, so dropping the entity downgrades a
-    // hallucinated mention to harmless plain text instead of a bogus @ notify.
-    entities = isValidUid
-      ? converted.entities.filter((e) => isValidUid(e.uid))
-      : [...converted.entities];
+    entities = [...converted.entities];
   }
 
   // v1: @name fallback via memberMap (skip offsets already covered by v2)

--- a/src/stream-relay.ts
+++ b/src/stream-relay.ts
@@ -165,7 +165,6 @@ export class StreamRelay {
     botToken: string,
     maxResponseChars: number = DEFAULT_MAX_RESPONSE_CHARS,
     memberMap?: Map<string, string>,
-    isValidUid?: (uid: string) => boolean,
   ): Promise<void> {
     // --- Typing heartbeat ---
     const typingParams = { apiUrl, botToken, channelId, channelType };
@@ -220,7 +219,7 @@ export class StreamRelay {
           finalContent,
           mentionEntities: globalEntities,
           mentionAll,
-        } = resolveMentions(accumulated, memberMap, isValidUid);
+        } = resolveMentions(accumulated, memberMap);
 
         const protectedRanges = globalEntities.map(e => ({
           start: e.offset,

--- a/src/stream-relay.ts
+++ b/src/stream-relay.ts
@@ -165,6 +165,7 @@ export class StreamRelay {
     botToken: string,
     maxResponseChars: number = DEFAULT_MAX_RESPONSE_CHARS,
     memberMap?: Map<string, string>,
+    isValidUid?: (uid: string) => boolean,
   ): Promise<void> {
     // --- Typing heartbeat ---
     const typingParams = { apiUrl, botToken, channelId, channelType };
@@ -219,7 +220,7 @@ export class StreamRelay {
           finalContent,
           mentionEntities: globalEntities,
           mentionAll,
-        } = resolveMentions(accumulated, memberMap);
+        } = resolveMentions(accumulated, memberMap, isValidUid);
 
         const protectedRanges = globalEntities.map(e => ({
           start: e.offset,


### PR DESCRIPTION
Reworks #144 to fix **Jerry-Xin's blocking 🔴**. Re-closes #143.

This branch is **revert of #144** + a corrected reimplementation, so the history shows exactly what changed vs the merged-then-reverted version.

## What was wrong with #144

#144 was merged prematurely over an unresolved blocking review. Jerry-Xin correctly flagged: the membership check **wasn't based on an authoritative member set**.

`refreshMembers` only **upserted** members returned by `getGroupMembers` — it **never pruned** members who left. So `isMember()` accepted:
- a user who left the group (still cached), and
- stale uids restored from the `group_members` DB table on restart.

→ the outbound guard's core guarantee (`uid ∉ members → downgrade to plain text`) was defeated. The "stronger than openclaw, validates real membership" claim was hollow because the set only ever grew.

## Fix

**1. Authoritative roster in `refreshMembers`** — members absent from a (non-empty) server response are pruned from memory (`memberMap` / `nameToUid` / `robotFlags`) **and** the persisted `group_members` row (new `deleteMember` statement). The server roster is the source of truth (verified non-paginated).

**2. Empty-roster guard** (found by the post-fix code-review) — `getGroupMembers` returns `[]` both for a genuinely empty group **and** for a malformed 200 (`data.members` not an array → silently `[]`). A group the bot is in always has ≥1 member, so we **prune only when `present.size > 0`**. Otherwise one transient quirk would wipe the whole roster — and since `lastRefresh` is set on that "success", it wouldn't re-fetch for 1h, downgrading every mention to plain text in that window. A real emptying still prunes member-by-member across non-empty shrinking responses.

**3. A8 guard on the now-authoritative set** — `isMember` / `getNameToUidMap` getters; `resolveMentions` gains an optional `isValidUid` predicate (a v2 `@[uid:name]` whose uid isn't a member → downgraded to plain `@name`, no entity/uid); `deliver` + `index.ts` wired (groups only, DMs skip). Also activates the previously-**dead** v1 `@name` resolution (`deliver`'s `memberMap` param was never passed).

**Best-effort, documented:** only as fresh as the throttled (1h) refresh + DB seed on restart. Defense-in-depth — the server still enforces real permissions.

## Tests (8 new, 988 total)

- **Jerry-Xin's required case**: refresh `{u1,u2}` then `{u1}` → `isMember(u2)` false, reverse name entry gone.
- Departed member's **DB row** pruned and **not resurrected** on `loadMembersFromDb`.
- **Empty-roster does NOT mass-prune** (transient-quirk guard).
- A8 hit / miss (downgrade) / mixed / legacy-no-predicate; `isMember` + `getNameToUidMap` getters.

## Verification

- `npm run type-check` ok · `npm run lint` (zero warnings) ok · `npm test` — 988 passing
- `code-review` skill (medium) run — surfaced the empty-roster mass-prune, fixed in this branch before pushing.

cc @Jerry-Xin — this addresses the stale-membership 🔴 directly; please re-review.