### PR TITLE
chore: merge main into feat/agent-runtime

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,20 @@
+# Release Drafter config — https://github.com/release-drafter/release-drafter
+name-template: "$NEXT_PATCH_VERSION"
+tag-template: "v$NEXT_PATCH_VERSION"
+template: |
+  ## What's Changed
+
+  $CHANGES
+
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
+categories:
+  - title: "Features"
+    labels: ["type:feature"]
+  - title: "Bug Fixes"
+    labels: ["type:bug"]
+  - title: "CI and Infrastructure"
+    labels: ["type:chore", dependencies-changed, dependencies]
+  - title: "Documentation"
+    labels: ["type:docs"]
+exclude-labels: [skip-changelog]
+change-template: "- $TITLE @$AUTHOR (#$NUMBER)"

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,94 @@
+name: npm Publish
+
+# Publishes the package to the public npm registry.
+#
+# Trigger: when a GitHub Release is published (the release-publish workflow flips
+# the draft to published, which fires `release: published`), or manually via
+# workflow_dispatch with an explicit tag.
+#
+# Auth: uses the NPM_TOKEN repository secret (an npm automation/granular token
+# with publish rights on the @mininglamp-oss scope). Provenance is attached via
+# OIDC (`id-token: write` + publishConfig.provenance:true in package.json), so
+# the published version carries a verifiable build-origin attestation.
+#
+# Safety: the job refuses to publish unless the tag's `vX.Y.Z` matches the
+# version in package.json, so a mismatched tag can never push a wrong version.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to publish (e.g. v1.0.0). Must be an existing tag."
+        required: true
+        type: string
+
+permissions: {}
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write # required for npm provenance (OIDC)
+    steps:
+      - name: Resolve tag
+        id: tag
+        env:
+          EVENT_TAG: ${{ github.event.release.tag_name }}
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          TAG="${EVENT_TAG:-$INPUT_TAG}"
+          if [ -z "$TAG" ]; then
+            echo "::error::No tag resolved from release event or dispatch input."
+            exit 1
+          fi
+          # Strict semver tag (mirrors the org release-publish regex).
+          if ! printf '%s' "$TAG" | grep -Eq \
+            '^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*))?([+][0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'; then
+            echo "::error::Tag '$TAG' is not strict semver (vMAJOR.MINOR.PATCH[-prerelease])"
+            exit 1
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "Resolved tag: $TAG"
+
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ steps.tag.outputs.tag }}
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '22'
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Verify tag matches package.json version
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          EXPECTED="v${PKG_VERSION}"
+          if [ "$TAG" != "$EXPECTED" ]; then
+            echo "::error::Tag '$TAG' does not match package.json version '$EXPECTED'. Refusing to publish."
+            exit 1
+          fi
+          echo "Tag matches package.json: $EXPECTED"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm test
+
+      - name: Publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -2,21 +2,28 @@ name: npm Publish
 
 # Publishes the package to the public npm registry.
 #
-# Trigger: when a GitHub Release is published (the release-publish workflow flips
-# the draft to published, which fires `release: published`), or manually via
-# workflow_dispatch with an explicit tag.
+# Trigger: on a pushed stable version tag `vX.Y.Z` (NOT pre-releases like
+# `vX.Y.Z-rc.1`), or manually via workflow_dispatch with an explicit tag.
+#
+# Why tag-push instead of `release: published`: the release-publish workflow
+# creates the GitHub Release with the built-in GITHUB_TOKEN, and GitHub does not
+# cascade workflow triggers from GITHUB_TOKEN-produced events (anti-recursion),
+# so a `release: published` trigger never fires automatically. A tag push is not
+# subject to that block.
 #
 # Auth: uses the NPM_TOKEN repository secret (an npm automation/granular token
 # with publish rights on the @mininglamp-oss scope). Provenance is attached via
 # OIDC (`id-token: write` + publishConfig.provenance:true in package.json), so
 # the published version carries a verifiable build-origin attestation.
 #
-# Safety: the job refuses to publish unless the tag's `vX.Y.Z` matches the
-# version in package.json, so a mismatched tag can never push a wrong version.
+# Safety: the job refuses to publish unless (a) the tag is strict semver, (b) the
+# tagged commit is an ancestor of origin/main (no publishing off-branch code),
+# and (c) the tag's `vX.Y.Z` matches the version in package.json.
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - 'v*.*.*'
   workflow_dispatch:
     inputs:
       tag:
@@ -38,13 +45,13 @@ jobs:
       - name: Resolve tag
         id: tag
         env:
-          EVENT_TAG: ${{ github.event.release.tag_name }}
+          REF_TAG: ${{ github.ref_type == 'tag' && github.ref_name || '' }}
           INPUT_TAG: ${{ inputs.tag }}
         run: |
           set -euo pipefail
-          TAG="${EVENT_TAG:-$INPUT_TAG}"
+          TAG="${REF_TAG:-$INPUT_TAG}"
           if [ -z "$TAG" ]; then
-            echo "::error::No tag resolved from release event or dispatch input."
+            echo "::error::No tag resolved from tag push or dispatch input."
             exit 1
           fi
           # Strict semver tag (mirrors the org release-publish regex).
@@ -53,20 +60,46 @@ jobs:
             echo "::error::Tag '$TAG' is not strict semver (vMAJOR.MINOR.PATCH[-prerelease])"
             exit 1
           fi
+          # Skip pre-release tags on automatic (tag-push) runs so they never land
+          # on npm 'latest'. A maintainer can still force one via workflow_dispatch.
+          if printf '%s' "$TAG" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+-'; then
+            if [ "${{ github.event_name }}" = "push" ]; then
+              echo "::notice::Tag '$TAG' is a pre-release; skipping automatic npm publish. Use workflow_dispatch to publish a pre-release deliberately."
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+            fi
+          fi
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "Resolved tag: $TAG"
 
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        if: steps.tag.outputs.skip != 'true'
         with:
           ref: ${{ steps.tag.outputs.tag }}
+          fetch-depth: 0 # need history for the ancestor check
+
+      - name: Verify tagged commit is on main
+        if: steps.tag.outputs.skip != 'true'
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin main
+          TAG_SHA=$(git rev-list -n 1 "$TAG")
+          if ! git merge-base --is-ancestor "$TAG_SHA" origin/main; then
+            echo "::error::Tag '$TAG' ($TAG_SHA) is not an ancestor of origin/main. Refusing to publish off-branch code."
+            exit 1
+          fi
+          echo "Tag commit $TAG_SHA is reachable from origin/main ✓"
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        if: steps.tag.outputs.skip != 'true'
         with:
           node-version: '22'
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Verify tag matches package.json version
+        if: steps.tag.outputs.skip != 'true'
         env:
           TAG: ${{ steps.tag.outputs.tag }}
         run: |
@@ -80,15 +113,19 @@ jobs:
           echo "Tag matches package.json: $EXPECTED"
 
       - name: Install dependencies
+        if: steps.tag.outputs.skip != 'true'
         run: npm ci
 
       - name: Build
+        if: steps.tag.outputs.skip != 'true'
         run: npm run build
 
       - name: Test
+        if: steps.tag.outputs.skip != 'true'
         run: npm test
 
       - name: Publish
+        if: steps.tag.outputs.skip != 'true'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,15 @@
+name: Release Drafter
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  draft:
+    uses: Mininglamp-OSS/.github/.github/workflows/reusable-release-drafter.yml@v1
+    permissions:
+      contents: write
+      pull-requests: read

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,0 +1,31 @@
+name: Release Publish
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to publish (e.g. v1.4.0)"
+        required: true
+        type: string
+      validate_run_id:
+        description: "Required: successful CI run ID from the tagged commit as release evidence"
+        required: true
+        type: string
+      draft:
+        description: "Keep as draft instead of publishing"
+        required: false
+        type: boolean
+        default: false
+
+permissions: {}
+
+jobs:
+  publish:
+    uses: Mininglamp-OSS/.github/.github/workflows/reusable-release-publish.yml@v1
+    with:
+      tag: ${{ inputs.tag }}
+      validate_run_id: ${{ inputs.validate_run_id }}
+      draft: ${{ inputs.draft }}
+    permissions:
+      contents: write
+      actions: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,110 +8,15 @@ While the major version is `0`, minor releases may carry breaking changes.
 
 ## [Unreleased]
 
-### Security
+## [1.0.0] - 2026-06-10
 
-- **WebSocket transport must be `wss://`** — the WuKongIM payload layer is
-  AES-CBC without an auth tag, so transport integrity is the only tamper guarantee.
-  `gateway.connect()` now refuses a plaintext `ws://` endpoint for any non-loopback
-  host (`isAllowedWsUrl` in `url-policy.ts`); `ws://localhost` stays allowed for
-  local dev / a co-located TLS-terminating proxy.
-- **Binary protocol decoder bounds-checked** — `Decoder` (`octo/socket.ts`) now
-  throws `RangeError` on any over-read (truncated packet, or a string length field
-  exceeding the remaining buffer) instead of silently reading `undefined`
-  (→ 0/NaN coercion → corrupt parses, wrong messageID/seq → ack mismatch). The
-  packet-decode loop already catches and reconnects, so a malformed packet now
-  fails cleanly.
-- **Partial agent output no longer lost on stream error** — if the agent stream
-  throws mid-delivery, `StreamRelay.deliver` now flushes the already-accumulated
-  text to the channel before re-throwing, instead of dropping a real partial reply.
-- **`@all` / `@所有人` broadcast detection tightened** — the trailing-boundary
-  check used `[^\w]`, so `@all-members` / `@all.foo` wrongly triggered a
-  broadcast-to-everyone. It now excludes name-continuation chars (`-`, `.`, CJK),
-  while still matching a standalone token followed by space, CJK punctuation, or
-  end-of-string.
-
-### Changed
-
-- **Frozen system prompt + SDK-session-owned history** — the bot's
-  `systemPrompt.append` now carries ONLY stable, operator-controlled content
-  (security prefix + SOUL + group instructions). Per-turn-variable content —
-  conversation history (B5) and group context (B4) — no longer sits inside the
-  SDK's cached system block, so the prompt-caching prefix is byte-identical
-  turn-to-turn and actually hits (previously every turn was a cache-write with zero
-  reads, because the changing history/context lived inside the `cache_control`
-  block). Follows Anthropic's own guidance ("keep the system prompt frozen; inject
-  dynamic context in a user message"). **Conversation history is now owned by the
-  SDK session:** cc always `resume`s the stored session id; only a session's FIRST
-  turn (or a migration from existing SQLite history) injects prior history ONCE as
-  a `[Prior conversation history]` block in the user message. **Group context** is
-  injected as a delta — only messages new since a per-channel consumption cursor
-  (`group_context_cursors`), not the whole window every turn. **`sdk.cron`-style
-  flag removed:** `sdk.persistentSession` is gone — SDK sessions are always on (with
-  the flag off and history out of the prompt, "off" would mean no memory at all).
-  **Stale-resume recovery:** an expired/invalid session id (the SDK throws "No
-  conversation found with session ID …") is caught, the bad id cleared, and the turn
-  retried once without resume — re-injecting history from SQLite so a conversation is
-  never silently lost. SQLite's role is now state/cursors/mappings + a durable record
-  (migration & recovery substrate), not live prompt-history reconstruction.
-  `buildSystemPrompt(customPrompt?, groupInstructions?)` and `queryAgent(userMessage,
-  config, sessionCtx?, onToolUse?, opts?)` lost their history/context params.
-  **Migration:** drop any `sdk.persistentSession` / `CC_OCTO_SDK_PERSISTENT_SESSION`
-  from config — it's ignored now; existing SQLite history is injected once on each
-  session's next turn, then carried by the SDK session.
-
-### Removed
-
-- **Dead Octo API functions** — removed `fetchBotGroups`, `getGroupInfo`,
-  `searchSpaceMembers` (originally G15/G16/G17) and their `BotGroup` / `GroupInfo`
-  / `SpaceMember` interfaces from `octo/api.ts`. They had **zero production callers**
-  (only tests referenced them) — these read-only group/space queries are covered by
-  the agent's octo-cli skill (`octo-cli group list` / `group get` / `bot space-members`).
-  No runtime behavior change.
-- **Dead media-upload pipeline + `cos-nodejs-sdk-v5`** — removed `media-upload.ts`
-  (`uploadAndSendMedia` / `sendRichTextCombined` / `uploadFileToCOS`) and the
-  `sendMediaMessage` / `sendRichTextMessage` API functions. This outbound media /
-  rich-text pipeline had **zero production callers** (born-dead) — outbound media is
-  handled by the agent's octo-cli skill (`octo-cli file upload` + `message send`)
-  under the skill-as-data model. Dropping it removes the direct dependency on
-  `cos-nodejs-sdk-v5`, which transitively pulled in the deprecated `request@2.88.2`
-  chain and an old `fast-xml-parser` — clearing **11 Dependabot alerts** (2 critical,
-  2 high incl. an unpatchable `request` SSRF) with no runtime behavior change.
-  Inbound media (`media-inbound.ts`) and the startup CDN-host probe
-  (`getUploadCredentials` in `index.ts`) are unaffected.
-- **Webhook transport** (#105) — removed; the Octo server does not POST to the
-  bot, so webhook mode was dead code. WebSocket is the only transport.
-
-### Fixed
-
-- **Cron robustness — review follow-ups** (#115) — four operational-hardening
-  fixes from the xhigh review: (1/5) cron fires now **bypass the rate limit**
-  (like the @mention gate) so an operator-scheduled task isn't silently dropped
-  when the owner's bucket is exhausted, and the scheduler **logs an async fire
-  failure attributed to the specific task** (delivery errors were previously
-  invisible); (2) a **startup warning** when `sdk.cron` is on but the bot has no
-  `owner_uid` (the owner-gate would otherwise reject every `cron_create` with no
-  hint why); (3) a synthetic cron fire's `message_seq=0` **no longer poisons the
-  history-segmentation cursor** (`setLastBotReplySeq` is skipped for non-positive
-  seq); (6) **strict ISO-8601 validation** for one-shot schedules
-  (`parseOneShot`) so a lenient rollover like `2026-13-13T…` is rejected instead
-  of silently firing at a shifted time.
-
-- **Router drops non-conversation channel types** (#68) — found in live
-  deployment: on connect the bot received a system message on `channel_type: 8`
-  (`systemcmdonline`) and replied to it. `SessionRouter` now allowlists only DM /
-  Group / CommunityTopic as repliable; any other (system/command) channel type is
-  dropped before the agent is invoked.
-
-### Changed
-
-- **Config is JSON-only — all environment-variable overrides removed** (#103).
-  The entire `CC_OCTO_*` env surface and the `ANTHROPIC_BASE_URL` env read are
-  gone; `applyEnv()` (and its `parseCsv`/`parseIntStrict` helpers) were deleted.
-  Configuration now comes solely from the two-layer config.json (global +
-  per-bot). `sdk.anthropicBaseUrl` remains a config.json field (still forwarded
-  to the SDK subprocess as `ANTHROPIC_BASE_URL`). **Migration:** move any
-  `CC_OCTO_*` / `ANTHROPIC_BASE_URL` values into `~/.cc-channel-octo/config.json`
-  (or the per-bot file). Old env vars are now silently ignored.
+First stable release. Consolidates everything merged since `0.2.0` — the v0.3
+line (slash commands, tool progress, multi-bot, v2 Session API), the v1.0 line
+(per-group `GROUP.md` instructions), scheduled tasks (cron), skill-as-data
+external tooling, the frozen-system-prompt / SDK-session-owned-history rework,
+and a large batch of security hardening. **Contains breaking changes** —
+configuration is now JSON-only and the `sdk.persistentSession` flag was removed
+(see Changed / Migration notes below).
 
 ### Added
 
@@ -210,8 +115,64 @@ While the major version is `0`, minor releases may carry breaking changes.
   cold-start backfill cannot resurrect the cleared history, even across a
   process restart. Commands are subject to the normal per-session rate limit.
 
+### Changed
+
+- **Frozen system prompt + SDK-session-owned history** — the bot's
+  `systemPrompt.append` now carries ONLY stable, operator-controlled content
+  (security prefix + SOUL + group instructions). Per-turn-variable content —
+  conversation history (B5) and group context (B4) — no longer sits inside the
+  SDK's cached system block, so the prompt-caching prefix is byte-identical
+  turn-to-turn and actually hits (previously every turn was a cache-write with zero
+  reads, because the changing history/context lived inside the `cache_control`
+  block). Follows Anthropic's own guidance ("keep the system prompt frozen; inject
+  dynamic context in a user message"). **Conversation history is now owned by the
+  SDK session:** cc always `resume`s the stored session id; only a session's FIRST
+  turn (or a migration from existing SQLite history) injects prior history ONCE as
+  a `[Prior conversation history]` block in the user message. **Group context** is
+  injected as a delta — only messages new since a per-channel consumption cursor
+  (`group_context_cursors`), not the whole window every turn. **`sdk.cron`-style
+  flag removed:** `sdk.persistentSession` is gone — SDK sessions are always on (with
+  the flag off and history out of the prompt, "off" would mean no memory at all).
+  **Stale-resume recovery:** an expired/invalid session id (the SDK throws "No
+  conversation found with session ID …") is caught, the bad id cleared, and the turn
+  retried once without resume — re-injecting history from SQLite so a conversation is
+  never silently lost. SQLite's role is now state/cursors/mappings + a durable record
+  (migration & recovery substrate), not live prompt-history reconstruction.
+  `buildSystemPrompt(customPrompt?, groupInstructions?)` and `queryAgent(userMessage,
+  config, sessionCtx?, onToolUse?, opts?)` lost their history/context params.
+  **Migration:** drop any `sdk.persistentSession` / `CC_OCTO_SDK_PERSISTENT_SESSION`
+  from config — it's ignored now; existing SQLite history is injected once on each
+  session's next turn, then carried by the SDK session.
+- **Config is JSON-only — all environment-variable overrides removed** (#103).
+  The entire `CC_OCTO_*` env surface and the `ANTHROPIC_BASE_URL` env read are
+  gone; `applyEnv()` (and its `parseCsv`/`parseIntStrict` helpers) were deleted.
+  Configuration now comes solely from the two-layer config.json (global +
+  per-bot). `sdk.anthropicBaseUrl` remains a config.json field (still forwarded
+  to the SDK subprocess as `ANTHROPIC_BASE_URL`). **Migration:** move any
+  `CC_OCTO_*` / `ANTHROPIC_BASE_URL` values into `~/.cc-channel-octo/config.json`
+  (or the per-bot file). Old env vars are now silently ignored.
+
 ### Removed
 
+- **Dead Octo API functions** — removed `fetchBotGroups`, `getGroupInfo`,
+  `searchSpaceMembers` (originally G15/G16/G17) and their `BotGroup` / `GroupInfo`
+  / `SpaceMember` interfaces from `octo/api.ts`. They had **zero production callers**
+  (only tests referenced them) — these read-only group/space queries are covered by
+  the agent's octo-cli skill (`octo-cli group list` / `group get` / `bot space-members`).
+  No runtime behavior change.
+- **Dead media-upload pipeline + `cos-nodejs-sdk-v5`** — removed `media-upload.ts`
+  (`uploadAndSendMedia` / `sendRichTextCombined` / `uploadFileToCOS`) and the
+  `sendMediaMessage` / `sendRichTextMessage` API functions. This outbound media /
+  rich-text pipeline had **zero production callers** (born-dead) — outbound media is
+  handled by the agent's octo-cli skill (`octo-cli file upload` + `message send`)
+  under the skill-as-data model. Dropping it removes the direct dependency on
+  `cos-nodejs-sdk-v5`, which transitively pulled in the deprecated `request@2.88.2`
+  chain and an old `fast-xml-parser` — clearing **11 Dependabot alerts** (2 critical,
+  2 high incl. an unpatchable `request` SSRF) with no runtime behavior change.
+  Inbound media (`media-inbound.ts`) and the startup CDN-host probe
+  (`getUploadCredentials` in `index.ts`) are unaffected.
+- **Webhook transport** (#105) — removed; the Octo server does not POST to the
+  bot, so webhook mode was dead code. WebSocket is the only transport.
 - **In-process Octo MCP tool server** (#87, never released) — the read-only
   `mcp__octo__*` tools (`list_groups`, `group_info`, `group_members`,
   `search_members`) and the `sdk.octoTools` toggle are removed in favor of the
@@ -222,6 +183,48 @@ While the major version is `0`, minor releases may carry breaking changes.
   seeding, and the `OCTO_API_BASE_URL`/`OCTO_BOT_ID` env injection are removed.
   They baked one CLI into cc's core; #100 replaces them with the generic,
   zero-CLI-name skill loader.
+
+### Fixed
+
+- **Cron robustness — review follow-ups** (#115) — four operational-hardening
+  fixes from the xhigh review: (1/5) cron fires now **bypass the rate limit**
+  (like the @mention gate) so an operator-scheduled task isn't silently dropped
+  when the owner's bucket is exhausted, and the scheduler **logs an async fire
+  failure attributed to the specific task** (delivery errors were previously
+  invisible); (2) a **startup warning** when `sdk.cron` is on but the bot has no
+  `owner_uid` (the owner-gate would otherwise reject every `cron_create` with no
+  hint why); (3) a synthetic cron fire's `message_seq=0` **no longer poisons the
+  history-segmentation cursor** (`setLastBotReplySeq` is skipped for non-positive
+  seq); (6) **strict ISO-8601 validation** for one-shot schedules
+  (`parseOneShot`) so a lenient rollover like `2026-13-13T…` is rejected instead
+  of silently firing at a shifted time.
+- **Router drops non-conversation channel types** (#68) — found in live
+  deployment: on connect the bot received a system message on `channel_type: 8`
+  (`systemcmdonline`) and replied to it. `SessionRouter` now allowlists only DM /
+  Group / CommunityTopic as repliable; any other (system/command) channel type is
+  dropped before the agent is invoked.
+
+### Security
+
+- **WebSocket transport must be `wss://`** — the WuKongIM payload layer is
+  AES-CBC without an auth tag, so transport integrity is the only tamper guarantee.
+  `gateway.connect()` now refuses a plaintext `ws://` endpoint for any non-loopback
+  host (`isAllowedWsUrl` in `url-policy.ts`); `ws://localhost` stays allowed for
+  local dev / a co-located TLS-terminating proxy.
+- **Binary protocol decoder bounds-checked** — `Decoder` (`octo/socket.ts`) now
+  throws `RangeError` on any over-read (truncated packet, or a string length field
+  exceeding the remaining buffer) instead of silently reading `undefined`
+  (→ 0/NaN coercion → corrupt parses, wrong messageID/seq → ack mismatch). The
+  packet-decode loop already catches and reconnects, so a malformed packet now
+  fails cleanly.
+- **Partial agent output no longer lost on stream error** — if the agent stream
+  throws mid-delivery, `StreamRelay.deliver` now flushes the already-accumulated
+  text to the channel before re-throwing, instead of dropping a real partial reply.
+- **`@all` / `@所有人` broadcast detection tightened** — the trailing-boundary
+  check used `[^\w]`, so `@all-members` / `@all.foo` wrongly triggered a
+  broadcast-to-everyone. It now excludes name-continuation chars (`-`, `.`, CJK),
+  while still matching a standalone token followed by space, CJK punctuation, or
+  end-of-string.
 
 ## [0.2.0] - 2026-06-07
 
@@ -310,5 +313,6 @@ hardening across the SSRF, prompt-injection, and protocol-DoS surfaces.
 Initial tagged baseline: text messaging, streaming output, SQLite session
 persistence, rate limiting, and the core security model.
 
+[1.0.0]: https://github.com/Mininglamp-OSS/cc-channel-octo/compare/v0.2.0...v1.0.0
 [0.2.0]: https://github.com/Mininglamp-OSS/cc-channel-octo/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/Mininglamp-OSS/cc-channel-octo/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ While the major version is `0`, minor releases may carry breaking changes.
 
 ## [Unreleased]
 
+### Added
+
+- **Process-supervisor CLI** — `cc-channel-octo start|stop|restart|status`
+  backgrounds the gateway, tracks a process-wide PID file, and stops it
+  gracefully (SIGTERM → SIGKILL on timeout). The `bin` now points at the
+  supervisor (`dist/cli.js`). Backward compatible: a bare `cc-channel-octo`
+  (or `npx @mininglamp-oss/cc-channel-octo`) still starts the gateway in the
+  foreground, same as before.
+
 ## [1.0.1] - 2026-06-10
 
 The first npm-installable release. No runtime behavior change — packaging only.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,36 @@ While the major version is `0`, minor releases may carry breaking changes.
 
 ## [Unreleased]
 
+## [1.0.1] - 2026-06-10
+
+The first npm-installable release. No runtime behavior change — packaging only.
+
+### Added
+
+- **Published to npm as `@mininglamp-oss/cc-channel-octo`** — install with
+  `npm install -g @mininglamp-oss/cc-channel-octo` or run via
+  `npx @mininglamp-oss/cc-channel-octo`. A new GitHub Actions workflow
+  (`npm-publish.yml`) publishes on a released tag (and via manual dispatch),
+  with OIDC build provenance; it refuses to publish unless the tag matches
+  `package.json`.
+- **`cc-channel-octo` CLI bin** — the package now exposes a `bin`, so a global
+  install / `npx` starts the gateway directly (no clone + build needed).
+
+### Fixed
+
+- **Gateway auto-start when launched via the installed bin** — the main-module
+  guard compared `import.meta.url` against `process.argv[1]` verbatim, but the
+  installed bin is a symlink under `node_modules/.bin/`, so the paths never
+  matched and `main()` never fired (the command exited silently). The guard now
+  canonicalizes both sides with `realpath`.
+
+### Changed
+
+- **`package.json` packaging metadata** — scoped name, a `files` allowlist
+  (so the compiled `dist/` is actually shipped despite being `.gitignore`d),
+  `publishConfig` (public + provenance), `repository` / `bugs` / `homepage`,
+  and a `prepublishOnly` build hook.
+
 ## [1.0.0] - 2026-06-10
 
 First stable release. Consolidates everything merged since `0.2.0` — the v0.3
@@ -313,6 +343,7 @@ hardening across the SSRF, prompt-injection, and protocol-DoS surfaces.
 Initial tagged baseline: text messaging, streaming output, SQLite session
 persistence, rate limiting, and the core security model.
 
+[1.0.1]: https://github.com/Mininglamp-OSS/cc-channel-octo/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/Mininglamp-OSS/cc-channel-octo/compare/v0.2.0...v1.0.0
 [0.2.0]: https://github.com/Mininglamp-OSS/cc-channel-octo/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/Mininglamp-OSS/cc-channel-octo/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 
 <p align="center">
   <a href="https://github.com/Mininglamp-OSS/cc-channel-octo/actions"><img src="https://github.com/Mininglamp-OSS/cc-channel-octo/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <a href="https://www.npmjs.com/package/cc-channel-octo"><img src="https://img.shields.io/npm/v/cc-channel-octo" alt="npm version"></a>
+  <a href="https://www.npmjs.com/package/@mininglamp-oss/cc-channel-octo"><img src="https://img.shields.io/npm/v/@mininglamp-oss/cc-channel-octo" alt="npm version"></a>
   <a href="./LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-blue" alt="License"></a>
-  <img src="https://img.shields.io/node/v/cc-channel-octo" alt="Node.js version">
+  <img src="https://img.shields.io/node/v/@mininglamp-oss/cc-channel-octo" alt="Node.js version">
 </p>
 
 ---

--- a/README.md
+++ b/README.md
@@ -532,7 +532,7 @@ src/
     └── types.ts        # Protocol type definitions
 ```
 
-## Known Limitations (v0.2)
+## Known Limitations (v1.0)
 
 - **Per-session workspace isolation** — Each session gets its own SHA-256 hex sandbox under the bot's `workspace/` (`<baseDir>/<botId>/workspace`), partitioned by the same key as conversation history — **per DM peer** and **per group channel** (a whole group shares one sandbox by design). Idle sandboxes (>7d) are auto-cleaned every 6h. Note: it separates sessions from each other but does not confine a session to its directory (absolute-path reads via Bash/Read remain possible) — see the Security Model section.
 - **Groups are a shared workspace** — All members of a group share one history, one sandbox, and one auto-memory store (the session key is the channel id). There is **no member-to-member isolation within a group**; DM sessions remain private per peer.
@@ -544,9 +544,8 @@ src/
 | Version | Scope |
 |---------|-------|
 | **v0.1** | Text messaging, streaming, session persistence, rate limiting, security model |
-| **v0.2** *(released)* | Media reception & sending (image/file/RichText), @mention, group context, per-session `cwdBase` isolation, self-hosted gateway, SSRF/prompt-injection hardening |
-| **v0.3** *(merged, unreleased)* | Slash commands, tool progress, multi-bot, v2 Session API |
-| **v1.0** *(merged, unreleased)* | GROUP.md per-group instructions |
+| **v0.2** | Media reception & sending (image/file/RichText), @mention, group context, per-session `cwdBase` isolation, self-hosted gateway, SSRF/prompt-injection hardening |
+| **v1.0** *(current)* | Slash commands, tool progress, multi-bot, SDK-session-owned history, GROUP.md per-group instructions, scheduled tasks (cron), skill-as-data external tooling, JSON-only config |
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,23 @@ Users talk to a bot in Octo (DM or group @mention). The bot sends messages to Cl
 
 ### Install & Run
 
+**Option A — install from npm (recommended):**
+
+```bash
+npm install -g @mininglamp-oss/cc-channel-octo
+# or run without installing:
+npx @mininglamp-oss/cc-channel-octo
+```
+
+This installs the `cc-channel-octo` command (prebuilt — no compile step). Skip
+straight to creating the config files below, then run `cc-channel-octo`.
+
+To use it as a library instead, `npm install @mininglamp-oss/cc-channel-octo`
+and import from it; the Claude Agent SDK is a peer dependency, so install
+`@anthropic-ai/claude-agent-sdk` alongside it.
+
+**Option B — build from source:**
+
 ```bash
 git clone https://github.com/Mininglamp-OSS/cc-channel-octo.git
 cd cc-channel-octo
@@ -94,7 +111,9 @@ Per-bot `~/.cc-channel-octo/default/config.json`:
 Start the gateway:
 
 ```bash
-npm start
+npm start                      # from source (Option B)
+# or, if installed from npm (Option A):
+cc-channel-octo
 ```
 
 The bot is now online. Send it a DM or @mention it in a group.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "cc-channel-octo",
-  "version": "0.2.0",
+  "name": "@mininglamp-oss/cc-channel-octo",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "cc-channel-octo",
-      "version": "0.2.0",
+      "name": "@mininglamp-oss/cc-channel-octo",
+      "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "better-sqlite3": "^12.10.0",
@@ -15,6 +15,9 @@
         "md5-typescript": "^1.0.5",
         "ws": "^8.16.0",
         "zod": "^4.4.3"
+      },
+      "bin": {
+        "cc-channel-octo": "dist/index.js"
       },
       "devDependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.162",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mininglamp-oss/cc-channel-octo",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Bridge Claude Code (via Claude Agent SDK) to Octo IM — independent Node.js gateway",
   "license": "Apache-2.0",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,34 @@
 {
-  "name": "cc-channel-octo",
+  "name": "@mininglamp-oss/cc-channel-octo",
   "version": "1.0.0",
   "description": "Bridge Claude Code (via Claude Agent SDK) to Octo IM — independent Node.js gateway",
   "license": "Apache-2.0",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "bin": {
+    "cc-channel-octo": "dist/index.js"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "CHANGELOG.md",
+    "LICENSE",
+    "config.example.json",
+    "config.bot.example.json"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Mininglamp-OSS/cc-channel-octo.git"
+  },
+  "homepage": "https://github.com/Mininglamp-OSS/cc-channel-octo#readme",
+  "bugs": {
+    "url": "https://github.com/Mininglamp-OSS/cc-channel-octo/issues"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
@@ -15,6 +38,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
+    "prepublishOnly": "npm run build",
     "prepare": "husky || true"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-channel-octo",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "description": "Bridge Claude Code (via Claude Agent SDK) to Octo IM — independent Node.js gateway",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/__tests__/group-context.test.ts
+++ b/src/__tests__/group-context.test.ts
@@ -170,6 +170,24 @@ describe('GroupContext', () => {
     expect(ctx.resolveMentions('@Alice and @Alice again', 'ch1')).toEqual(['u1']);
   });
 
+  // --- A8 (#143): outbound mention validation getters ---
+
+  it('isMember reflects the live member list per channel', () => {
+    ctx.learnMember('ch1', 'u1', 'Alice');
+    expect(ctx.isMember('ch1', 'u1')).toBe(true);
+    expect(ctx.isMember('ch1', 'ghost')).toBe(false);
+    // Isolation: a member of ch1 is not a member of ch2.
+    expect(ctx.isMember('ch2', 'u1')).toBe(false);
+  });
+
+  it('getNameToUidMap exposes the displayName→uid map for outbound @name', () => {
+    ctx.learnMember('ch1', 'u1', 'Alice');
+    const map = ctx.getNameToUidMap('ch1');
+    expect(map.get('Alice')).toBe('u1');
+    // Unknown channel → empty (not undefined).
+    expect(ctx.getNameToUidMap('nope').size).toBe(0);
+  });
+
   // --- refreshMembers ---
 
   it('refreshMembers throttles within 1h', async () => {

--- a/src/__tests__/group-context.test.ts
+++ b/src/__tests__/group-context.test.ts
@@ -170,24 +170,6 @@ describe('GroupContext', () => {
     expect(ctx.resolveMentions('@Alice and @Alice again', 'ch1')).toEqual(['u1']);
   });
 
-  // --- A8 (#143): outbound mention validation getters ---
-
-  it('isMember reflects the live member list per channel', () => {
-    ctx.learnMember('ch1', 'u1', 'Alice');
-    expect(ctx.isMember('ch1', 'u1')).toBe(true);
-    expect(ctx.isMember('ch1', 'ghost')).toBe(false);
-    // Isolation: a member of ch1 is not a member of ch2.
-    expect(ctx.isMember('ch2', 'u1')).toBe(false);
-  });
-
-  it('getNameToUidMap exposes the displayName→uid map for outbound @name', () => {
-    ctx.learnMember('ch1', 'u1', 'Alice');
-    const map = ctx.getNameToUidMap('ch1');
-    expect(map.get('Alice')).toBe('u1');
-    // Unknown channel → empty (not undefined).
-    expect(ctx.getNameToUidMap('nope').size).toBe(0);
-  });
-
   // --- refreshMembers ---
 
   it('refreshMembers throttles within 1h', async () => {
@@ -430,5 +412,98 @@ describe('G23: robot flag', () => {
     await ctx.refreshMembers('ch2', 'https://api', 'token');
     expect(ctx.isRobot('ch1', 'shared')).toBe(true);
     expect(ctx.isRobot('ch2', 'shared')).toBe(false);
+  });
+
+  // --- A8 (#143): authoritative membership + outbound validation getters ---
+
+  it('isMember / getNameToUidMap reflect a learned member', () => {
+    ctx.learnMember('ch1', 'u1', 'Alice');
+    expect(ctx.isMember('ch1', 'u1')).toBe(true);
+    expect(ctx.isMember('ch1', 'ghost')).toBe(false);
+    expect(ctx.isMember('ch2', 'u1')).toBe(false); // per-channel isolation
+    expect(ctx.getNameToUidMap('ch1').get('Alice')).toBe('u1');
+    expect(ctx.getNameToUidMap('nope').size).toBe(0);
+  });
+
+  it('refreshMembers prunes a departed member (Jerry-Xin 🔴): memory + reverse map', async () => {
+    // First authoritative refresh: u1 + u2 present.
+    (getGroupMembers as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce([
+        { uid: 'u1', name: 'Alice', role: 0 },
+        { uid: 'u2', name: 'Bob', role: 0 },
+      ])
+      .mockResolvedValueOnce([{ uid: 'u1', name: 'Alice', role: 0 }]); // u2 left
+    await ctx.refreshMembers('ch-prune', 'https://api', 'token');
+    expect(ctx.isMember('ch-prune', 'u1')).toBe(true);
+    expect(ctx.isMember('ch-prune', 'u2')).toBe(true);
+
+    // Bypass the 1h throttle so the second refresh is effective.
+    vi.useFakeTimers();
+    vi.setSystemTime(Date.now() + 61 * 60 * 1000);
+    try {
+      await ctx.refreshMembers('ch-prune', 'https://api', 'token');
+    } finally {
+      vi.useRealTimers();
+    }
+    // Guard: the second refresh actually ran (not silently throttled).
+    expect(getGroupMembers).toHaveBeenCalledTimes(2);
+
+    // u2 left → must no longer be a member, and its reverse name entry is gone.
+    expect(ctx.isMember('ch-prune', 'u1')).toBe(true);
+    expect(ctx.isMember('ch-prune', 'u2')).toBe(false);
+    expect(ctx.getNameToUidMap('ch-prune').get('Bob')).toBeUndefined();
+    expect(ctx.getNameToUidMap('ch-prune').get('Alice')).toBe('u1');
+  });
+
+  it('refreshMembers pruning removes the persisted DB row for a departed member', async () => {
+    // Roster shrinks from {gone, keep} → {keep}. A non-empty response is trusted
+    // as authoritative, so `gone` is pruned from memory AND the DB.
+    (getGroupMembers as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce([
+        { uid: 'gone', name: 'Ghost', role: 0 },
+        { uid: 'keep', name: 'Keeper', role: 0 },
+      ])
+      .mockResolvedValueOnce([{ uid: 'keep', name: 'Keeper', role: 0 }]);
+    await ctx.refreshMembers('ch-db', 'https://api', 'token');
+    expect(ctx.isMember('ch-db', 'gone')).toBe(true);
+
+    vi.useFakeTimers();
+    vi.setSystemTime(Date.now() + 61 * 60 * 1000);
+    try {
+      await ctx.refreshMembers('ch-db', 'https://api', 'token');
+    } finally {
+      vi.useRealTimers();
+    }
+    expect(ctx.isMember('ch-db', 'gone')).toBe(false);
+    expect(ctx.isMember('ch-db', 'keep')).toBe(true);
+
+    // A fresh GroupContext loading from the same DB must NOT resurrect the row.
+    const ctx2 = new GroupContext(adapter, 6000);
+    ctx2.loadMembersFromDb('ch-db');
+    expect(ctx2.isMember('ch-db', 'gone')).toBe(false);
+    expect(ctx2.isMember('ch-db', 'keep')).toBe(true);
+  });
+
+  it('refreshMembers does NOT mass-prune on an empty roster response (transient-quirk guard)', async () => {
+    (getGroupMembers as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce([
+        { uid: 'u1', name: 'Alice', role: 0 },
+        { uid: 'u2', name: 'Bob', role: 0 },
+      ])
+      .mockResolvedValueOnce([]); // empty: treated as a quirk, not "everyone left"
+    await ctx.refreshMembers('ch-empty', 'https://api', 'token');
+    expect(ctx.isMember('ch-empty', 'u1')).toBe(true);
+
+    vi.useFakeTimers();
+    vi.setSystemTime(Date.now() + 61 * 60 * 1000);
+    try {
+      await ctx.refreshMembers('ch-empty', 'https://api', 'token');
+    } finally {
+      vi.useRealTimers();
+    }
+    expect(getGroupMembers).toHaveBeenCalledTimes(2);
+    // Prior roster is kept — an empty response does not wipe everyone.
+    expect(ctx.isMember('ch-empty', 'u1')).toBe(true);
+    expect(ctx.isMember('ch-empty', 'u2')).toBe(true);
   });
 });

--- a/src/__tests__/mention-utils.test.ts
+++ b/src/__tests__/mention-utils.test.ts
@@ -250,7 +250,6 @@ describe('resolveMentions', () => {
     it('downgrades a hallucinated uid to plain text (drops entity, keeps @name)', () => {
       const members = new Set(['u1']);
       const result = resolveMentions('@[deadbeef:Ghost] hi', undefined, (uid) => members.has(uid));
-      // @name text survives, but no entity/uid is emitted → no bogus notify.
       expect(result.finalContent).toBe('@Ghost hi');
       expect(result.mentionUids).toEqual([]);
       expect(result.mentionEntities).toEqual([]);

--- a/src/__tests__/mention-utils.test.ts
+++ b/src/__tests__/mention-utils.test.ts
@@ -236,6 +236,40 @@ describe('resolveMentions', () => {
     expect(result.mentionEntities[1].uid).toBe('u1');
     expect(result.mentionUids).toEqual(['u2', 'u1']);
   });
+
+  // A8 (#143): membership validation of outbound structured @[uid:name]
+  describe('isValidUid membership guard', () => {
+    it('keeps a structured mention whose uid passes the predicate', () => {
+      const members = new Set(['u1']);
+      const result = resolveMentions('@[u1:Alice] hi', undefined, (uid) => members.has(uid));
+      expect(result.finalContent).toBe('@Alice hi');
+      expect(result.mentionUids).toEqual(['u1']);
+      expect(result.mentionEntities).toHaveLength(1);
+    });
+
+    it('downgrades a hallucinated uid to plain text (drops entity, keeps @name)', () => {
+      const members = new Set(['u1']);
+      const result = resolveMentions('@[deadbeef:Ghost] hi', undefined, (uid) => members.has(uid));
+      // @name text survives, but no entity/uid is emitted → no bogus notify.
+      expect(result.finalContent).toBe('@Ghost hi');
+      expect(result.mentionUids).toEqual([]);
+      expect(result.mentionEntities).toEqual([]);
+    });
+
+    it('keeps real members and drops hallucinated ones in the same message', () => {
+      const members = new Set(['u1']);
+      const result = resolveMentions('@[u1:Alice] and @[fake:Bob]', undefined, (uid) => members.has(uid));
+      expect(result.finalContent).toBe('@Alice and @Bob');
+      expect(result.mentionUids).toEqual(['u1']);
+      expect(result.mentionEntities).toHaveLength(1);
+      expect(result.mentionEntities[0].uid).toBe('u1');
+    });
+
+    it('without a predicate, trusts every structured uid (legacy behavior)', () => {
+      const result = resolveMentions('@[whatever:Ghost] hi');
+      expect(result.mentionUids).toEqual(['whatever']);
+    });
+  });
 });
 
 describe('patterns', () => {

--- a/src/__tests__/session-router.test.ts
+++ b/src/__tests__/session-router.test.ts
@@ -469,6 +469,112 @@ describe('routeAndHandle concurrency', () => {
   });
 });
 
+// ─── #141: Dispatch timeout ────────────────────────────────────────────────
+
+describe('dispatch timeout (#141)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('a hung handler does not block the next message on the same session', async () => {
+    const router = new SessionRouter(
+      makeConfig({ rateLimit: { maxPerMinute: 100 }, dispatchTimeoutMs: 50 }),
+      ROBOT_ID,
+    );
+    const completed: number[] = [];
+
+    // Message 1: handler never resolves (simulates a hung agent turn).
+    const p1 = router.routeAndHandle(
+      makeMsg({ message_id: '1', channel_type: ChannelType.DM, from_uid: 'same-user' }),
+      () => new Promise<void>(() => { /* never resolves */ }),
+    );
+
+    // Message 2: a normal fast handler on the SAME session. Without the
+    // timeout it would be blocked forever behind message 1's session lock.
+    const p2 = router.routeAndHandle(
+      makeMsg({ message_id: '2', channel_type: ChannelType.DM, from_uid: 'same-user' }),
+      async () => { completed.push(2); },
+    );
+
+    await Promise.all([p1, p2]);
+
+    // Message 2 ran — the lock was released after message 1 timed out.
+    expect(completed).toEqual([2]);
+  });
+
+  it('sends a single bounded apology on timeout', async () => {
+    const router = new SessionRouter(
+      makeConfig({ rateLimit: { maxPerMinute: 100 }, dispatchTimeoutMs: 30 }),
+      ROBOT_ID,
+    );
+
+    await router.routeAndHandle(
+      makeMsg({ message_id: '1', channel_type: ChannelType.DM, from_uid: 'u1' }),
+      () => new Promise<void>(() => { /* never resolves */ }),
+    );
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(sendMessage).mock.calls[0][0]).toMatchObject({
+      content: expect.stringContaining('处理超时'),
+    });
+  });
+
+  it('does not fire for a normal fast handler', async () => {
+    const router = new SessionRouter(
+      makeConfig({ rateLimit: { maxPerMinute: 100 }, dispatchTimeoutMs: 1000 }),
+      ROBOT_ID,
+    );
+    let ran = false;
+
+    await router.routeAndHandle(
+      makeMsg({ message_id: '1', channel_type: ChannelType.DM, from_uid: 'u1' }),
+      async () => { ran = true; },
+    );
+
+    expect(ran).toBe(true);
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it('disabled (0) runs the handler unguarded', async () => {
+    const router = new SessionRouter(
+      makeConfig({ rateLimit: { maxPerMinute: 100 }, dispatchTimeoutMs: 0 }),
+      ROBOT_ID,
+    );
+    let ran = false;
+
+    await router.routeAndHandle(
+      makeMsg({ message_id: '1', channel_type: ChannelType.DM, from_uid: 'u1' }),
+      async () => { ran = true; },
+    );
+
+    expect(ran).toBe(true);
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it('a rejecting handler does not wedge the session (next message still runs)', async () => {
+    const router = new SessionRouter(
+      makeConfig({ rateLimit: { maxPerMinute: 100 }, dispatchTimeoutMs: 1000 }),
+      ROBOT_ID,
+    );
+    const completed: number[] = [];
+
+    // Message 1: handler rejects fast (a real handler error, not a timeout).
+    await router.routeAndHandle(
+      makeMsg({ message_id: '1', channel_type: ChannelType.DM, from_uid: 'same-user' }),
+      async () => { throw new Error('boom'); },
+    );
+    // Message 2: same session — must still run (lock released, no timeout apology).
+    await router.routeAndHandle(
+      makeMsg({ message_id: '2', channel_type: ChannelType.DM, from_uid: 'same-user' }),
+      async () => { completed.push(2); },
+    );
+
+    expect(completed).toEqual([2]);
+    // A non-timeout error must NOT trigger the timeout apology.
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+});
+
 // ─── Q10: Message length limit ─────────────────────────────────────────────
 
 describe('Message length limit (Q10)', () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -230,8 +230,12 @@ export async function run(argv: string[], baseDir?: string): Promise<number> {
       console.log(USAGE);
       return 0;
     case '':
-      console.error(USAGE);
-      return 2;
+      // Backward compat: bare `cc-channel-octo` (e.g. `npx cc-channel-octo`)
+      // runs the gateway in the foreground, matching the pre-supervisor bin
+      // (`dist/index.js`) behavior documented in README/CHANGELOG. Daemon-style
+      // process management is opt-in via the `start`/`stop`/`restart`/`status`
+      // subcommands.
+      return cmdStart(paths, true);
     default:
       console.error(`cc-channel-octo: unknown command '${cmd}'\n`);
       console.error(USAGE);

--- a/src/config.ts
+++ b/src/config.ts
@@ -174,6 +174,15 @@ export interface Config {
   };
   /** Maximum response length in chars before truncation (Q32). */
   maxResponseChars: number;
+  /**
+   * Per-message dispatch timeout in ms (#141). Bounds the full handler
+   * pipeline (agent query + stream) under the per-session lock. If a turn
+   * hangs past this, the session lock is released (a hung turn would otherwise
+   * block every subsequent message on that session forever) and the user gets
+   * a one-shot apology. Does NOT cancel the in-flight turn — only unblocks the
+   * queue. Default 5 minutes.
+   */
+  dispatchTimeoutMs: number;
   botBlocklist?: string[];
   /**
    * G14: Bots in this list are allowed to DM the bot even if their uid matches
@@ -247,6 +256,7 @@ type PartialConfig = {
   rateLimit?: Partial<Config['rateLimit']>;
   context?: Partial<Config['context']>;
   maxResponseChars?: number;
+  dispatchTimeoutMs?: number;
   botBlocklist?: string[];
   allowedBotUids?: string[];
   mentionFreeGroups?: string[];
@@ -282,6 +292,7 @@ function defaults(): Config {
       historyLimit: 40,
     },
     maxResponseChars: 524_288, // 512 KB (Q32)
+    dispatchTimeoutMs: 300_000, // 5 min (#141)
   };
 }
 
@@ -345,6 +356,7 @@ function mergeConfig(base: Config, override: PartialConfig): Config {
       ...(override.context ?? {}),
     },
     maxResponseChars: override.maxResponseChars ?? base.maxResponseChars,
+    dispatchTimeoutMs: override.dispatchTimeoutMs ?? base.dispatchTimeoutMs,
     botBlocklist: override.botBlocklist ?? base.botBlocklist,
     allowedBotUids: override.allowedBotUids ?? base.allowedBotUids,
     mentionFreeGroups: override.mentionFreeGroups ?? base.mentionFreeGroups,

--- a/src/group-context.ts
+++ b/src/group-context.ts
@@ -36,6 +36,7 @@ export class GroupContext {
   private readonly maxWindowSize: number;
 
   private upsertMember!: PreparedStatement;
+  private deleteMember!: PreparedStatement;
   private selectMembers!: PreparedStatement;
   private insertMessage!: PreparedStatement;
   private selectRecentMessages!: PreparedStatement;
@@ -83,6 +84,9 @@ export class GroupContext {
 
     this.upsertMember = this.adapter.prepare(
       'INSERT INTO group_members (group_id, uid, name, updated_at) VALUES (?, ?, ?, ?) ON CONFLICT(group_id, uid) DO UPDATE SET name = excluded.name, updated_at = excluded.updated_at',
+    );
+    this.deleteMember = this.adapter.prepare(
+      'DELETE FROM group_members WHERE group_id = ? AND uid = ?',
     );
     this.selectMembers = this.adapter.prepare(
       'SELECT uid, name FROM group_members WHERE group_id = ?',
@@ -202,8 +206,23 @@ export class GroupContext {
       this.lastRefresh.set(channelId, now); // Record only on success
       const memberMap = this.getMemberMap(channelId);
       const nameMap = this.getNameToUid(channelId);
+
+      // A8 (#143, take 2): the server response is AUTHORITATIVE — it is the full
+      // current roster, not a delta. Upserting returned members WITHOUT pruning
+      // departed ones (the original #144 bug, Jerry-Xin's 🔴) left a user who
+      // left the group cached forever, so isMember() kept accepting them and the
+      // outbound mention guard let a stale @uid through. Track who the server
+      // returned, then drop anyone cached/persisted who is no longer present.
+      //
+      // Best-effort caveat: this is only as fresh as the last successful refresh,
+      // which is throttled to REFRESH_INTERVAL_MS (1h) and seeded from DB on
+      // restart. A membership change inside that window is not reflected until
+      // the next refresh — the outbound guard is defense-in-depth, not a
+      // real-time authority. The server still enforces real permissions.
+      const present = new Set<string>();
       for (const m of members) {
         if (!m.uid || !m.name) continue;
+        present.add(m.uid);
         const oldName = memberMap.get(m.uid);
         if (oldName && oldName !== m.name && nameMap.get(oldName) === m.uid) {
           nameMap.delete(oldName);
@@ -223,6 +242,39 @@ export class GroupContext {
           this.upsertMember.run(channelId, m.uid, m.name, now);
         } catch (err) {
           console.error(`group-context: upsert member failed: ${String(err)}`);
+        }
+      }
+
+      // Prune members no longer in the authoritative roster (memory + DB + robot
+      // flags). Iterate a snapshot of uids since we mutate the map in the loop.
+      //
+      // Guard: skip pruning when the roster came back EMPTY. getGroupMembers
+      // returns [] not only for a genuinely empty group but also for a
+      // malformed/unexpected-shape 200 response (data.members not an array →
+      // silently []). A group the bot is in always has ≥1 member, so an empty
+      // roster is far more likely a transient quirk than "everyone left".
+      // Mass-pruning on it would wipe the whole roster — and since lastRefresh
+      // was already set on this "success", it wouldn't re-fetch for an hour,
+      // downgrading every mention to plain text in that window. Keep the prior
+      // snapshot instead; a real emptying still prunes member-by-member as the
+      // roster shrinks across non-empty responses.
+      if (present.size > 0) {
+        const rfMap = this.robotFlags.get(channelId);
+        for (const uid of [...memberMap.keys()]) {
+          if (present.has(uid)) continue;
+          const staleName = memberMap.get(uid);
+          memberMap.delete(uid);
+          // Only remove the reverse entry if it still points at THIS uid (a rename
+          // may have already re-pointed the name to someone else).
+          if (staleName !== undefined && nameMap.get(staleName) === uid) {
+            nameMap.delete(staleName);
+          }
+          rfMap?.delete(uid);
+          try {
+            this.deleteMember.run(channelId, uid);
+          } catch (err) {
+            console.error(`group-context: delete stale member failed: ${String(err)}`);
+          }
         }
       }
     } catch (err) {
@@ -393,9 +445,13 @@ export class GroupContext {
   }
 
   /**
-   * A8 (#143): true iff `uid` is a current member of `channelId` per the live
-   * member list (refreshed on every inbound group message). Used by the outbound
-   * mention sanitizer to drop hallucinated @uids that aren't real members.
+   * A8 (#143): true iff `uid` is a current member of `channelId` per the cached
+   * member list. The list is kept authoritative by refreshMembers (it prunes
+   * departed members, not just upserts) — but it is only best-effort fresh:
+   * refresh is throttled to REFRESH_INTERVAL_MS and seeded from DB on restart,
+   * so a membership change inside that window may not be reflected yet. Used by
+   * the outbound mention guard as defense-in-depth (the server still enforces
+   * real permissions), NOT as a real-time authority.
    */
   isMember(channelId: string, uid: string): boolean {
     return this.memberMapByChannel.get(channelId)?.has(uid) ?? false;

--- a/src/group-context.ts
+++ b/src/group-context.ts
@@ -392,6 +392,24 @@ export class GroupContext {
     return this.robotFlags.get(channelId)?.get(uid);
   }
 
+  /**
+   * A8 (#143): true iff `uid` is a current member of `channelId` per the live
+   * member list (refreshed on every inbound group message). Used by the outbound
+   * mention sanitizer to drop hallucinated @uids that aren't real members.
+   */
+  isMember(channelId: string, uid: string): boolean {
+    return this.memberMapByChannel.get(channelId)?.has(uid) ?? false;
+  }
+
+  /**
+   * A8 (#143): the channel's displayName→uid map, for v1 `@name` outbound
+   * resolution in StreamRelay.deliver. Returns the live map (empty if the
+   * channel has no cached members yet). Read-only use by callers.
+   */
+  getNameToUidMap(channelId: string): Map<string, string> {
+    return this.getNameToUid(channelId);
+  }
+
   loadMembersFromDb(channelId: string): void {
     try {
       const rows = this.selectMembers.all(channelId) as MemberRow[];

--- a/src/index.ts
+++ b/src/index.ts
@@ -782,7 +782,15 @@ export async function handleMessage(
       }
 
       // --- Stream output to Octo ---
-      await streamRelay.deliver(channelId, channelType, teeChunks(), config.apiUrl, config.botToken, config.maxResponseChars);
+      // A8 (#143): in groups, resolve v1 @name against the live member list and
+      // validate v2 @[uid:name] uids against membership — a hallucinated uid not
+      // in the group is downgraded to plain text (no bogus @ notify). DMs have no
+      // member list and no @ semantics, so both args stay undefined (skip).
+      const outboundNameToUid = isGroup ? groupContext.getNameToUidMap(channelId) : undefined;
+      const isValidMentionUid = isGroup
+        ? (uid: string): boolean => groupContext.isMember(channelId, uid)
+        : undefined;
+      await streamRelay.deliver(channelId, channelType, teeChunks(), config.apiUrl, config.botToken, config.maxResponseChars, outboundNameToUid, isValidMentionUid);
 
       // G8: Send read receipt after processing (fire-and-forget)
       if (msg.message_id && msg.channel_id && msg.channel_type !== undefined) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 /**
  * cc-channel-octo — Entry point.
  * Bridge Claude Code (via Claude Agent SDK) to Octo IM.
@@ -30,8 +31,8 @@ import { CronScheduler } from './cron-scheduler.js';
 import { createCronToolServer, CRON_TOOL_SERVER_NAME, type CronSessionCoords } from './cron-tool.js';
 import { buildInlinedFileBody, truncateUtf8ByBytes, assembleUserMessage, MAX_USER_LLM_BYTES } from './file-inline-wrap.js';
 import { join } from 'node:path';
-import { mkdirSync } from 'node:fs';
-import { pathToFileURL } from 'node:url';
+import { mkdirSync, realpathSync } from 'node:fs';
+import { pathToFileURL, fileURLToPath } from 'node:url';
 
 async function main(): Promise<void> {
   // --- Q8: Global unhandled rejection handler ---
@@ -982,12 +983,28 @@ function seedHistoryFromApi(
 }
 
 // Only auto-start the gateway when this module is run directly (production
-// entrypoint), NOT when it is imported (e.g. tests importing handleMessage).
+// entrypoint or the installed `cc-channel-octo` bin), NOT when it is imported
+// (e.g. tests importing handleMessage).
 // `process.argv[1]` is undefined under `node -e`/`--input-type`, so guard it.
+// When invoked via the bin, `process.argv[1]` is a symlink under
+// `node_modules/.bin/` whose href would NOT equal the resolved module url —
+// so canonicalize both sides with realpath before comparing.
 const entrypoint = process.argv[1];
-if (entrypoint && import.meta.url === pathToFileURL(entrypoint).href) {
+if (entrypoint && isMainModule(entrypoint)) {
   main().catch((err) => {
     console.error('[cc-channel-octo] Fatal error:', String(err));
     process.exit(1);
   });
+}
+
+function isMainModule(argvPath: string): boolean {
+  try {
+    const resolvedArgv = pathToFileURL(realpathSync(argvPath)).href;
+    const resolvedSelf = pathToFileURL(realpathSync(fileURLToPath(import.meta.url))).href;
+    return resolvedArgv === resolvedSelf;
+  } catch {
+    // Fall back to a direct href comparison if realpath fails (e.g. the file
+    // was unlinked after launch). Better to under-trigger than to crash.
+    return import.meta.url === pathToFileURL(argvPath).href;
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -782,10 +782,12 @@ export async function handleMessage(
       }
 
       // --- Stream output to Octo ---
-      // A8 (#143): in groups, resolve v1 @name against the live member list and
+      // A8 (#143): in groups, resolve v1 @name against the member list and
       // validate v2 @[uid:name] uids against membership — a hallucinated uid not
-      // in the group is downgraded to plain text (no bogus @ notify). DMs have no
-      // member list and no @ semantics, so both args stay undefined (skip).
+      // in the group is downgraded to plain text (no bogus @ notify). The member
+      // list is kept authoritative by refreshMembers (prunes departed members),
+      // best-effort fresh (1h refresh throttle). DMs have no member list and no
+      // @ semantics, so both args stay undefined (skip).
       const outboundNameToUid = isGroup ? groupContext.getNameToUidMap(channelId) : undefined;
       const isValidMentionUid = isGroup
         ? (uid: string): boolean => groupContext.isMember(channelId, uid)

--- a/src/mention-utils.ts
+++ b/src/mention-utils.ts
@@ -205,12 +205,13 @@ export function buildEntitiesFromFallback(
  * @param memberMap Optional displayName→uid map for @name resolution
  * @param isValidUid Optional A8 (#143) membership predicate. When provided, a
  *   structured `@[uid:name]` whose uid fails the predicate (e.g. a hallucinated
- *   uid not in the group's live member list) is DOWNGRADED to plain text: the
+ *   uid not in the group's member list) is DOWNGRADED to plain text: the
  *   human-readable `@name` stays in the body (convertStructuredMentions already
  *   replaced `@[uid:name]` with `@name`), but no entity/uid is emitted, so no
  *   bogus notification is sent. Omit it (DMs, or to preserve legacy behavior) to
  *   trust every structured uid. v1 `@name` entities are inherently members (they
- *   come from memberMap) so they are not re-checked.
+ *   come from memberMap) so they are not re-checked. Best-effort: only as fresh
+ *   as the caller's member snapshot (see GroupContext.isMember).
  * @returns finalContent (with @[uid:name] replaced by @name) + entities + uids + mentionAll
  */
 export function resolveMentions(

--- a/src/mention-utils.ts
+++ b/src/mention-utils.ts
@@ -203,11 +203,20 @@ export function buildEntitiesFromFallback(
  *
  * @param content Raw text possibly containing @[uid:name] and/or @name
  * @param memberMap Optional displayName→uid map for @name resolution
+ * @param isValidUid Optional A8 (#143) membership predicate. When provided, a
+ *   structured `@[uid:name]` whose uid fails the predicate (e.g. a hallucinated
+ *   uid not in the group's live member list) is DOWNGRADED to plain text: the
+ *   human-readable `@name` stays in the body (convertStructuredMentions already
+ *   replaced `@[uid:name]` with `@name`), but no entity/uid is emitted, so no
+ *   bogus notification is sent. Omit it (DMs, or to preserve legacy behavior) to
+ *   trust every structured uid. v1 `@name` entities are inherently members (they
+ *   come from memberMap) so they are not re-checked.
  * @returns finalContent (with @[uid:name] replaced by @name) + entities + uids + mentionAll
  */
 export function resolveMentions(
   content: string,
   memberMap?: Map<string, string>,
+  isValidUid?: (uid: string) => boolean,
 ): {
   finalContent: string;
   mentionUids: string[];
@@ -222,7 +231,12 @@ export function resolveMentions(
   if (structured.length > 0) {
     const converted = convertStructuredMentions(finalContent, structured);
     finalContent = converted.content;
-    entities = [...converted.entities];
+    // A8 (#143): drop entities for uids that aren't real members — the `@name`
+    // text is already in finalContent, so dropping the entity downgrades a
+    // hallucinated mention to harmless plain text instead of a bogus @ notify.
+    entities = isValidUid
+      ? converted.entities.filter((e) => isValidUid(e.uid))
+      : [...converted.entities];
   }
 
   // v1: @name fallback via memberMap (skip offsets already covered by v2)

--- a/src/session-router.ts
+++ b/src/session-router.ts
@@ -128,10 +128,76 @@ export class SessionRouter {
     return this.withSessionLock(key, async () => {
       const result = await this.processMessage(msg, key);
       if (result && result.shouldProcess) {
-        await handler(result);
+        await this.runHandlerWithTimeout(result, handler);
       }
       return result;
     });
+  }
+
+  /**
+   * #141: Run the handler under a dispatch timeout so a hung turn (a stuck SDK
+   * query, a wedged tool subprocess, a stalled stream) cannot block the session
+   * forever. The handler runs inside withSessionLock — if it never returns, the
+   * lock's gate never resolves and EVERY subsequent message for this session is
+   * stuck permanently (silent). Racing the handler against a timeout guarantees
+   * the lock releases.
+   *
+   * Scope (mirrors openclaw #75): we do NOT cancel the in-flight turn — the SDK
+   * query keeps running to completion in the background; we only unblock the
+   * queue. Worst case is a delayed real reply arriving after the apology.
+   *
+   * `timeoutError` is a per-invocation Error so the catch identifies OUR timeout
+   * by reference equality, never by string comparison (a same-text upstream
+   * error must not be misclassified).
+   */
+  private async runHandlerWithTimeout(
+    result: RouteResult,
+    handler: (result: RouteResult) => Promise<void>,
+  ): Promise<void> {
+    const timeoutMs = this.config.dispatchTimeoutMs;
+    if (!timeoutMs || timeoutMs <= 0) {
+      // Timeout disabled — run unguarded.
+      await handler(result);
+      return;
+    }
+
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+    const timeoutError = new Error(`dispatch timed out after ${timeoutMs}ms`);
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      timeoutHandle = setTimeout(() => reject(timeoutError), timeoutMs);
+    });
+
+    // The handler keeps running after a timeout (we don't cancel the in-flight
+    // turn — see scope note above). Once the race settles on timeoutError, that
+    // orphaned promise is no longer awaited; attach a no-op catch so a late
+    // rejection from a handler that doesn't self-contain its errors can't surface
+    // as an unhandledRejection. Today's caller (index.ts) is fully try/caught, so
+    // this is defense-in-depth for future callers.
+    const handlerPromise = handler(result);
+    handlerPromise.catch(() => { /* swallow late rejection after timeout */ });
+
+    try {
+      await Promise.race([handlerPromise, timeoutPromise]);
+    } catch (err) {
+      if (err === timeoutError) {
+        console.warn(
+          `session-router: dispatch hung past ${timeoutMs}ms, releasing session lock (session=${result.sessionKey})`,
+        );
+        // Bounded apology — replySafe swallows its own errors, and the
+        // underlying sendMessage in octo/api.ts is itself time-bounded, so a
+        // sick Octo API can't re-hang us here.
+        await this.replySafe(result.message, '⚠️ 处理超时，请稍后重试。');
+        return; // swallow: the lock releases, the queue advances
+      }
+      // A real handler error — index.ts's handler already catches and replies
+      // internally, so reaching here is unexpected. Swallow to keep the lock
+      // release path identical (never let an error wedge the queue).
+      console.error(
+        `session-router: handler error (session=${result.sessionKey}): ${String(err)}`,
+      );
+    } finally {
+      if (timeoutHandle) clearTimeout(timeoutHandle);
+    }
   }
 
   async route(msg: BotMessage): Promise<RouteResult | null> {

--- a/src/stream-relay.ts
+++ b/src/stream-relay.ts
@@ -165,6 +165,7 @@ export class StreamRelay {
     botToken: string,
     maxResponseChars: number = DEFAULT_MAX_RESPONSE_CHARS,
     memberMap?: Map<string, string>,
+    isValidUid?: (uid: string) => boolean,
   ): Promise<void> {
     // --- Typing heartbeat ---
     const typingParams = { apiUrl, botToken, channelId, channelType };
@@ -219,7 +220,7 @@ export class StreamRelay {
           finalContent,
           mentionEntities: globalEntities,
           mentionAll,
-        } = resolveMentions(accumulated, memberMap);
+        } = resolveMentions(accumulated, memberMap, isValidUid);
 
         const protectedRanges = globalEntities.map(e => ({
           start: e.offset,


### PR DESCRIPTION
## What

Merge `main` into `feat/agent-runtime` to bring the runtime branch up to date with the released gateway (v1.0.0/v1.0.1) and two functional fixes that the runtime branch was missing.

## Why

`feat/agent-runtime` had diverged: it added the supervisor CLI (`src/cli.ts`) but was missing 8 commits from `main`, including two real fixes:

- **#142** — per-message dispatch timeout to unblock hung sessions
- **#144 / #145** — outbound `@mention` validated against the live group member set (drops hallucinated mentions)

…plus the npm release machinery (v1.0.0/v1.0.1, `npm-publish.yml`, release-drafter).

## Conflict resolution

Only `package.json` conflicted (src code had **zero** overlap — main touched session-router/mention-utils/group-context/etc., the runtime branch only added `cli.ts`):

- `bin` → kept the runtime branch's `dist/cli.js` (the process-supervisor entry).
- `version` → took main's `1.0.1` (already published; must not regress).
- `files` / `repository` / `homepage` / `bugs` / `publishConfig` → kept main's publish fields.
- `package-lock.json` regenerated via `npm install` (bin → `dist/cli.js`, version → `1.0.1`; no dependency-tree drift).

## Follow-up fix included (`fix(cli)`)

The `bin` switch to the supervisor meant a bare `cc-channel-octo` / `npx @mininglamp-oss/cc-channel-octo` returned usage+exit 2 instead of starting the gateway — contradicting the README/CHANGELOG. Restored the documented behavior: an empty command now runs `cmdStart(foreground)`. Daemon-style management stays opt-in via `start`/`stop`/`restart`/`status`. CHANGELOG `[Unreleased]` updated.

## Verification

- `npm run build` (tsc) — clean
- `npm test` (vitest) — **1002/1002 passed** (51 files), incl. `cli.test.ts`
- `npm run lint` (eslint `--max-warnings 0`) — clean
- codex review — merge correctness + cli fix confirmed, no blockers
