### PR TITLE
feat(cli): add version command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ While the major version is `0`, minor releases may carry breaking changes.
   supervisor (`dist/cli.js`). Backward compatible: a bare `cc-channel-octo`
   (or `npx @mininglamp-oss/cc-channel-octo`) still starts the gateway in the
   foreground, same as before.
+- **`version` / `--version` / `-v`** — prints the package version (read at
+  runtime from `package.json`), and the `--help` banner now carries the version
+  on its first line.
 
 ## [1.0.1] - 2026-06-10
 

--- a/docs/superpowers/plans/2026-06-17-cli-version.md
+++ b/docs/superpowers/plans/2026-06-17-cli-version.md
@@ -28,34 +28,53 @@
 
 **Interfaces:**
 - Consumes: nothing.
-- Produces: `export function readVersion(): string` — returns the package version string, or `'unknown'` if `package.json` can't be read/parsed or has no string `version`.
+- Produces:
+  - `export function parseVersion(raw: string): string` — pure (no I/O); extracts the version from raw package.json text, returns `'unknown'` if the text is malformed or has no non-empty string `version`.
+  - `export function readVersion(): string` — reads the package's own `package.json` and delegates to `parseVersion`; returns `'unknown'` if the file can't be read.
 
 **Why this resolves correctly:** both `src/cli.ts` and `dist/cli.js` are direct children of the package root, so `new URL('../package.json', import.meta.url)` points at the real `package.json` in test (vitest runs the TS source) and in production (compiled `dist`).
 
 - [ ] **Step 1: Write the failing test**
 
-Add to `src/__tests__/cli.test.ts`. First extend the import line:
+Add to `src/__tests__/cli.test.ts`. First extend the existing `from 'node:fs'` import to include `readFileSync`, and the `from '../cli.js'` import to include `readVersion` and `parseVersion` (do NOT import `run` yet — it's unused until Task 2, and `eslint --max-warnings 0` fails on an unused import):
 
 ```ts
+// node:fs import becomes:
+import { mkdtempSync, rmSync, writeFileSync, existsSync, readFileSync } from 'node:fs';
+// cli.js import adds readVersion, parseVersion:
 import {
-  parseArgs, isAlive, readPid, writePid, removePid, resolveSupervisorPaths, readVersion, run,
+  parseArgs, isAlive, readPid, writePid, removePid, resolveSupervisorPaths,
+  readVersion, parseVersion,
 } from '../cli.js';
-import { readFileSync } from 'node:fs';
 ```
 
 Then append:
 
 ```ts
+describe('parseVersion', () => {
+  it('extracts a string version', () => {
+    expect(parseVersion('{"version":"1.2.3"}')).toBe('1.2.3');
+  });
+  it('falls back to "unknown" on malformed JSON', () => {
+    expect(parseVersion('not json')).toBe('unknown');
+  });
+  it('falls back to "unknown" when version is missing', () => {
+    expect(parseVersion('{"name":"x"}')).toBe('unknown');
+  });
+  it('falls back to "unknown" when version is not a string', () => {
+    expect(parseVersion('{"version":123}')).toBe('unknown');
+  });
+  it('falls back to "unknown" on an empty version string', () => {
+    expect(parseVersion('{"version":""}')).toBe('unknown');
+  });
+});
+
 describe('readVersion', () => {
-  it('returns the version from package.json', () => {
+  it('returns the version from the real package.json', () => {
     const pkg = JSON.parse(
       readFileSync(new URL('../../package.json', import.meta.url), 'utf-8'),
     ) as { version: string };
     expect(readVersion()).toBe(pkg.version);
-  });
-
-  it('returns a non-empty semver-shaped string', () => {
-    expect(readVersion()).toMatch(/^\d+\.\d+\.\d+/);
   });
 });
 ```
@@ -64,22 +83,21 @@ describe('readVersion', () => {
 
 - [ ] **Step 2: Run test to verify it fails**
 
-Run: `npx vitest run src/__tests__/cli.test.ts -t readVersion`
-Expected: FAIL — `readVersion is not exported` / `is not a function`.
+Run: `npx vitest run src/__tests__/cli.test.ts -t "parseVersion|readVersion"`
+Expected: FAIL — `parseVersion`/`readVersion` not exported.
 
 - [ ] **Step 3: Write minimal implementation**
 
-In `src/cli.ts`, add `readFileSync` is already imported. Add after `resolveSupervisorPaths`:
+In `src/cli.ts`, `readFileSync` is already imported. Add after `resolveSupervisorPaths`:
 
 ```ts
 /**
- * The package version, read at runtime from package.json (a sibling of the
- * package root, one level up from this module in both src/ and dist/). Returns
- * 'unknown' rather than throwing if the file is missing or malformed.
+ * Extract a package version from raw package.json text. Returns 'unknown'
+ * rather than throwing if the text is malformed or has no non-empty string
+ * `version`. Pure (no I/O) so the fallback paths are unit-testable.
  */
-export function readVersion(): string {
+export function parseVersion(raw: string): string {
   try {
-    const raw = readFileSync(new URL('../package.json', import.meta.url), 'utf-8');
     const pkg: unknown = JSON.parse(raw);
     if (pkg && typeof pkg === 'object' && 'version' in pkg) {
       const v = (pkg as { version: unknown }).version;
@@ -90,12 +108,25 @@ export function readVersion(): string {
   }
   return 'unknown';
 }
+
+/**
+ * The package version, read at runtime from package.json — which lives at the
+ * package root, one level up from this module in both src/ (src/cli.ts) and the
+ * compiled output (dist/cli.js). Returns 'unknown' if the file can't be read.
+ */
+export function readVersion(): string {
+  try {
+    return parseVersion(readFileSync(new URL('../package.json', import.meta.url), 'utf-8'));
+  } catch {
+    return 'unknown';
+  }
+}
 ```
 
 - [ ] **Step 4: Run test to verify it passes**
 
-Run: `npx vitest run src/__tests__/cli.test.ts -t readVersion`
-Expected: PASS (both cases).
+Run: `npx vitest run src/__tests__/cli.test.ts -t "parseVersion|readVersion"`
+Expected: PASS (all six cases).
 
 - [ ] **Step 5: Commit**
 
@@ -118,11 +149,10 @@ git commit -m "feat(cli): add readVersion helper reading package.json at runtime
 
 - [ ] **Step 1: Write the failing test**
 
-Append to `src/__tests__/cli.test.ts`:
+In `src/__tests__/cli.test.ts`, add `run` to the `from '../cli.js'` import and `vi` to the existing `from 'vitest'` import, then append the block:
 
 ```ts
-import { vi } from 'vitest';
-
+// from '../cli.js' adds run; from 'vitest' adds vi.
 describe('run version command', () => {
   it.each(['version', '--version', '-v'])('prints bare version and exits 0 for %s', async (arg) => {
     const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
@@ -261,7 +291,7 @@ git commit -m "docs(changelog): note version command"
 
 ## Self-Review
 
-- **Spec coverage:** bare-version output (Task 2 Step 1 asserts `console.log` called with bare `readVersion()`), three triggers `version`/`--version`/`-v` (Task 2 `it.each`), runtime read of package.json (Task 1), `'unknown'` fallback (Task 1 implementation), USAGE banner carries version (Task 2 Step 3). All covered.
+- **Spec coverage:** bare-version output (Task 2 Step 1 asserts `console.log` called with bare `readVersion()`), three triggers `version`/`--version`/`-v` (Task 2 `it.each`), runtime read of package.json (Task 1 `readVersion`), `'unknown'` fallback (Task 1 `parseVersion` tests cover malformed/missing/non-string/empty), USAGE banner carries version (Task 2 Step 3). All covered.
 - **Placeholder scan:** no TBD/TODO; all code shown in full.
-- **Type consistency:** `readVersion(): string` defined Task 1, consumed Task 2 — signature matches. JSON parsed as `unknown` then narrowed (no `any`).
+- **Type consistency:** `parseVersion(raw: string): string` and `readVersion(): string` defined Task 1, consumed Task 2 — signatures match. JSON parsed as `unknown` then narrowed (no `any`). `run` imported in Task 2 (not Task 1) to avoid an unused-import lint failure.
 - **Path note:** `../package.json` inside `cli.ts` (src/ or dist/ → root); `../../package.json` inside the test file (src/__tests__/ → root). Both verified against the package layout.

--- a/docs/superpowers/plans/2026-06-17-cli-version.md
+++ b/docs/superpowers/plans/2026-06-17-cli-version.md
@@ -1,0 +1,267 @@
+# CLI `version` Command Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `version` / `--version` / `-v` command to the `cc-channel-octo` CLI that prints the package version (bare, e.g. `1.0.1`) read at runtime from `package.json`.
+
+**Architecture:** Add a pure `readVersion()` helper to `src/cli.ts` that reads `version` from the package's own `package.json` (resolved relative to the module via `import.meta.url`, so it works both from `dist/cli.js` and `src/cli.ts`). Wire three new cases into the existing `run()` switch that print the bare version and return 0. The `USAGE` banner gains the version on its first line, assembled at print time (not as a module-load constant) so it stays a single source of truth.
+
+**Tech Stack:** TypeScript (strict, ES2022, NodeNext), Node `fs.readFileSync` + `URL`, vitest.
+
+## Global Constraints
+
+- All code, comments, commit messages in English (per repo CLAUDE.md).
+- `.js` extension on TS relative imports (NodeNext) — N/A here (no new imports).
+- No `any` (ESLint warn-level rule fails the `--max-warnings 0` build). Parse JSON as `unknown` and narrow.
+- Conventional Commits (`feat:` / `fix:` / `chore(scope):`).
+- Tests live in `src/__tests__/`, run with vitest; must pass before commit.
+- Pure CLI-layer change only — do NOT touch any communication logic (octo/, gateway, agent-bridge, session-router).
+- OSS repo (Mininglamp-OSS): no AI attribution / `Co-Authored-By` / review-tool names in commits or comments.
+
+---
+
+### Task 1: `readVersion()` helper
+
+**Files:**
+- Modify: `src/cli.ts` (add helper near the other pure helpers, after `resolveSupervisorPaths`)
+- Test: `src/__tests__/cli.test.ts` (add a `describe('readVersion', …)` block + import)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `export function readVersion(): string` — returns the package version string, or `'unknown'` if `package.json` can't be read/parsed or has no string `version`.
+
+**Why this resolves correctly:** both `src/cli.ts` and `dist/cli.js` are direct children of the package root, so `new URL('../package.json', import.meta.url)` points at the real `package.json` in test (vitest runs the TS source) and in production (compiled `dist`).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/__tests__/cli.test.ts`. First extend the import line:
+
+```ts
+import {
+  parseArgs, isAlive, readPid, writePid, removePid, resolveSupervisorPaths, readVersion, run,
+} from '../cli.js';
+import { readFileSync } from 'node:fs';
+```
+
+Then append:
+
+```ts
+describe('readVersion', () => {
+  it('returns the version from package.json', () => {
+    const pkg = JSON.parse(
+      readFileSync(new URL('../../package.json', import.meta.url), 'utf-8'),
+    ) as { version: string };
+    expect(readVersion()).toBe(pkg.version);
+  });
+
+  it('returns a non-empty semver-shaped string', () => {
+    expect(readVersion()).toMatch(/^\d+\.\d+\.\d+/);
+  });
+});
+```
+
+(Note: the test file lives in `src/__tests__/`, one level deeper than `src/cli.ts`, hence `../../package.json` here vs `../package.json` inside `cli.ts`.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/__tests__/cli.test.ts -t readVersion`
+Expected: FAIL — `readVersion is not exported` / `is not a function`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/cli.ts`, add `readFileSync` is already imported. Add after `resolveSupervisorPaths`:
+
+```ts
+/**
+ * The package version, read at runtime from package.json (a sibling of the
+ * package root, one level up from this module in both src/ and dist/). Returns
+ * 'unknown' rather than throwing if the file is missing or malformed.
+ */
+export function readVersion(): string {
+  try {
+    const raw = readFileSync(new URL('../package.json', import.meta.url), 'utf-8');
+    const pkg: unknown = JSON.parse(raw);
+    if (pkg && typeof pkg === 'object' && 'version' in pkg) {
+      const v = (pkg as { version: unknown }).version;
+      if (typeof v === 'string' && v.length > 0) return v;
+    }
+  } catch {
+    /* fall through to 'unknown' */
+  }
+  return 'unknown';
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/__tests__/cli.test.ts -t readVersion`
+Expected: PASS (both cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cli.ts src/__tests__/cli.test.ts
+git commit -m "feat(cli): add readVersion helper reading package.json at runtime"
+```
+
+---
+
+### Task 2: Wire `version` / `--version` / `-v` into `run()` + version the USAGE banner
+
+**Files:**
+- Modify: `src/cli.ts` (`USAGE` constant → version line at print time; new switch cases)
+- Test: `src/__tests__/cli.test.ts` (add a `describe('run version command', …)` block)
+
+**Interfaces:**
+- Consumes: `readVersion()` from Task 1; existing `run(argv: string[], baseDir?: string): Promise<number>`.
+- Produces: no new exports. `run(['version'])`, `run(['--version'])`, `run(['-v'])` each print the bare version via `console.log` and resolve `0`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/__tests__/cli.test.ts`:
+
+```ts
+import { vi } from 'vitest';
+
+describe('run version command', () => {
+  it.each(['version', '--version', '-v'])('prints bare version and exits 0 for %s', async (arg) => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      const code = await run([arg]);
+      expect(code).toBe(0);
+      expect(spy).toHaveBeenCalledWith(readVersion());
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/__tests__/cli.test.ts -t "run version command"`
+Expected: FAIL — `-v` / `--version` hit the `default` branch (return 2, and `console.error` not `console.log`); `version` is `unknown command`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/cli.ts`, change the `USAGE` banner first line to carry the version. Replace:
+
+```ts
+const USAGE = `cc-channel-octo — gateway process supervisor
+```
+
+with a function so the version is read once at print time:
+
+```ts
+function usage(): string {
+  return `cc-channel-octo ${readVersion()} — gateway process supervisor
+```
+
+…and close it the same way the template literal already ends (keep the full body identical), then rename the trailing `` `; `` to `` `;\n} ``. Concretely, the block becomes:
+
+```ts
+function usage(): string {
+  return `cc-channel-octo ${readVersion()} — gateway process supervisor
+
+Usage:
+  cc-channel-octo start [--foreground]   start the gateway in the background
+  cc-channel-octo stop [--timeout=<s>]   gracefully stop (SIGTERM, then SIGKILL)
+  cc-channel-octo restart                stop (if running) then start
+  cc-channel-octo status                 show running state
+  cc-channel-octo version                print the version
+
+Paths (under ~/.cc-channel-octo):
+  pid : cc-channel-octo.pid
+  log : logs/gateway.log
+
+POSIX only (macOS/Linux). On Windows, run under a service manager.`;
+}
+```
+
+Then update the two `USAGE` references in `run()` to call `usage()`:
+
+```ts
+    case 'help':
+    case '--help':
+    case '-h':
+      console.log(usage());
+      return 0;
+```
+
+and in the `default` branch:
+
+```ts
+    default:
+      console.error(`cc-channel-octo: unknown command '${cmd}'\n`);
+      console.error(usage());
+      return 2;
+```
+
+Add the version cases to the switch, before `help`:
+
+```ts
+    case 'version':
+    case '--version':
+    case '-v':
+      console.log(readVersion());
+      return 0;
+```
+
+- [ ] **Step 4: Run the full CLI test file**
+
+Run: `npx vitest run src/__tests__/cli.test.ts`
+Expected: PASS (all existing + new). The existing `--help` test (if any references `USAGE` string) still passes because the body text is unchanged apart from the version prefix and the new `version` usage line.
+
+- [ ] **Step 5: Type-check + lint**
+
+Run: `npm run type-check && npm run lint`
+Expected: no errors (no `any`, no unused symbols — confirm the old `USAGE` const has no lingering references).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/cli.ts src/__tests__/cli.test.ts
+git commit -m "feat(cli): add version command and show version in usage banner"
+```
+
+---
+
+### Task 3: Manual smoke + CHANGELOG
+
+**Files:**
+- Modify: `CHANGELOG.md` (add an entry under the unreleased/next section, matching existing style)
+
+- [ ] **Step 1: Build and smoke-test the real binary**
+
+```bash
+npm run build
+node dist/cli.js version
+node dist/cli.js --version
+node dist/cli.js -v
+node dist/cli.js --help
+```
+Expected: first three print the bare version (e.g. `1.0.1`); `--help` shows the banner with `cc-channel-octo <version> —` on line 1 and the new `version` line.
+
+- [ ] **Step 2: Add CHANGELOG entry**
+
+Match the existing CHANGELOG format (read the top entries first). Add a bullet like:
+
+```markdown
+- `version` / `--version` / `-v` CLI command prints the package version.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs(changelog): note version command"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** bare-version output (Task 2 Step 1 asserts `console.log` called with bare `readVersion()`), three triggers `version`/`--version`/`-v` (Task 2 `it.each`), runtime read of package.json (Task 1), `'unknown'` fallback (Task 1 implementation), USAGE banner carries version (Task 2 Step 3). All covered.
+- **Placeholder scan:** no TBD/TODO; all code shown in full.
+- **Type consistency:** `readVersion(): string` defined Task 1, consumed Task 2 — signature matches. JSON parsed as `unknown` then narrowed (no `any`).
+- **Path note:** `../package.json` inside `cli.ts` (src/ or dist/ → root); `../../package.json` inside the test file (src/__tests__/ → root). Both verified against the package layout.

--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -6,13 +6,13 @@
  * exercised here — they fork a real process and belong in an integration test.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdtempSync, rmSync, writeFileSync, existsSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
   parseArgs, isAlive, readPid, writePid, removePid, resolveSupervisorPaths,
-  readVersion, parseVersion,
+  readVersion, parseVersion, run,
 } from '../cli.js';
 
 describe('parseArgs', () => {
@@ -130,5 +130,18 @@ describe('readVersion', () => {
       readFileSync(new URL('../../package.json', import.meta.url), 'utf-8'),
     ) as { version: string };
     expect(readVersion()).toBe(pkg.version);
+  });
+});
+
+describe('run version command', () => {
+  it.each(['version', '--version', '-v'])('prints bare version and exits 0 for %s', async (arg) => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      const code = await run([arg]);
+      expect(code).toBe(0);
+      expect(spy).toHaveBeenCalledWith(readVersion());
+    } finally {
+      spy.mockRestore();
+    }
   });
 });

--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -7,10 +7,13 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, writeFileSync, existsSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync, existsSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { parseArgs, isAlive, readPid, writePid, removePid, resolveSupervisorPaths } from '../cli.js';
+import {
+  parseArgs, isAlive, readPid, writePid, removePid, resolveSupervisorPaths,
+  readVersion, parseVersion,
+} from '../cli.js';
 
 describe('parseArgs', () => {
   it('defaults: no flags', () => {
@@ -100,5 +103,32 @@ describe('resolveSupervisorPaths', () => {
   it('defaults baseDir to the global config directory', () => {
     const p = resolveSupervisorPaths();
     expect(p.pidFile).toMatch(/\.cc-channel-octo\/cc-channel-octo\.pid$/);
+  });
+});
+
+describe('parseVersion', () => {
+  it('extracts a string version', () => {
+    expect(parseVersion('{"version":"1.2.3"}')).toBe('1.2.3');
+  });
+  it('falls back to "unknown" on malformed JSON', () => {
+    expect(parseVersion('not json')).toBe('unknown');
+  });
+  it('falls back to "unknown" when version is missing', () => {
+    expect(parseVersion('{"name":"x"}')).toBe('unknown');
+  });
+  it('falls back to "unknown" when version is not a string', () => {
+    expect(parseVersion('{"version":123}')).toBe('unknown');
+  });
+  it('falls back to "unknown" on an empty version string', () => {
+    expect(parseVersion('{"version":""}')).toBe('unknown');
+  });
+});
+
+describe('readVersion', () => {
+  it('returns the version from the real package.json', () => {
+    const pkg = JSON.parse(
+      readFileSync(new URL('../../package.json', import.meta.url), 'utf-8'),
+    ) as { version: string };
+    expect(readVersion()).toBe(pkg.version);
   });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -228,19 +228,22 @@ function cmdStatus(paths: SupervisorPaths): number {
   return 0;
 }
 
-const USAGE = `cc-channel-octo — gateway process supervisor
+function usage(): string {
+  return `cc-channel-octo ${readVersion()} — gateway process supervisor
 
 Usage:
   cc-channel-octo start [--foreground]   start the gateway in the background
   cc-channel-octo stop [--timeout=<s>]   gracefully stop (SIGTERM, then SIGKILL)
   cc-channel-octo restart                stop (if running) then start
   cc-channel-octo status                 show running state
+  cc-channel-octo version                print the version
 
 Paths (under ~/.cc-channel-octo):
   pid : cc-channel-octo.pid
   log : logs/gateway.log
 
 POSIX only (macOS/Linux). On Windows, run under a service manager.`;
+}
 
 export async function run(argv: string[], baseDir?: string): Promise<number> {
   const { cmd, foreground, timeoutMs } = parseArgs(argv);
@@ -255,10 +258,15 @@ export async function run(argv: string[], baseDir?: string): Promise<number> {
       return cmdStart(paths, false);
     case 'status':
       return cmdStatus(paths);
+    case 'version':
+    case '--version':
+    case '-v':
+      console.log(readVersion());
+      return 0;
     case 'help':
     case '--help':
     case '-h':
-      console.log(USAGE);
+      console.log(usage());
       return 0;
     case '':
       // Backward compat: bare `cc-channel-octo` (e.g. `npx cc-channel-octo`)
@@ -269,7 +277,7 @@ export async function run(argv: string[], baseDir?: string): Promise<number> {
       return cmdStart(paths, true);
     default:
       console.error(`cc-channel-octo: unknown command '${cmd}'\n`);
-      console.error(USAGE);
+      console.error(usage());
       return 2;
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -52,6 +52,37 @@ export interface ParsedArgs {
   timeoutMs: number;
 }
 
+/**
+ * Extract a package version from raw package.json text. Returns 'unknown'
+ * rather than throwing if the text is malformed or has no non-empty string
+ * `version`. Pure (no I/O) so the fallback paths are unit-testable.
+ */
+export function parseVersion(raw: string): string {
+  try {
+    const pkg: unknown = JSON.parse(raw);
+    if (pkg && typeof pkg === 'object' && 'version' in pkg) {
+      const v = (pkg as { version: unknown }).version;
+      if (typeof v === 'string' && v.length > 0) return v;
+    }
+  } catch {
+    /* fall through to 'unknown' */
+  }
+  return 'unknown';
+}
+
+/**
+ * The package version, read at runtime from package.json — which lives at the
+ * package root, one level up from this module in both src/ (src/cli.ts) and the
+ * compiled output (dist/cli.js). Returns 'unknown' if the file can't be read.
+ */
+export function readVersion(): string {
+  try {
+    return parseVersion(readFileSync(new URL('../package.json', import.meta.url), 'utf-8'));
+  } catch {
+    return 'unknown';
+  }
+}
+
 export function parseArgs(argv: string[]): ParsedArgs {
   const [cmd = '', ...rest] = argv;
   let foreground = false;


### PR DESCRIPTION
## What

Add a `version` / `--version` / `-v` command to the `cc-channel-octo` CLI. It prints the bare package version (e.g. `1.0.1`), read at runtime from `package.json`. The `--help` banner now also carries the version on its first line and lists the new `version` subcommand.

Previously the CLI exposed no way to query the installed version — `cc-channel-octo --version` fell through to the `unknown command` branch.

## How

- `parseVersion(raw)` — pure helper that extracts a non-empty string `version` from raw `package.json` text, falling back to `'unknown'` on malformed JSON / missing / non-string / empty value.
- `readVersion()` — reads the package's own `package.json` via `new URL('../package.json', import.meta.url)` (resolves to the package root from both `src/cli.ts` and `dist/cli.js`) and delegates to `parseVersion`; returns `'unknown'` if the file can't be read.
- `run()` gains `version` / `--version` / `-v` cases that print `readVersion()` and exit 0.
- `USAGE` constant becomes a `usage()` function so the banner reads the version at print time (single source of truth).

## Tests

- `parseVersion`: happy path + four fallback branches (malformed / missing / non-string / empty).
- `readVersion`: matches the real `package.json` version.
- `run`: `version` / `--version` / `-v` each print the bare version and exit 0.

Full suite: 1011 passing. `lint` (`--max-warnings 0`) and `type-check` clean. Pure CLI-layer change — no communication logic touched.