### PR TITLE
feat: add upgrade subcommand and resilient multi-bot startup

### DIFF
--- a/src/__tests__/cli-upgrade.test.ts
+++ b/src/__tests__/cli-upgrade.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { buildUpgradeArgs } from '../cli.js';
+
+describe('buildUpgradeArgs', () => {
+  it('builds npm args for an explicit version', () => {
+    expect(buildUpgradeArgs('1.2.3')).toEqual([
+      'install',
+      '-g',
+      '@mininglamp-oss/cc-channel-octo@1.2.3',
+    ]);
+  });
+
+  it('falls back to @latest when no version is given', () => {
+    expect(buildUpgradeArgs()).toEqual([
+      'install',
+      '-g',
+      '@mininglamp-oss/cc-channel-octo@latest',
+    ]);
+  });
+
+  it('treats blank/whitespace version as latest', () => {
+    expect(buildUpgradeArgs('   ')).toEqual([
+      'install',
+      '-g',
+      '@mininglamp-oss/cc-channel-octo@latest',
+    ]);
+  });
+
+  it('accepts a prerelease/build-metadata semver', () => {
+    expect(buildUpgradeArgs('1.2.3-rc.1+build5')).toEqual([
+      'install',
+      '-g',
+      '@mininglamp-oss/cc-channel-octo@1.2.3-rc.1+build5',
+    ]);
+  });
+
+  it('rejects a version with shell metacharacters (injection guard)', () => {
+    expect(() => buildUpgradeArgs('1.2.3; rm -rf /')).toThrow();
+    expect(() => buildUpgradeArgs('$(whoami)')).toThrow();
+    expect(() => buildUpgradeArgs('1.2.3 && curl evil')).toThrow();
+  });
+});

--- a/src/__tests__/multibot-resilience.test.ts
+++ b/src/__tests__/multibot-resilience.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { partitionStartResults, type BotStack } from '../index.js';
+
+// A minimal BotStack-shaped stub; partitionStartResults only ever moves the
+// fulfilled value through, it never calls into it. Cast through unknown to keep
+// the test free of `any` (the repo lints with --max-warnings 0).
+function fakeStack(id: string): BotStack {
+  return {
+    botId: id,
+    connect: async () => {},
+    shutdown: async () => {},
+  } as unknown as BotStack;
+}
+
+describe('partitionStartResults', () => {
+  const configs = [{ botId: 'a' }, { botId: 'b' }, { botId: 'c' }];
+
+  it('all fulfilled → every stack, no failures', () => {
+    const results: PromiseSettledResult<BotStack>[] = [
+      { status: 'fulfilled', value: fakeStack('a') },
+      { status: 'fulfilled', value: fakeStack('b') },
+      { status: 'fulfilled', value: fakeStack('c') },
+    ];
+    const { stacks, failures } = partitionStartResults(results, configs);
+    expect(stacks.map((s) => s.botId)).toEqual(['a', 'b', 'c']);
+    expect(failures).toEqual([]);
+  });
+
+  it('partial failure → keeps successful stacks, records failures (does not throw)', () => {
+    const err = new Error('401 bad token');
+    const results: PromiseSettledResult<BotStack>[] = [
+      { status: 'fulfilled', value: fakeStack('a') },
+      { status: 'rejected', reason: err },
+      { status: 'fulfilled', value: fakeStack('c') },
+    ];
+    const { stacks, failures } = partitionStartResults(results, configs);
+    expect(stacks.map((s) => s.botId)).toEqual(['a', 'c']);
+    expect(failures).toEqual([{ id: 'b', reason: err }]);
+  });
+
+  it('all failed → no stacks, every failure recorded (caller decides fatal)', () => {
+    const results: PromiseSettledResult<BotStack>[] = [
+      { status: 'rejected', reason: new Error('e1') },
+      { status: 'rejected', reason: new Error('e2') },
+      { status: 'rejected', reason: new Error('e3') },
+    ];
+    const { stacks, failures } = partitionStartResults(results, configs);
+    expect(stacks).toEqual([]);
+    expect(failures.map((f) => f.id)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('falls back to a positional id when botId is missing', () => {
+    const results: PromiseSettledResult<BotStack>[] = [
+      { status: 'rejected', reason: new Error('e') },
+    ];
+    const { failures } = partitionStartResults(results, [{}]);
+    expect(failures[0].id).toBe('#0');
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -50,6 +50,8 @@ export interface ParsedArgs {
   cmd: string;
   foreground: boolean;
   timeoutMs: number;
+  /** Positional version target for `upgrade` (e.g. `upgrade 1.2.3`); undefined → latest. */
+  version?: string;
 }
 
 /**
@@ -87,15 +89,19 @@ export function parseArgs(argv: string[]): ParsedArgs {
   const [cmd = '', ...rest] = argv;
   let foreground = false;
   let timeoutSec = 10;
+  let version: string | undefined;
   for (const a of rest) {
     if (a === '--foreground' || a === '-f') {
       foreground = true;
     } else if (a.startsWith('--timeout=')) {
       const n = Number.parseInt(a.slice('--timeout='.length), 10);
       if (Number.isFinite(n) && n > 0) timeoutSec = n;
+    } else if (!a.startsWith('-') && version === undefined) {
+      // First positional token (e.g. `upgrade 1.2.3`).
+      version = a;
     }
   }
-  return { cmd, foreground, timeoutMs: timeoutSec * 1000 };
+  return { cmd, foreground, timeoutMs: timeoutSec * 1000, version };
 }
 
 /**
@@ -228,6 +234,60 @@ function cmdStatus(paths: SupervisorPaths): number {
   return 0;
 }
 
+/** npm package name installed globally for the gateway. */
+const NPM_PKG = '@mininglamp-oss/cc-channel-octo';
+/**
+ * Semantic-version whitelist. The version reaches us from the daemon → fleet
+ * upgrade order (an untrusted boundary) and is interpolated into an npm spec,
+ * so reject anything outside `[0-9A-Za-z.-+]` to prevent argument/shell
+ * injection even though we spawn npm without a shell.
+ */
+const VERSION_RE = /^[0-9A-Za-z.\-+]+$/;
+
+/**
+ * Build the `npm install -g <pkg>@<version>` argument vector. A blank/omitted
+ * version installs `@latest`. Pure (no I/O) so the injection guard is unit
+ * testable. Throws on an unsafe version string.
+ */
+export function buildUpgradeArgs(version?: string): string[] {
+  const v = version && version.trim() ? version.trim() : 'latest';
+  if (v !== 'latest' && !VERSION_RE.test(v)) {
+    throw new Error(`unsafe version: ${v}`);
+  }
+  return ['install', '-g', `${NPM_PKG}@${v}`];
+}
+
+/**
+ * Self-update: `npm install -g @mininglamp-oss/cc-channel-octo@<version>` then
+ * restart the gateway so the new code is live. Invoked by the daemon to drive
+ * a fleet upgrade order (mirrors openclaw's daemon-driven plugin install).
+ */
+async function cmdUpgrade(paths: SupervisorPaths, timeoutMs: number, version?: string): Promise<number> {
+  let args: string[];
+  try {
+    args = buildUpgradeArgs(version);
+  } catch (err) {
+    console.error(`cc-channel-octo: ${(err as Error).message}`);
+    return 2;
+  }
+  console.log(`cc-channel-octo: upgrading via npm ${args.join(' ')}`);
+  const code = await new Promise<number>((resolve) => {
+    const child = spawn('npm', args, { stdio: 'inherit', env: process.env });
+    child.on('error', (err) => {
+      console.error(`cc-channel-octo: failed to spawn npm: ${err.message}`);
+      resolve(1);
+    });
+    child.on('exit', (c) => resolve(c ?? 1));
+  });
+  if (code !== 0) {
+    console.error(`cc-channel-octo: npm install failed (exit ${code})`);
+    return code;
+  }
+  // Restart so the freshly installed code is running.
+  await cmdStop(paths, timeoutMs);
+  return cmdStart(paths, false);
+}
+
 function usage(): string {
   return `cc-channel-octo ${readVersion()} — gateway process supervisor
 
@@ -236,6 +296,7 @@ Usage:
   cc-channel-octo stop [--timeout=<s>]   gracefully stop (SIGTERM, then SIGKILL)
   cc-channel-octo restart                stop (if running) then start
   cc-channel-octo status                 show running state
+  cc-channel-octo upgrade [<version>]    npm install -g the gateway (default latest) then restart
   cc-channel-octo version                print the version
 
 Paths (under ~/.cc-channel-octo):
@@ -246,7 +307,7 @@ POSIX only (macOS/Linux). On Windows, run under a service manager.`;
 }
 
 export async function run(argv: string[], baseDir?: string): Promise<number> {
-  const { cmd, foreground, timeoutMs } = parseArgs(argv);
+  const { cmd, foreground, timeoutMs, version } = parseArgs(argv);
   const paths = resolveSupervisorPaths(baseDir);
   switch (cmd) {
     case 'start':
@@ -258,6 +319,8 @@ export async function run(argv: string[], baseDir?: string): Promise<number> {
       return cmdStart(paths, false);
     case 'status':
       return cmdStatus(paths);
+    case 'upgrade':
+      return cmdUpgrade(paths, timeoutMs, version);
     case 'version':
     case '--version':
     case '-v':

--- a/src/gateway.ts
+++ b/src/gateway.ts
@@ -269,7 +269,12 @@ export class OctoGateway {
     }
   }
 
-  private releaseLock(): void {
+  /**
+   * Release the per-bot startup lock if we still hold it. Best-effort and
+   * idempotent (nonce-guarded), so it is safe to call from a partial-startup
+   * cleanup path even if connect()/services were never started.
+   */
+  releaseLock(): void {
     try {
       if (existsSync(this.lockFilePath)) {
         const content = readFileSync(this.lockFilePath, 'utf-8').trim();

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,17 +64,24 @@ async function main(): Promise<void> {
   // already succeeded must be torn down, or their locks/stores/intervals leak.
   // Promise.all would discard the resolved stacks on first rejection, so settle
   // all and clean up the successful ones before rethrowing.
+  // startBot() acquires the gateway.lock, opens the SQLite store, and arms the
+  // cwd-cleanup interval; on its own failure it releases those (see startBot's
+  // try/catch), so a rejected bot leaves nothing behind. Settle all, then apply
+  // the multi-bot resilience policy: skip the bots that failed, keep the ones
+  // that came up, and only treat startup as fatal when NONE start. (Single-bot
+  // mode has one entry, so "none started" == that bot failed → fatal, same as
+  // the old fail-fast behavior.) This stops one bot's bad token / held lock from
+  // taking the whole gateway — and every sibling bot — offline.
   const startResults = await Promise.allSettled(botConfigs.map((c) => startBot(c, multi)));
-  const stacks: BotStack[] = [];
-  let startError: unknown;
-  for (const r of startResults) {
-    if (r.status === 'fulfilled') stacks.push(r.value);
-    else startError = startError ?? r.reason;
+  const { stacks, failures } = partitionStartResults(startResults, botConfigs);
+  for (const f of failures) {
+    const reason = f.reason instanceof Error ? f.reason.message : String(f.reason);
+    console.error(`[cc-channel-octo] bot "${f.id}" failed to start, skipping: ${reason}`);
   }
-  if (startError) {
-    console.error('[cc-channel-octo] Startup failed; cleaning up bots that did start...');
-    await Promise.allSettled(stacks.map((s) => s.shutdown()));
-    throw startError;
+  if (stacks.length === 0) {
+    // Nothing came up — surface the first failure and exit (process supervisor
+    // / operator restarts once the underlying cause is fixed).
+    throw failures[0]?.reason ?? new Error('no bots started');
   }
 
   // Multi-bot loop guard: make every router aware of ALL bot ids in this
@@ -91,43 +98,74 @@ async function main(): Promise<void> {
   }
 
   // Handlers are wired and siblings registered — now open every socket. From
-  // this point inbound messages are dispatched, never ACK'd-and-dropped. Awaited
-  // so a connection failure surfaces as a startup error. On a partial failure
-  // (e.g. one bot's lock is held), shut down the stacks that did start so we
-  // don't leave open sockets / stores dangling before the fatal exit.
+  // this point inbound messages are dispatched, never ACK'd-and-dropped. Same
+  // resilience policy as the register phase: a bot whose socket fails to open is
+  // shut down and dropped, the rest keep running; only fatal when none connect.
   const connected: BotStack[] = [];
-  try {
-    for (const s of stacks) {
+  for (const s of stacks) {
+    try {
       await s.connect();
       connected.push(s);
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      console.error(`[cc-channel-octo] bot "${s.botId}" failed to connect, skipping: ${reason}`);
+      await s.shutdown().catch(() => {});
     }
-  } catch (err) {
-    console.error('[cc-channel-octo] Startup failed during socket connect; cleaning up...');
-    await Promise.allSettled(connected.map((s) => s.shutdown()));
-    throw err;
+  }
+  if (connected.length === 0) {
+    throw new Error('no bots connected');
   }
 
-  // Wire a single process-wide shutdown that drains every bot, so N gateways
-  // don't each call process.exit. The per-gateway signal handlers are disabled
-  // in multi-bot mode (handleSignals=false); we own the signals here.
+  // Wire a single process-wide shutdown that drains every LIVE bot, so N
+  // gateways don't each call process.exit. The per-gateway signal handlers are
+  // disabled in multi-bot mode (handleSignals=false); we own the signals here.
   if (multi) {
     const shutdownAll = async (signal: string): Promise<void> => {
-      console.log(`[cc-channel-octo] Received ${signal}, shutting down ${stacks.length} bots...`);
-      await Promise.allSettled(stacks.map((s) => s.shutdown()));
+      console.log(`[cc-channel-octo] Received ${signal}, shutting down ${connected.length} bots...`);
+      await Promise.allSettled(connected.map((s) => s.shutdown()));
       process.exit(0);
     };
     process.once('SIGINT', () => void shutdownAll('SIGINT'));
     process.once('SIGTERM', () => void shutdownAll('SIGTERM'));
   }
 
-  console.log('[cc-channel-octo] Ready — listening for messages');
+  console.log(`[cc-channel-octo] Ready — listening for messages (${connected.length} bot(s))`);
 }
 
-interface BotStack {
+export interface BotStack {
   botId: string;
   router: SessionRouter;
   connect: () => Promise<void>;
   shutdown: () => Promise<void>;
+}
+
+export interface StartFailure {
+  /** The failed bot's id (or a positional `#<index>` fallback). */
+  id: string;
+  reason: unknown;
+}
+
+/**
+ * Split the settled results of starting every bot into the stacks that came up
+ * and the ones that failed. Pure (no I/O) so the multi-bot resilience policy —
+ * skip failed bots, keep the rest, only fatal when none start — is unit
+ * testable. A failed bot's own partial resources are released inside startBot's
+ * failure path (see its try/catch); this function never touches a stack.
+ */
+export function partitionStartResults(
+  results: PromiseSettledResult<BotStack>[],
+  configs: { botId?: string }[],
+): { stacks: BotStack[]; failures: StartFailure[] } {
+  const stacks: BotStack[] = [];
+  const failures: StartFailure[] = [];
+  results.forEach((r, i) => {
+    if (r.status === 'fulfilled') {
+      stacks.push(r.value);
+    } else {
+      failures.push({ id: configs[i]?.botId ?? `#${i}`, reason: r.reason });
+    }
+  });
+  return { stacks, failures };
 }
 
 /**
@@ -158,140 +196,162 @@ async function startBot(config: ReturnType<typeof loadConfig>, multi: boolean): 
   const dbPath = join(config.dataDir, 'cc-octo.db');
   const adapter = createAdapter(dbPath);
   const store = new SessionStore(adapter);
-  store.init();
-  const cleaned = store.cleanExpired();
-  if (cleaned > 0) {
-    console.log(`[cc-channel-octo] ${label}Cleaned ${cleaned} expired session(s)`);
-  }
 
-  // --- Auto-memory base (create eagerly so a deleted/unmounted memory volume
-  // fails loudly at boot instead of silently disabling recall at message time). ---
-  const memoryBase = config.memoryBase ?? join(config.dataDir, 'memory');
-  mkdirSync(memoryBase, { recursive: true });
-
-  // --- Group context ---
-  const groupContext = new GroupContext(adapter, config.context.maxContextChars);
-  groupContext.loadAllFromDb();
-
-  // --- #115: cron (opt-in). Store is shared by the per-turn cron tool (writes)
-  // and the scheduler (reads + fires). Scheduler is armed after the handler is
-  // installed (see below), stopped in shutdown. ---
+  // #115: cron handles (hoisted so the failure-cleanup catch below can stop the
+  // scheduler). Store is shared by the per-turn cron tool (writes) and the
+  // scheduler (reads + fires); armed after the handler is installed, stopped in
+  // shutdown.
   let cronStore: CronStore | undefined;
   let cronScheduler: CronScheduler | undefined;
-  if (config.sdk.cron && config.botId) {
-    cronStore = new CronStore(join(config.baseDir, config.botId, 'cron.json'));
-  }
 
-  // --- Stream relay ---
-  const streamRelay = new StreamRelay();
-
-  // --- Gateway. In multi-bot mode main() owns shutdown signals, so the gateway
-  // must NOT register its own (N gateways racing process.exit). ---
-  const gateway = new OctoGateway(config, { handleSignals: !multi });
-  // Phase 1: register over REST (gets botId) — does NOT open the socket yet, so
-  // no message can arrive before the handler below is installed.
-  await gateway.register();
-  console.log(`[cc-channel-octo] ${label}Bot registered: id=${gateway.botId}`);
-
-  // #115: cron creation/deletion is owner-gated on gateway.ownerUid. If the
-  // registration didn't return an owner_uid, the gate can never pass and the
-  // cron tool is silently unusable — warn loudly so the operator isn't left
-  // wondering why every cron_create is rejected.
-  if (config.sdk.cron && !gateway.ownerUid) {
-    console.warn(
-      `[cc-channel-octo] ${label}sdk.cron is enabled but the bot has no owner_uid ` +
-      `(registration returned none) — cron_create/delete will be rejected for everyone. ` +
-      `The cron tool is effectively disabled until the bot has an owner.`,
-    );
-  }
-
-  // #86: prefetch the media CDN host (best-effort). Octo serves media from a
-  // separate CDN than apiUrl; without this, inbound image URLs on the CDN host
-  // are rejected by buildMediaUrl and the agent can't see them. The STS
-  // upload-credentials response carries cdnBaseUrl; we only need its host. A
-  // failure leaves mediaCdnHost undefined (same-host-only media), never fatal.
+  // Multi-bot mode no longer exits the process when one bot fails to start, so
+  // a failed startBot() must release the durable resources it already acquired
+  // (the cwd-cleanup timer + the sqlite handle) instead of leaking them for the
+  // lifetime of the surviving bots. The gateway releases its own lock in
+  // register()'s failure path, so it isn't repeated here.
   try {
-    const creds = await getUploadCredentials({
-      apiUrl: config.apiUrl,
-      botToken: config.botToken,
-      // The credentials endpoint validates the filename's type; use an image
-      // name so the probe isn't rejected (file_type_unsupported). We only read
-      // cdnBaseUrl from the response — nothing is uploaded.
-      filename: 'probe.png',
-    });
-    if (creds.cdnBaseUrl) {
-      config.mediaCdnHost = new URL(creds.cdnBaseUrl).host;
-      console.log(`[cc-channel-octo] ${label}Media CDN host: ${config.mediaCdnHost}`);
+    store.init();
+    const cleaned = store.cleanExpired();
+    if (cleaned > 0) {
+      console.log(`[cc-channel-octo] ${label}Cleaned ${cleaned} expired session(s)`);
     }
-  } catch (err) {
-    console.warn(`[cc-channel-octo] ${label}Could not prefetch media CDN host (inbound media limited to apiUrl host): ${err instanceof Error ? err.message : String(err)}`);
-  }
 
-  // --- Session router ---
-  const router = new SessionRouter(config, gateway.botId, gateway.ownerUid);
+    // --- Auto-memory base (create eagerly so a deleted/unmounted memory volume
+    // fails loudly at boot instead of silently disabling recall at message time). ---
+    const memoryBase = config.memoryBase ?? join(config.dataDir, 'memory');
+    mkdirSync(memoryBase, { recursive: true });
 
-  // --- Active handler tracking (Q6: in-flight drain on shutdown) ---
-  const activeHandlers = new Set<Promise<void>>();
+    // --- Group context ---
+    const groupContext = new GroupContext(adapter, config.context.maxContextChars);
+    groupContext.loadAllFromDb();
 
-  // Install the message handler NOW (before the socket opens). The socket is
-  // opened later via connect(), after main() has cross-registered sibling bot
-  // ids — so there is no window where a message is ACK'd and dropped, nor one
-  // where a sibling bot's message slips through unrecognized.
-  const onInbound = (msg: BotMessage): void => {
-    if (gateway.draining) return;
-    // Drop self-authored messages. OctoGateway.handleMessage() already filters
-    // these on the WS path; guard here too for safety (otherwise a bot's own
-    // group message could be cached into group context as un-processed chatter).
-    if (msg.from_uid === gateway.botId) return;
-    const p = handleMessage(msg, config, store, router, groupContext, streamRelay, gateway.botId, cronStore)
-      .catch((err) => {
-        console.error(`[cc-channel-octo] ${label}Unhandled message handler error:`, err instanceof Error ? err.message : err);
-      })
-      .finally(() => {
-        activeHandlers.delete(p);
+    // --- #115: cron (opt-in). ---
+    if (config.sdk.cron && config.botId) {
+      cronStore = new CronStore(join(config.baseDir, config.botId, 'cron.json'));
+    }
+
+    // --- Stream relay ---
+    const streamRelay = new StreamRelay();
+
+    // --- Gateway. In multi-bot mode main() owns shutdown signals, so the gateway
+    // must NOT register its own (N gateways racing process.exit). ---
+    const gateway = new OctoGateway(config, { handleSignals: !multi });
+    // Phase 1: register over REST (gets botId) — does NOT open the socket yet, so
+    // no message can arrive before the handler below is installed.
+    await gateway.register();
+    console.log(`[cc-channel-octo] ${label}Bot registered: id=${gateway.botId}`);
+
+    // #115: cron creation/deletion is owner-gated on gateway.ownerUid. If the
+    // registration didn't return an owner_uid, the gate can never pass and the
+    // cron tool is silently unusable — warn loudly so the operator isn't left
+    // wondering why every cron_create is rejected.
+    if (config.sdk.cron && !gateway.ownerUid) {
+      console.warn(
+        `[cc-channel-octo] ${label}sdk.cron is enabled but the bot has no owner_uid ` +
+        `(registration returned none) — cron_create/delete will be rejected for everyone. ` +
+        `The cron tool is effectively disabled until the bot has an owner.`,
+      );
+    }
+
+    // #86: prefetch the media CDN host (best-effort). Octo serves media from a
+    // separate CDN than apiUrl; without this, inbound image URLs on the CDN host
+    // are rejected by buildMediaUrl and the agent can't see them. The STS
+    // upload-credentials response carries cdnBaseUrl; we only need its host. A
+    // failure leaves mediaCdnHost undefined (same-host-only media), never fatal.
+    try {
+      const creds = await getUploadCredentials({
+        apiUrl: config.apiUrl,
+        botToken: config.botToken,
+        // The credentials endpoint validates the filename's type; use an image
+        // name so the probe isn't rejected (file_type_unsupported). We only read
+        // cdnBaseUrl from the response — nothing is uploaded.
+        filename: 'probe.png',
       });
-    activeHandlers.add(p);
-  };
-  gateway.setMessageHandler(onInbound);
+      if (creds.cdnBaseUrl) {
+        config.mediaCdnHost = new URL(creds.cdnBaseUrl).host;
+        console.log(`[cc-channel-octo] ${label}Media CDN host: ${config.mediaCdnHost}`);
+      }
+    } catch (err) {
+      console.warn(`[cc-channel-octo] ${label}Could not prefetch media CDN host (inbound media limited to apiUrl host): ${err instanceof Error ? err.message : String(err)}`);
+    }
 
-  // #115: arm the cron scheduler now that onInbound exists. Fired tasks go
-  // through the exact same pipeline as real inbound messages. The fire callback
-  // returns a tracked promise that REJECTS on handler error (distinct from
-  // onInbound, which swallows) so the scheduler can attribute a delivery failure
-  // to the specific task. Still tracked in activeHandlers for shutdown drain.
-  if (cronStore) {
-    cronScheduler = new CronScheduler({
-      cronStore,
-      onFire: (msg: BotMessage): Promise<void> => {
-        if (gateway.draining) return Promise.resolve();
-        const p = handleMessage(msg, config, store, router, groupContext, streamRelay, gateway.botId, cronStore)
-          .finally(() => { activeHandlers.delete(p); });
-        activeHandlers.add(p);
-        return p;
-      },
-      label,
-    });
-    cronScheduler.start();
-  }
+    // --- Session router ---
+    const router = new SessionRouter(config, gateway.botId, gateway.ownerUid);
 
-  // Phase 2 (called by main() after cross-registration): open the WebSocket.
-  // Async + awaited so a connection failure fails startup instead of leaving
-  // the process "ready" with no inbound endpoint.
-  const connect = async (): Promise<void> => {
-    gateway.connect();
-    console.log(`[cc-channel-octo] ${label}Bot connected: id=${gateway.botId}`);
-  };
+    // --- Active handler tracking (Q6: in-flight drain on shutdown) ---
+    const activeHandlers = new Set<Promise<void>>();
 
-  const shutdown = async (): Promise<void> => {
+    // Install the message handler NOW (before the socket opens). The socket is
+    // opened later via connect(), after main() has cross-registered sibling bot
+    // ids — so there is no window where a message is ACK'd and dropped, nor one
+    // where a sibling bot's message slips through unrecognized.
+    const onInbound = (msg: BotMessage): void => {
+      if (gateway.draining) return;
+      // Drop self-authored messages. OctoGateway.handleMessage() already filters
+      // these on the WS path; guard here too for safety (otherwise a bot's own
+      // group message could be cached into group context as un-processed chatter).
+      if (msg.from_uid === gateway.botId) return;
+      const p = handleMessage(msg, config, store, router, groupContext, streamRelay, gateway.botId, cronStore)
+        .catch((err) => {
+          console.error(`[cc-channel-octo] ${label}Unhandled message handler error:`, err instanceof Error ? err.message : err);
+        })
+        .finally(() => {
+          activeHandlers.delete(p);
+        });
+      activeHandlers.add(p);
+    };
+    gateway.setMessageHandler(onInbound);
+
+    // #115: arm the cron scheduler now that onInbound exists. Fired tasks go
+    // through the exact same pipeline as real inbound messages. The fire callback
+    // returns a tracked promise that REJECTS on handler error (distinct from
+    // onInbound, which swallows) so the scheduler can attribute a delivery failure
+    // to the specific task. Still tracked in activeHandlers for shutdown drain.
+    if (cronStore) {
+      cronScheduler = new CronScheduler({
+        cronStore,
+        onFire: (msg: BotMessage): Promise<void> => {
+          if (gateway.draining) return Promise.resolve();
+          const p = handleMessage(msg, config, store, router, groupContext, streamRelay, gateway.botId, cronStore)
+            .finally(() => { activeHandlers.delete(p); });
+          activeHandlers.add(p);
+          return p;
+        },
+        label,
+      });
+      cronScheduler.start();
+    }
+
+    // Phase 2 (called by main() after cross-registration): open the WebSocket.
+    // Async + awaited so a connection failure fails startup instead of leaving
+    // the process "ready" with no inbound endpoint.
+    const connect = async (): Promise<void> => {
+      gateway.connect();
+      console.log(`[cc-channel-octo] ${label}Bot connected: id=${gateway.botId}`);
+    };
+
+    const shutdown = async (): Promise<void> => {
+      clearInterval(cwdCleanupTimer);
+      cronScheduler?.stop();
+      await gateway.stop(activeHandlers);
+      store.close();
+    };
+    // Single-bot: the gateway's own SIGINT/SIGTERM handler invokes this.
+    gateway.setShutdownCallback(shutdown);
+
+    return { botId: gateway.botId, router, connect, shutdown };
+  } catch (err) {
+    // Release the durable resources acquired above so a failed bot doesn't leak
+    // them in multi-bot mode (the surviving bots keep the process alive).
     clearInterval(cwdCleanupTimer);
     cronScheduler?.stop();
-    await gateway.stop(activeHandlers);
-    store.close();
-  };
-  // Single-bot: the gateway's own SIGINT/SIGTERM handler invokes this.
-  gateway.setShutdownCallback(shutdown);
-
-  return { botId: gateway.botId, router, connect, shutdown };
+    try {
+      store.close();
+    } catch {
+      /* best effort — store may not have opened */
+    }
+    throw err;
+  }
 }
 
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -206,8 +206,9 @@ async function startBot(config: ReturnType<typeof loadConfig>, multi: boolean): 
   // shutdown.
   let cronStore: CronStore | undefined;
   let cronScheduler: CronScheduler | undefined;
-  // Set once register() has acquired the gateway lock; the failure-cleanup catch
-  // calls it to release that lock if a later step throws before return.
+  // Set right after gateway construction; releaseLock is nonce-guarded so it is
+  // a no-op until register() actually acquires the lock, and the catch can call
+  // it to release that lock if a later step throws before return.
   let releaseGatewayLock: (() => void) | undefined;
 
   // Multi-bot mode no longer exits the process when one bot fails to start, so

--- a/src/index.ts
+++ b/src/index.ts
@@ -196,9 +196,12 @@ async function startBot(config: ReturnType<typeof loadConfig>, multi: boolean): 
   cwdCleanupTimer.unref();
 
   // --- Database (per-bot dataDir → no cross-bot history) ---
+  // createAdapter / new SessionStore are created INSIDE the try below, so a
+  // SQLite open failure (inaccessible dataDir, locked db, …) is caught and the
+  // cwd-cleanup timer is released — otherwise a skipped bot would leak the
+  // interval for the surviving gateway's lifetime.
   const dbPath = join(config.dataDir, 'cc-octo.db');
-  const adapter = createAdapter(dbPath);
-  const store = new SessionStore(adapter);
+  let storeForCleanup: SessionStore | undefined;
 
   // #115: cron handles (hoisted so the failure-cleanup catch below can stop the
   // scheduler). Store is shared by the per-turn cron tool (writes) and the
@@ -217,6 +220,9 @@ async function startBot(config: ReturnType<typeof loadConfig>, multi: boolean): 
   // it — the per-bot gateway lock) instead of leaking them for the lifetime of
   // the surviving bots.
   try {
+    const adapter = createAdapter(dbPath);
+    const store = new SessionStore(adapter);
+    storeForCleanup = store;
     store.init();
     const cleaned = store.cleanExpired();
     if (cleaned > 0) {
@@ -357,7 +363,7 @@ async function startBot(config: ReturnType<typeof loadConfig>, multi: boolean): 
     // where register() succeeded (lock held) but a later step threw.
     releaseGatewayLock?.();
     try {
-      store.close();
+      storeForCleanup?.close();
     } catch {
       /* best effort — store may not have opened */
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,12 +58,7 @@ async function main(): Promise<void> {
   // ready: startBot() registers over REST (gets botId) and installs the message
   // handler, but does NOT open the socket. We then cross-register sibling bot
   // ids, and only AFTER that connect every socket.
-  // Start each bot's pipeline. startBot() acquires the gateway.lock, opens the
-  // SQLite store, and arms the cwd-cleanup interval BEFORE any socket connects —
-  // so if one bot's startBot() rejects (bad token, taken lock), the bots that
-  // already succeeded must be torn down, or their locks/stores/intervals leak.
-  // Promise.all would discard the resolved stacks on first rejection, so settle
-  // all and clean up the successful ones before rethrowing.
+  //
   // startBot() acquires the gateway.lock, opens the SQLite store, and arms the
   // cwd-cleanup interval; on its own failure it releases those (see startBot's
   // try/catch), so a rejected bot leaves nothing behind. Settle all, then apply
@@ -98,9 +93,17 @@ async function main(): Promise<void> {
   }
 
   // Handlers are wired and siblings registered — now open every socket. From
-  // this point inbound messages are dispatched, never ACK'd-and-dropped. Same
-  // resilience policy as the register phase: a bot whose socket fails to open is
-  // shut down and dropped, the rest keep running; only fatal when none connect.
+  // this point inbound messages are dispatched, never ACK'd-and-dropped.
+  //
+  // connect() is synchronous: it opens the WebSocket (fire-and-forget) and
+  // starts services. The try/catch here isolates a *synchronous* connect
+  // failure (e.g. an insecure ws:// URL rejected by isAllowedWsUrl, or a
+  // createSocket error) to that one bot — the others keep running. A *later*
+  // async WS drop is NOT surfaced here; it's handled by the gateway's own
+  // reconnect loop and never kills the process. The real auth gate is the
+  // register phase above (bad bot tokens fail there over REST and are isolated);
+  // by here every bot holds a freshly minted im_token, so connect failures are
+  // transport/transient, not per-bot auth.
   const connected: BotStack[] = [];
   for (const s of stacks) {
     try {
@@ -203,12 +206,15 @@ async function startBot(config: ReturnType<typeof loadConfig>, multi: boolean): 
   // shutdown.
   let cronStore: CronStore | undefined;
   let cronScheduler: CronScheduler | undefined;
+  // Set once register() has acquired the gateway lock; the failure-cleanup catch
+  // calls it to release that lock if a later step throws before return.
+  let releaseGatewayLock: (() => void) | undefined;
 
   // Multi-bot mode no longer exits the process when one bot fails to start, so
   // a failed startBot() must release the durable resources it already acquired
-  // (the cwd-cleanup timer + the sqlite handle) instead of leaking them for the
-  // lifetime of the surviving bots. The gateway releases its own lock in
-  // register()'s failure path, so it isn't repeated here.
+  // (the cwd-cleanup timer, the sqlite handle, and — once register() acquired
+  // it — the per-bot gateway lock) instead of leaking them for the lifetime of
+  // the surviving bots.
   try {
     store.init();
     const cleaned = store.cleanExpired();
@@ -236,6 +242,7 @@ async function startBot(config: ReturnType<typeof loadConfig>, multi: boolean): 
     // --- Gateway. In multi-bot mode main() owns shutdown signals, so the gateway
     // must NOT register its own (N gateways racing process.exit). ---
     const gateway = new OctoGateway(config, { handleSignals: !multi });
+    releaseGatewayLock = () => gateway.releaseLock();
     // Phase 1: register over REST (gets botId) — does NOT open the socket yet, so
     // no message can arrive before the handler below is installed.
     await gateway.register();
@@ -345,6 +352,9 @@ async function startBot(config: ReturnType<typeof loadConfig>, multi: boolean): 
     // them in multi-bot mode (the surviving bots keep the process alive).
     clearInterval(cwdCleanupTimer);
     cronScheduler?.stop();
+    // register() releases its own lock when IT fails; this covers the window
+    // where register() succeeded (lock held) but a later step threw.
+    releaseGatewayLock?.();
     try {
       store.close();
     } catch {


### PR DESCRIPTION
## Summary
Brings the cc-channel-octo gateway up to parity with the openclaw plugin for the cc-octo runtime line: a daemon-drivable self-update path, and multi-bot startup that no longer fails the whole gateway when one bot is bad.

## Changes
- **`upgrade` subcommand** — `cc-channel-octo upgrade [<version>]` runs `npm install -g @mininglamp-oss/cc-channel-octo@<version|latest>` then restarts the gateway. Version string is whitelisted to guard against argument injection.
- **Resilient multi-bot startup** — in multi-bot mode a bot that fails to register/connect is now skipped (logged) instead of tearing down every bot; startup is only fatal when no bot comes up. Single-bot keeps fail-fast.
- **Partial-startup cleanup** — `startBot` releases its own durable resources (cwd-cleanup timer, sqlite handle, gateway lock) if it throws after acquiring them, so a skipped bot leaks nothing.

## Test plan
- `npm run build` / `npm run lint` clean
- `npm test` — full suite green (incl. new `cli-upgrade` and `multibot-resilience` unit tests)
- Local: gateway runs two bots (different servers) concurrently; both online; injection guard rejects unsafe version

Part of the cc-octo parity work; sibling PRs in octo-daemon-cli / octo-fleet / octo-web.