### PR TITLE
feat(stream-relay): re-wire incremental stream path via /v1/bot/stream/{start,end} (OCT-37)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -38,7 +38,7 @@ This document describes the internal architecture of cc-channel-octo: a standalo
 └─────────────────────────────────────────────────────────────┘
          ▲                                      │
          │ WuKongIM binary protocol             │ Octo REST API
-         │ (WebSocket)                          │ (send/typing)
+         │ (WebSocket)                          │ (stream/send/typing)
          ▼                                      ▼
 ┌─────────────────────────────────────────────────────────────┐
 │                      Octo Server                            │
@@ -56,7 +56,7 @@ Forked from [openclaw-channel-octo](https://github.com/Mininglamp-OSS/openclaw-c
 | File | Responsibility |
 |---|---|
 | `types.ts` | Octo Bot API types, channel/message enums, mention payloads |
-| `api.ts` | REST API functions: register, send, typing, heartbeat, group members, user info, channel message sync |
+| `api.ts` | REST API functions: register, send, typing, heartbeat, stream start/end, group members, user info, channel message sync |
 | `socket.ts` | WuKongIM binary protocol over WebSocket: DH key exchange (curve25519), AES-CBC encryption, binary framing (variable-length encoding), CONNECT/CONNACK/RECV/RECVACK/PING/PONG, reconnect with exponential backoff + jitter |
 
 **Protocol details.** The WuKongIM protocol uses a custom binary framing format (not protobuf). Each frame has a 1-byte header (packet type in upper nibble, flags in lower nibble) followed by a variable-length body size and the body. Encryption is AES-128-CBC with keys derived from a Diffie-Hellman exchange (curve25519) during CONNECT/CONNACK. The salt from CONNACK provides the IV. Message IDs are 64-bit integers transmitted as big-endian — the API layer uses `parseOctoJson` to convert 16+ digit numeric IDs to strings before `JSON.parse` to avoid JavaScript precision loss.
@@ -77,7 +77,7 @@ Forked from [openclaw-channel-octo](https://github.com/Mininglamp-OSS/openclaw-c
 | `session-router.ts` | Message routing pipeline: self-message filter → bot blocklist → group mention gate (`uids` or `ais`, NOT `all`) → rate limiting (token bucket, per-session, debounced notification) → non-text rejection. **Critical design: `routeAndHandle` holds a per-session lock across both routing and handler execution** — this eliminates the TOCTOU gap between "should I process this?" and "processing it". |
 | `group-context.ts` | Group chat context management: in-memory message window (100 messages per channel, budget-capped to `maxContextChars`), member name cache (SQLite-backed, hourly API refresh), bidirectional uid↔name mapping, `@name` mention resolution via regex. Context string is built BEFORE the current message is cached to avoid duplication. |
 | `agent-bridge.ts` | Claude Agent SDK integration. Builds a **frozen** system prompt (security prefix + SOUL + group instructions only — no per-turn history/context, so the SDK's cached system block hits) and always `resume`s the SDK session (the source of truth for conversation history). Calls `query()` with configured permissions/tools/model, yields text chunks as `AsyncIterable<string>`. Recovers from a stale/expired resume by clearing the id + retrying once with an injected history fallback. **Knows nothing about Octo.** |
-| `stream-relay.ts` | Output delivery. Typing indicator heartbeat (5s). Delivers agent output via plain `sendMessage` with intelligent splitting (paragraph > newline > space > hard cut, 3500 char segments). |
+| `stream-relay.ts` | Output delivery. Typing indicator heartbeat (5s). Two-tier (OCT-37): incremental **stream path** (`stream/start` → per-chunk `sendMessage({stream_no})` → `stream/end` in a `finally` so END always fires), with **fallback** to plain `sendMessage` + @mention resolution + intelligent splitting (paragraph > newline > space > hard cut, 3500 char segments) when stream routes are absent (404). |
 | `index.ts` | Entry point orchestrator. Wires all modules in sequence: config → adapter → store → cleanup → group-context → stream-relay → gateway → router → message handler. The `handleMessage` function coordinates the full pipeline under the router's session lock. |
 
 ## Data Flow
@@ -93,7 +93,7 @@ Forked from [openclaw-channel-octo](https://github.com/Mininglamp-OSS/openclaw-c
 6. Inside handler (still under lock):
    a. session-store: getOrCreate session, build history prefix
    b. agent-bridge: buildPrompt (history + message) → query() → AsyncIterable<string>
-   c. stream-relay: typing heartbeat + sendMessage delivery to Octo
+   c. stream-relay: typing heartbeat + incremental stream delivery (or plain sendMessage fallback) to Octo
    d. session-store: append user message + assistant response
 7. Lock released → next queued message for this session proceeds
 ```
@@ -244,20 +244,32 @@ All 14 config fields are overridable via environment variables. See [README.md](
 
 ## Output Delivery
 
-### Text
+The stream relay implements a two-tier delivery strategy (OCT-37).
 
-The stream relay delivers agent text via plain `sendMessage` with intelligent text splitting. Split priority: paragraph break (`\n\n`) > newline (`\n`) > space > hard cut (surrogate-pair safe). Maximum segment size: 3500 characters. Per-segment try/catch ensures one failed segment does not drop the rest.
+### Stream path (preferred)
 
-A typing indicator heartbeat runs at 5-second intervals so the user sees activity during long agent runs.
+When the server advertises `/v1/bot/stream/{start,end}` (OCT-31), the relay renders a live, token-by-token bubble:
 
-### @mentions (G7)
+1. `stream/start` opens the bubble and returns a `stream_no` (the server forces the sender to the authenticated bot).
+2. Each agent chunk is sent via `sendMessage({ stream_no, content })` — the server forwards `stream_no` → `MsgSendReq` so octo-web appends it to the streaming bubble.
+3. `stream/end` is called in a **`finally`** so the terminal END (`streamFlag === END`) **always** fires — on success, agent error, abort, or truncation. octo-web (OCT-11) stops the streaming bubble on that END; a missing END leaves it stuck "streaming".
 
-Before each `sendMessage` call, the relay runs `resolveMentions()` from `mention-utils.ts`:
-- **Structured form** `@[uid:displayName]` (preferred, generated from system prompt) — converted to `@displayName` with precise `MentionEntity` payload.
-- **Plain form** `@displayName` — resolved via optional `memberMap` (displayName → uid). Longest-prefix match handles names containing spaces.
-- **`@all` / `@所有人`** — detected and surfaced as `mentionAll: true`.
+Per-chunk send failures are swallowed (logged) so one bad chunk does not abort the stream. A source-iterable error is re-thrown after END fires so the caller's error path still runs. Total streamed length is bounded by `maxResponseChars` (Q32). The stream path streams raw chunks and does **not** resolve @mentions — see note below.
 
-Resolved `mentionUids`, `mentionEntities`, and `mentionAll` are attached to the outbound payload so the IM server can route notifications correctly.
+### Fallback path
+
+When the server does not advertise the stream routes (**404** on `stream/start`), the relay falls back to plain `sendMessage` — this is a capability signal, not a turn error, and the result is cached so later turns skip the probe. The fallback accumulates the full reply, then:
+
+- **Text splitting.** Split priority: paragraph break (`\n\n`) > newline (`\n`) > space > hard cut (surrogate-pair safe). Maximum segment size: 3500 characters. Per-segment try/catch ensures one failed segment does not drop the rest.
+- **@mentions (G7).** `resolveMentions()` (from `mention-utils.ts`) runs ONCE on the full text before splitting:
+  - **Structured** `@[uid:displayName]` → `@displayName` with a precise `MentionEntity`.
+  - **Plain** `@displayName` → resolved via optional `memberMap`. Longest-prefix match handles names with spaces.
+  - **`@all` / `@所有人`** → surfaced as `mentionAll: true`, attached to the first segment only (no notification spam).
+  Resolved `mentionUids`, `mentionEntities`, and `mentionAll` are attached to the outbound payload so the IM server routes notifications correctly.
+
+A typing indicator heartbeat runs at 5-second intervals on both paths so the user sees activity during long agent runs.
+
+> **@mentions on the stream path.** The live token-by-token path sends raw chunks, so structured `@[uid:name]` mentions are not resolved and group notifications do not fire while streaming (a mention can span chunk boundaries, and per-chunk entity offsets do not map onto octo-web's concatenated bubble). Full mention handling lives on the fallback path. Resolving mentions inside streamed bubbles is a follow-up owned with Frontend.
 
 ### Outbound media & rich text
 
@@ -272,6 +284,7 @@ itself. Inbound media (downloading images the user sent) lives in `media-inbound
 ## Error Handling
 
 - **Agent errors:** Caught per-message, best-effort error reply sent to user, does not crash the process.
+- **Stream routes absent / failures:** A 404 on `stream/start` is a capability signal → automatic fallback to plain `sendMessage` (cached, no re-probe), no user-visible error. Transient (non-404) start failures fall back for that turn without disabling streaming. `stream/end` is always called in a `finally` so the live bubble is never left stuck "streaming".
 - **WebSocket disconnects:** Exponential backoff reconnect (3s base, 60s max, ±25% jitter). Three consecutive rapid disconnects (<5s each) trigger token refresh instead of reconnect.
 - **Heartbeat failures:** Three consecutive API heartbeat failures trigger reconnect via token refresh.
 - **Token refresh:** 60-second cooldown prevents refresh storms. Re-registers bot and establishes new WebSocket connection.

--- a/src/__tests__/e2e.test.ts
+++ b/src/__tests__/e2e.test.ts
@@ -10,30 +10,42 @@ import { join } from 'node:path';
 
 // --- Mocks (hoisted before imports) ---
 
-vi.mock('../octo/api.js', () => ({
-  sendMessage: vi.fn().mockResolvedValue(undefined),
-  sendTyping: vi.fn().mockResolvedValue(undefined),
-  sendReadReceipt: vi.fn().mockResolvedValue(undefined),
-  getGroupMembers: vi.fn().mockResolvedValue([]),
-  // G4 backfill path in the real handleMessage — default to no history.
-  getChannelMessages: vi.fn().mockResolvedValue([]),
-  getUploadCredentials: vi.fn().mockResolvedValue({
-    bucket: 'b', region: 'r', key: 'k',
-    credentials: { tmpSecretId: 'i', tmpSecretKey: 'k', sessionToken: 't' },
-    startTime: 1, expiredTime: 2,
-  }),
-  sendHeartbeat: vi.fn().mockResolvedValue(undefined),
-  registerBot: vi.fn().mockResolvedValue({
-    robot_id: 'bot-001',
-    im_token: 'token',
-    ws_url: 'ws://localhost',
-    api_url: 'https://test.example.com',
-    owner_uid: 'owner',
-    owner_channel_id: 'ch-owner',
-  }),
-  generateClientMsgNo: vi.fn().mockReturnValue('client-msg-001'),
-  fetchUserInfo: vi.fn().mockResolvedValue(null),
-}));
+vi.mock('../octo/api.js', () => {
+  // OCT-37: stream routes "not advertised" in the smoke suite — streamStart
+  // rejects with a 404 OctoApiError so deliver() takes the plain sendMessage
+  // fallback path, which these assertions target.
+  class OctoApiError extends Error {
+    status: number;
+    constructor(message: string, status: number) { super(message); this.name = 'OctoApiError'; this.status = status; }
+  }
+  return {
+    OctoApiError,
+    streamStart: vi.fn(async () => { throw new OctoApiError('stream routes absent', 404); }),
+    streamEnd: vi.fn().mockResolvedValue(undefined),
+    sendMessage: vi.fn().mockResolvedValue(undefined),
+    sendTyping: vi.fn().mockResolvedValue(undefined),
+    sendReadReceipt: vi.fn().mockResolvedValue(undefined),
+    getGroupMembers: vi.fn().mockResolvedValue([]),
+    // G4 backfill path in the real handleMessage — default to no history.
+    getChannelMessages: vi.fn().mockResolvedValue([]),
+    getUploadCredentials: vi.fn().mockResolvedValue({
+      bucket: 'b', region: 'r', key: 'k',
+      credentials: { tmpSecretId: 'i', tmpSecretKey: 'k', sessionToken: 't' },
+      startTime: 1, expiredTime: 2,
+    }),
+    sendHeartbeat: vi.fn().mockResolvedValue(undefined),
+    registerBot: vi.fn().mockResolvedValue({
+      robot_id: 'bot-001',
+      im_token: 'token',
+      ws_url: 'ws://localhost',
+      api_url: 'https://test.example.com',
+      owner_uid: 'owner',
+      owner_channel_id: 'ch-owner',
+    }),
+    generateClientMsgNo: vi.fn().mockReturnValue('client-msg-001'),
+    fetchUserInfo: vi.fn().mockResolvedValue(null),
+  };
+});
 
 vi.mock('../agent-bridge.js', async (importOriginal) => {
   const original = await importOriginal<typeof import('../agent-bridge.js')>();

--- a/src/__tests__/p2-polish.test.ts
+++ b/src/__tests__/p2-polish.test.ts
@@ -11,6 +11,10 @@ import { StreamRelay } from '../stream-relay.js';
 vi.mock('../octo/api.js', () => ({
   sendTyping: vi.fn().mockResolvedValue(undefined),
   sendMessage: vi.fn().mockResolvedValue(undefined),
+  // OCT-37: these truncation tests target the plain (fallback) path; streamStart
+  // returns a 404-shaped error so deliver() falls back deterministically.
+  streamStart: vi.fn(async () => { throw Object.assign(new Error('stream routes absent'), { status: 404 }); }),
+  streamEnd: vi.fn().mockResolvedValue(undefined),
   registerBot: vi.fn().mockResolvedValue({
     robot_id: 'bot-001',
     im_token: 'test-token',

--- a/src/__tests__/stream-relay.test.ts
+++ b/src/__tests__/stream-relay.test.ts
@@ -116,21 +116,38 @@ interface ApiCall {
   args: Record<string, unknown>;
 }
 
-const mockState = vi.hoisted(() => {
+const { mockState, OctoApiError } = vi.hoisted(() => {
+  class OctoApiError extends Error {
+    status: number;
+    constructor(message: string, status: number) {
+      super(message);
+      this.name = "OctoApiError";
+      this.status = status;
+    }
+  }
   const calls: ApiCall[] = [];
   let sendMessageFail = false;
-  return {
+  // Default 404 → stream routes "not advertised", so the bulk of the suite
+  // exercises the fallback (plain sendMessage) path unchanged. Stream-path
+  // tests set this to 200.
+  let streamStartStatus = 404;
+  const mockState = {
     calls,
     get sendMessageFail() { return sendMessageFail; },
     set sendMessageFail(v: boolean) { sendMessageFail = v; },
+    get streamStartStatus() { return streamStartStatus; },
+    set streamStartStatus(v: number) { streamStartStatus = v; },
     reset() {
       calls.length = 0;
       sendMessageFail = false;
+      streamStartStatus = 404;
     },
   };
+  return { mockState, OctoApiError };
 });
 
 vi.mock("../octo/api.js", () => ({
+  OctoApiError,
   sendTyping: vi.fn(async (params: Record<string, unknown>) => {
     mockState.calls.push({ fn: "sendTyping", args: params });
   }),
@@ -138,6 +155,19 @@ vi.mock("../octo/api.js", () => ({
     mockState.calls.push({ fn: "sendMessage", args: params });
     if (mockState.sendMessageFail) throw new Error("sendMessage failed");
     return { message_id: "msg_1", client_msg_no: "c1", message_seq: 1 };
+  }),
+  streamStart: vi.fn(async (params: Record<string, unknown>) => {
+    mockState.calls.push({ fn: "streamStart", args: params });
+    if (mockState.streamStartStatus !== 200) {
+      throw new OctoApiError(
+        `Octo API /v1/bot/stream/start failed (${mockState.streamStartStatus})`,
+        mockState.streamStartStatus,
+      );
+    }
+    return { stream_no: "stream_001" };
+  }),
+  streamEnd: vi.fn(async (params: Record<string, unknown>) => {
+    mockState.calls.push({ fn: "streamEnd", args: params });
   }),
 }));
 
@@ -212,8 +242,12 @@ describe("StreamRelay", () => {
     await vi.runAllTimersAsync();
     await promise;
 
-    const nonTyping = mockState.calls.filter((c) => c.fn !== "sendTyping");
-    expect(nonTyping.length).toBe(0);
+    // No message is delivered for empty output (a streamStart capability probe
+    // may be recorded, but nothing is sent and no stream is left open).
+    const delivered = mockState.calls.filter(
+      (c) => c.fn === "sendMessage" || c.fn === "streamEnd",
+    );
+    expect(delivered.length).toBe(0);
   });
 
   it("cleans up typing timer on completion", async () => {
@@ -493,3 +527,196 @@ describe("StreamRelay", () => {
     }
   });
 });
+
+// ─── Stream path (OCT-37) ────────────────────────────────────────────────────
+//
+// When the server advertises /v1/bot/stream/{start,end} (mock streamStartStatus
+// === 200), deliver() streams each agent chunk incrementally under a stream_no
+// and ALWAYS emits a terminal stream/end. A 404 on start falls back cleanly to
+// the plain sendMessage path.
+
+describe("StreamRelay — incremental stream path", () => {
+  let relay: StreamRelay;
+
+  const CH_ID = "test_channel";
+  const CH_TYPE = 2; // Group
+  const API_URL = "https://api.test";
+  const BOT_TOKEN = "***";
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockState.reset();
+    mockState.streamStartStatus = 200; // stream routes available
+    relay = new StreamRelay();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("happy path: start → per-chunk sendMessage(stream_no) → end, in order", async () => {
+    const chunks = asyncChunks(["Hello", " world", "!"]);
+    const promise = relay.deliver(CH_ID, CH_TYPE, chunks, API_URL, BOT_TOKEN);
+    await vi.runAllTimersAsync();
+    await promise;
+
+    const seq = mockState.calls
+      .filter((c) => ["streamStart", "sendMessage", "streamEnd"].includes(c.fn))
+      .map((c) => c.fn);
+    expect(seq[0]).toBe("streamStart");
+    expect(seq[seq.length - 1]).toBe("streamEnd");
+
+    // One incremental sendMessage per chunk, each carrying the stream_no.
+    const sendCalls = mockState.calls.filter((c) => c.fn === "sendMessage");
+    expect(sendCalls.length).toBe(3);
+    expect(sendCalls.map((c) => (c.args as { content: string }).content)).toEqual([
+      "Hello", " world", "!",
+    ]);
+    for (const c of sendCalls) {
+      expect((c.args as { streamNo?: string }).streamNo).toBe("stream_001");
+    }
+
+    // Exactly one terminal END, carrying the stream_no + channel.
+    const endCalls = mockState.calls.filter((c) => c.fn === "streamEnd");
+    expect(endCalls.length).toBe(1);
+    expect(endCalls[0].args).toMatchObject({
+      streamNo: "stream_001",
+      channelId: CH_ID,
+      channelType: CH_TYPE,
+    });
+  });
+
+  it("forces a terminal END when the agent stream throws mid-stream, then re-throws", async () => {
+    async function* throwingChunks(): AsyncIterable<string> {
+      yield "partial";
+      throw new Error("source exploded");
+    }
+
+    const promise = relay.deliver(CH_ID, CH_TYPE, throwingChunks(), API_URL, BOT_TOKEN);
+    const guarded = promise.catch(() => {});
+    await vi.runAllTimersAsync();
+    await guarded;
+
+    // Source error still propagates so the caller's error path runs.
+    await expect(promise).rejects.toThrow("source exploded");
+
+    // The partial chunk was streamed…
+    const sendCalls = mockState.calls.filter((c) => c.fn === "sendMessage");
+    expect(sendCalls.length).toBe(1);
+    expect((sendCalls[0].args as { content: string }).content).toBe("partial");
+
+    // …and END fired despite the error (otherwise the bubble sticks "streaming").
+    expect(mockState.calls.filter((c) => c.fn === "streamEnd").length).toBe(1);
+  });
+
+  it("emits END even when a chunk send fails (per-chunk failures are swallowed)", async () => {
+    mockState.sendMessageFail = true;
+
+    const promise = relay.deliver(CH_ID, CH_TYPE, asyncChunks(["a", "b"]), API_URL, BOT_TOKEN);
+    await vi.runAllTimersAsync();
+    // Chunk-send failures do not reject the turn.
+    await expect(promise).resolves.toBeUndefined();
+
+    // Both chunk sends attempted, END still fired.
+    expect(mockState.calls.filter((c) => c.fn === "sendMessage").length).toBe(2);
+    expect(mockState.calls.filter((c) => c.fn === "streamEnd").length).toBe(1);
+  });
+
+  it("truncates an over-limit stream and still emits END", async () => {
+    const big = "x".repeat(50);
+    const promise = relay.deliver(
+      CH_ID, CH_TYPE, asyncChunks([big, big, big]), API_URL, BOT_TOKEN, 60,
+    );
+    await vi.runAllTimersAsync();
+    await promise;
+
+    const sent = mockState.calls
+      .filter((c) => c.fn === "sendMessage")
+      .map((c) => (c.args as { content: string }).content)
+      .join("");
+    // Total streamed content is bounded by maxResponseChars (+ suffix).
+    expect(sent).toContain("[response truncated]");
+    expect(sent.replace("\n\n[response truncated]", "").length).toBeLessThanOrEqual(60);
+    expect(mockState.calls.filter((c) => c.fn === "streamEnd").length).toBe(1);
+  });
+
+  it("does not resolve mentions on the stream path (raw chunks)", async () => {
+    // Mentions are a fallback-path feature; the stream path sends raw chunks.
+    const chunks = asyncChunks(["hello @[u1:Alice]"]);
+    const promise = relay.deliver(CH_ID, CH_TYPE, chunks, API_URL, BOT_TOKEN);
+    await vi.runAllTimersAsync();
+    await promise;
+
+    const sendCalls = mockState.calls.filter((c) => c.fn === "sendMessage");
+    const args = sendCalls[0].args as { content: string; mentionUids?: string[] };
+    expect(args.content).toBe("hello @[u1:Alice]"); // unresolved
+    expect(args.mentionUids).toBeUndefined();
+  });
+
+  it("falls back to plain sendMessage (with mentions) when start returns 404", async () => {
+    mockState.streamStartStatus = 404;
+
+    const chunks = asyncChunks(["hello @[u1:Alice]"]);
+    const promise = relay.deliver(CH_ID, CH_TYPE, chunks, API_URL, BOT_TOKEN);
+    await vi.runAllTimersAsync();
+    await promise;
+
+    // No END (stream never opened); plain path resolved the mention.
+    expect(mockState.calls.filter((c) => c.fn === "streamEnd").length).toBe(0);
+    const sendCalls = mockState.calls.filter((c) => c.fn === "sendMessage");
+    expect(sendCalls.length).toBe(1);
+    const args = sendCalls[0].args as { content: string; mentionUids?: string[]; streamNo?: string };
+    expect(args.content).toBe("hello @Alice");
+    expect(args.mentionUids).toEqual(["u1"]);
+    expect(args.streamNo).toBeUndefined();
+  });
+
+  it("caches a 404 capability result and does not re-probe on later turns", async () => {
+    mockState.streamStartStatus = 404;
+
+    await (async () => {
+      const p = relay.deliver(CH_ID, CH_TYPE, asyncChunks(["one"]), API_URL, BOT_TOKEN);
+      await vi.runAllTimersAsync();
+      await p;
+    })();
+
+    const startCallsAfterFirst = mockState.calls.filter((c) => c.fn === "streamStart").length;
+    expect(startCallsAfterFirst).toBe(1);
+
+    // Even if the server "comes back", the relay stays on the fallback path.
+    mockState.streamStartStatus = 200;
+    await (async () => {
+      const p = relay.deliver(CH_ID, CH_TYPE, asyncChunks(["two"]), API_URL, BOT_TOKEN);
+      await vi.runAllTimersAsync();
+      await p;
+    })();
+
+    // No new streamStart probe after the cached 404.
+    expect(mockState.calls.filter((c) => c.fn === "streamStart").length).toBe(1);
+    expect(mockState.calls.filter((c) => c.fn === "streamEnd").length).toBe(0);
+  });
+
+  it("a transient (non-404) start failure falls back without disabling streaming", async () => {
+    mockState.streamStartStatus = 503;
+
+    await (async () => {
+      const p = relay.deliver(CH_ID, CH_TYPE, asyncChunks(["one"]), API_URL, BOT_TOKEN);
+      await vi.runAllTimersAsync();
+      await p;
+    })();
+    // Fell back to plain send this turn.
+    expect(mockState.calls.filter((c) => c.fn === "sendMessage").length).toBe(1);
+
+    // Routes recover → next turn streams (capability was NOT cached as false).
+    mockState.streamStartStatus = 200;
+    mockState.calls.length = 0;
+    await (async () => {
+      const p = relay.deliver(CH_ID, CH_TYPE, asyncChunks(["two"]), API_URL, BOT_TOKEN);
+      await vi.runAllTimersAsync();
+      await p;
+    })();
+    expect(mockState.calls.filter((c) => c.fn === "streamStart").length).toBe(1);
+    expect(mockState.calls.filter((c) => c.fn === "streamEnd").length).toBe(1);
+  });
+});
+

--- a/src/octo/api.ts
+++ b/src/octo/api.ts
@@ -2,16 +2,32 @@
 // Source: https://github.com/Mininglamp-OSS/openclaw-channel-octo
 // Removed: COS upload, GROUP.md API, OBO, rich text, media, thread/group management,
 //          read receipts, bot groups list, group info, mention prefs, space members.
+// Re-added (OCT-37): stream start/end API functions (server side landed in OCT-31).
 
 import {
   ChannelType,
   MessageType,
   type MentionEntity,
   type SendMessageResult,
+  type BotStreamStartResp,
 } from "./types.js";
 import { randomUUID } from "node:crypto";
 
 const DEFAULT_TIMEOUT_MS = 30_000;
+
+/**
+ * Error carrying the HTTP status of a failed Octo API call.
+ *
+ * Used by the stream relay to distinguish "route not advertised" (404 on
+ * stream/start → capability fallback) from genuine failures. Extends Error so
+ * existing `catch (err)` / `instanceof Error` callers are unaffected.
+ */
+export class OctoApiError extends Error {
+  constructor(message: string, readonly status: number) {
+    super(message);
+    this.name = "OctoApiError";
+  }
+}
 
 /**
  * Maximum base64-encoded payload length accepted from /v1/bot/messages/sync.
@@ -73,7 +89,10 @@ export async function postJson<T>(
 
   if (!response.ok) {
     const text = await response.text().catch(() => "");
-    throw new Error(`Octo API ${path} failed (${response.status}): ${text || response.statusText}`);
+    throw new OctoApiError(
+      `Octo API ${path} failed (${response.status}): ${text || response.statusText}`,
+      response.status,
+    );
   }
 
   const text = await response.text();
@@ -98,6 +117,13 @@ export async function sendMessage(params: {
   mentionAll?: boolean;
   replyMsgId?: string;
   clientMsgNo?: string;
+  /**
+   * OCT-37: when set, this message is an incremental chunk of an open stream
+   * (opened via streamStart). The server forwards `stream_no` to MsgSendReq so
+   * octo-web appends it to the live "streaming" bubble instead of rendering a
+   * standalone message.
+   */
+  streamNo?: string;
   signal?: AbortSignal;
 }): Promise<SendMessageResult | undefined> {
   const payload: Record<string, unknown> = {
@@ -124,12 +150,87 @@ export async function sendMessage(params: {
   if (params.replyMsgId) {
     payload.reply = { message_id: params.replyMsgId };
   }
-  return await postJson<SendMessageResult>(params.apiUrl, params.botToken, "/v1/bot/sendMessage", {
+  const body: Record<string, unknown> = {
     channel_id: params.channelId,
     channel_type: params.channelType,
     payload,
     client_msg_no: params.clientMsgNo ?? generateClientMsgNo(),
-  }, params.signal);
+  };
+  // stream_no is a top-level field on the server's BotSendMessageReq (not inside
+  // payload); only include it when streaming so non-stream sends are unchanged.
+  if (params.streamNo) {
+    body.stream_no = params.streamNo;
+  }
+  return await postJson<SendMessageResult>(params.apiUrl, params.botToken, "/v1/bot/sendMessage", body, params.signal);
+}
+
+// ─── Stream API (OCT-31 / OCT-37) ───────────────────────────────────────────
+
+/**
+ * Open a streaming message. POST /v1/bot/stream/start → { stream_no }.
+ *
+ * The returned stream_no is passed to sendMessage() for each incremental chunk
+ * and to streamEnd() to terminate the live bubble. The server forces the
+ * sender to the authenticated bot and ignores any client from_uid.
+ *
+ * Throws OctoApiError on failure; a 404 status means the server does not
+ * advertise the stream routes — the relay treats this as "fall back to plain
+ * sendMessage", not a turn error.
+ */
+export async function streamStart(params: {
+  apiUrl: string;
+  botToken: string;
+  channelId: string;
+  channelType: ChannelType;
+  clientMsgNo?: string;
+  payload?: string;
+  signal?: AbortSignal;
+}): Promise<BotStreamStartResp> {
+  const body: Record<string, unknown> = {
+    channel_id: params.channelId,
+    channel_type: params.channelType,
+  };
+  if (params.clientMsgNo) body.client_msg_no = params.clientMsgNo;
+  if (params.payload) body.payload = params.payload;
+  const result = await postJson<BotStreamStartResp>(
+    params.apiUrl,
+    params.botToken,
+    "/v1/bot/stream/start",
+    body,
+    params.signal,
+  );
+  if (!result?.stream_no) {
+    throw new Error("streamStart: no stream_no in response");
+  }
+  return result;
+}
+
+/**
+ * Close a stream. POST /v1/bot/stream/end → 200.
+ *
+ * Emits the terminal END (streamFlag == END) that octo-web waits on to stop
+ * the live "streaming" bubble. MUST be called in a finally so END always fires
+ * — a missing END leaves the client bubble stuck "streaming" indefinitely.
+ */
+export async function streamEnd(params: {
+  apiUrl: string;
+  botToken: string;
+  streamNo: string;
+  channelId: string;
+  channelType: ChannelType;
+  signal?: AbortSignal;
+}): Promise<void> {
+  await postJson(
+    params.apiUrl,
+    params.botToken,
+    "/v1/bot/stream/end",
+    {
+      stream_no: params.streamNo,
+      channel_id: params.channelId,
+      channel_type: params.channelType,
+    },
+    params.signal,
+  );
 }
 
 /**

--- a/src/octo/types.ts
+++ b/src/octo/types.ts
@@ -88,6 +88,38 @@ export interface SendMessageResult {
   message_seq: number;
 }
 
+// ─── Stream API (OCT-31 / OCT-37) ───────────────────────────────────────────
+//
+// Re-introduced after b7139d2 removed the (then-dead) stream path. The server
+// now exposes /v1/bot/stream/{start,end} (OCT-31). The bot opens a live bubble
+// with stream/start, streams incremental chunks via /v1/bot/sendMessage with
+// `stream_no` set, and closes the bubble with stream/end (terminal END). The
+// server forces FromUID to the authenticated bot, so no sender field is sent.
+
+/** Request body for POST /v1/bot/stream/start. */
+export interface BotStreamStartReq {
+  channel_id: string;
+  channel_type: ChannelType;
+  /** Optional client-side idempotency key for the opening message. */
+  client_msg_no?: string;
+  /** Optional message header flags (e.g. red-dot). */
+  header?: Record<string, unknown>;
+  /** Optional base64-encoded initial payload. */
+  payload?: string;
+}
+
+/** Response body for POST /v1/bot/stream/start. */
+export interface BotStreamStartResp {
+  stream_no: string;
+}
+
+/** Request body for POST /v1/bot/stream/end. */
+export interface BotStreamEndReq {
+  stream_no: string;
+  channel_id: string;
+  channel_type: ChannelType;
+}
+
 /** Channel types */
 export enum ChannelType {
   DM = 1,

--- a/src/stream-relay.ts
+++ b/src/stream-relay.ts
@@ -1,19 +1,37 @@
 /**
- * Stream Relay — typing heartbeat + message splitting + plain sendMessage delivery.
+ * Stream Relay — incremental stream delivery + typing heartbeat + message splitting.
  *
- * Consumes an AsyncIterable<string> of text chunks and delivers them to Octo
- * via plain sendMessage with intelligent splitting.
+ * Consumes an AsyncIterable<string> of text chunks and delivers them to Octo.
+ *
+ * Two-tier delivery (OCT-37):
+ *  - **Stream path** (preferred): open a live bubble with `stream/start`, send
+ *    each agent chunk via `sendMessage({ stream_no, content })`, and always
+ *    close it with `stream/end` in a `finally` so the terminal END fires even
+ *    on agent error / abort / truncation. octo-web (OCT-11) stops the streaming
+ *    bubble on that END; a missing END leaves it stuck "streaming".
+ *  - **Fallback path**: when the server does not advertise the stream routes
+ *    (404 on `stream/start`), deliver the accumulated text via plain
+ *    `sendMessage` with @mention resolution + intelligent splitting. The 404
+ *    is a capability signal, NOT a turn error.
  *
  * Design constraints:
  * - Knows nothing about Claude SDK — input is a generic async text stream.
  * - All Octo API calls go through the api.ts functions (no raw fetch).
- * - Typing indicators keep the user informed while chunks accumulate.
+ * - Typing indicators keep the user informed while chunks flow.
+ *
+ * NOTE: the stream path streams raw chunks for the live token-by-token bubble
+ * and does NOT resolve @mentions (mentions can span chunk boundaries, and
+ * per-chunk entity offsets do not map onto octo-web's concatenated bubble).
+ * Full @mention resolution + notification routing happens on the fallback
+ * path. See OCT-37 follow-up for streamed-bubble mention handling.
  */
 
 import type { ChannelType } from "./octo/types.js";
 import {
   sendTyping,
   sendMessage,
+  streamStart,
+  streamEnd,
 } from "./octo/api.js";
 import { resolveMentions } from "./mention-utils.js";
 
@@ -150,11 +168,19 @@ export function splitMessage(
 
 export class StreamRelay {
   /**
+   * Cached stream-route capability. `undefined` = not yet probed, `true` =
+   * stream routes available, `false` = server returned 404 on stream/start
+   * (don't probe again — go straight to the fallback path every turn).
+   */
+  private streamRoutesAvailable?: boolean;
+
+  /**
    * Deliver an async stream of text chunks to an Octo channel.
    *
    * 1. Starts a typing indicator heartbeat (5 s interval).
-   * 2. Accumulates all chunks from the async iterable.
-   * 3. Sends the accumulated text via plain sendMessage with splitting.
+   * 2. Attempts the incremental stream path (start → per-chunk send → end).
+   * 3. If the server does not advertise stream routes (404 on start), falls
+   *    back to the plain accumulate → resolve mentions → split → send path.
    * 4. Always cleans up the typing heartbeat.
    */
   async deliver(
@@ -176,113 +202,243 @@ export class StreamRelay {
     }, TYPING_INTERVAL_MS);
 
     try {
-      // Accumulate all chunks, with truncation guard (Q32).
-      let accumulated = "";
+      // Attempt the stream path unless we already know the routes are absent.
+      if (this.streamRoutesAvailable !== false) {
+        const handled = await this._deliverViaStream(
+          channelId,
+          channelType,
+          chunks,
+          apiUrl,
+          botToken,
+          maxResponseChars,
+        );
+        // handled === false ONLY when stream/start failed BEFORE any chunk was
+        // consumed, so `chunks` is still pristine for the fallback path.
+        if (handled) return;
+      }
+      await this._deliverPlain(
+        channelId,
+        channelType,
+        chunks,
+        apiUrl,
+        botToken,
+        maxResponseChars,
+        memberMap,
+        isValidUid,
+      );
+    } finally {
+      clearInterval(typingTimer);
+    }
+  }
+
+  // ── Stream path (OCT-37) ─────────────────────────────────────────────────
+
+  /**
+   * Open a stream, send each chunk as an incremental message, and ALWAYS close
+   * the stream with a terminal END (in a finally) so octo-web stops the live
+   * bubble even on agent error / abort / truncation.
+   *
+   * Returns `true` when the stream path handled delivery (including when the
+   * agent produced no output after a successful start). Returns `false` only
+   * when stream/start failed before consuming any chunk — the caller then runs
+   * the fallback path on the still-untouched `chunks`.
+   *
+   * Re-throws a source-iterable error after END fires, mirroring the plain
+   * path, so the caller's error handling still runs. Per-chunk send failures
+   * are swallowed (logged) so one bad chunk does not abort the stream.
+   */
+  private async _deliverViaStream(
+    channelId: string,
+    channelType: ChannelType,
+    chunks: AsyncIterable<string>,
+    apiUrl: string,
+    botToken: string,
+    maxResponseChars: number,
+  ): Promise<boolean> {
+    let streamNo: string;
+    try {
+      const res = await streamStart({ apiUrl, botToken, channelId, channelType });
+      streamNo = res.stream_no;
+    } catch (err) {
+      // Capability detection by HTTP status (duck-typed via OctoApiError.status)
+      // — robust to cross-module instanceof and to test mocks.
+      const status = (err as { status?: number })?.status;
+      if (status === 404) {
+        // Server does not advertise the stream routes — remember and fall back.
+        this.streamRoutesAvailable = false;
+        return false;
+      }
+      // Transient start failure (5xx, network). Don't disable streaming
+      // permanently; fall back for this turn so the reply is not dropped.
+      console.error(`[stream-relay] stream/start failed, falling back to plain send: ${String(err)}`);
+      return false;
+    }
+    this.streamRoutesAvailable = true;
+
+    let streamError: unknown;
+    let accumulatedLen = 0;
+    try {
       let truncated = false;
-      // If the agent stream throws mid-way (network blip, non-recoverable SDK
-      // error after partial output), we still want to deliver what we have
-      // instead of dropping a real partial reply on the floor — then re-throw so
-      // the caller's error path still runs. Capture the error and flush below.
-      let streamError: unknown;
-      try {
-        for await (const chunk of chunks) {
-          accumulated += chunk;
-          // Q32: Stop accumulating once limit is reached to prevent unbounded memory.
-          if (accumulated.length > maxResponseChars) {
-            // P1-6: cut at code-unit boundary, but back off if it lands inside
-            // a surrogate pair (would produce an orphan high surrogate = invalid
-            // Unicode). Mirrors splitMessage's hard-cut surrogate guard.
-            let cutAt = maxResponseChars;
-            const code = accumulated.charCodeAt(cutAt - 1);
-            if (code >= 0xD800 && code <= 0xDBFF) cutAt--;
-            accumulated = accumulated.slice(0, cutAt) + TRUNCATION_SUFFIX;
-            truncated = true;
-            break;
+      for await (const chunk of chunks) {
+        if (truncated) break;
+        let piece = chunk;
+        // Q32: bound total streamed length; cut the chunk that crosses the limit.
+        if (accumulatedLen + piece.length > maxResponseChars) {
+          let cutAt = maxResponseChars - accumulatedLen;
+          if (cutAt > 0) {
+            // P1-6: don't cut inside a surrogate pair.
+            const code = piece.charCodeAt(cutAt - 1);
+            if (code >= 0xd800 && code <= 0xdbff) cutAt--;
+          }
+          piece = piece.slice(0, Math.max(0, cutAt)) + TRUNCATION_SUFFIX;
+          truncated = true;
+        }
+        accumulatedLen += piece.length;
+        if (piece.length > 0) {
+          try {
+            await sendMessage({ apiUrl, botToken, channelId, channelType, streamNo, content: piece });
+          } catch (err) {
+            console.error(`[stream-relay] stream chunk send failed (${piece.length} chars), continuing: ${String(err)}`);
           }
         }
-      } catch (err) {
-        streamError = err;
-        console.error(`[stream-relay] agent stream threw after ${accumulated.length} char(s); flushing partial output: ${String(err)}`);
       }
       if (truncated) {
         console.warn(`[stream-relay] Response truncated at ${maxResponseChars} chars`);
       }
+    } catch (err) {
+      streamError = err;
+      console.error(`[stream-relay] agent stream threw mid-stream after ${accumulatedLen} char(s); emitting terminal END: ${String(err)}`);
+    } finally {
+      // ALWAYS emit the terminal END so the live bubble is closed — even on
+      // agent error / abort / truncation. Swallow END failures (best-effort).
+      try {
+        await streamEnd({ apiUrl, botToken, streamNo, channelId, channelType });
+      } catch (err) {
+        console.error(`[stream-relay] stream/end failed: ${String(err)}`);
+      }
+    }
 
-      // Send accumulated text via plain messages with splitting.
-      if (accumulated.length > 0) {
-        // P0-1: Resolve @[uid:name] structured mentions and @name ONCE on the
-        // full accumulated text, BEFORE splitting. This guarantees splitMessage
-        // cannot break a structured mention across segments — by the time
-        // splitMessage runs, @[uid:name] is already @name. We additionally
-        // pass each resolved @name as a ProtectedRange so splitMessage avoids
-        // cutting through names that contain spaces (e.g. "John Smith").
-        const {
-          finalContent,
-          mentionEntities: globalEntities,
-          mentionAll,
-        } = resolveMentions(accumulated, memberMap, isValidUid);
+    // Surface the source error after END so the caller's error path still runs.
+    if (streamError !== undefined) throw streamError;
+    return true;
+  }
 
-        const protectedRanges = globalEntities.map(e => ({
-          start: e.offset,
-          end: e.offset + e.length,
-        }));
+  // ── Fallback path: accumulate → resolve mentions → split → plain send ─────
 
-        const segments = splitMessage(finalContent, undefined, protectedRanges);
-        let segStart = 0;
-        let mentionAllConsumed = false;
-        for (const segment of segments) {
-          const segEnd = segStart + segment.length;
-          // Partition entities falling within this segment, re-rebase to
-          // segment-local offsets. Server expects per-message offsets.
-          const segEntities = globalEntities
-            .filter(e => e.offset >= segStart && e.offset + e.length <= segEnd)
-            .map(e => ({ uid: e.uid, offset: e.offset - segStart, length: e.length }));
-          const segUids = segEntities.map(e => e.uid);
-
-          // mentionAll only applies to one segment (the first). Avoids spamming
-          // @所有人 notifications when a reply spans multiple chunks.
-          //
-          // Design choice (王大锤 PR#45 review note): we attach mentionAll to the
-          // FIRST segment unconditionally, not to the segment that actually
-          // contains the resolved "@all"/"@所有人" text. Three reasons:
-          //   1. mentionAll on the Octo API is a wire-level notification flag,
-          //      independent of where the literal "@all" text appears.
-          //   2. The first segment is always sent first — attaching the flag
-          //      there minimizes notification latency.
-          //   3. The literal text may have been resolved/rewritten by the LLM
-          //      into multiple positions; pinning to segment 0 is unambiguous.
-          // Alternative considered: scan each segment for @all literal and
-          // attach the flag only to segments containing it. Rejected because
-          // it would double-notify when @all appears more than once.
-          const useMentionAll = mentionAll && !mentionAllConsumed;
-          if (useMentionAll) mentionAllConsumed = true;
-
-          try {
-            await sendMessage({
-              apiUrl,
-              botToken,
-              channelId,
-              channelType,
-              content: segment,
-              ...(segUids.length > 0 ? { mentionUids: segUids } : {}),
-              ...(segEntities.length > 0 ? { mentionEntities: segEntities } : {}),
-              ...(useMentionAll ? { mentionAll: true } : {}),
-            });
-          } catch (err) {
-            console.error(`[stream-relay] sendMessage failed for segment (${segment.length} chars), continuing: ${String(err)}`);
-            // Continue sending remaining segments — don't let one failure drop the rest
-          }
-          segStart = segEnd;
+  private async _deliverPlain(
+    channelId: string,
+    channelType: ChannelType,
+    chunks: AsyncIterable<string>,
+    apiUrl: string,
+    botToken: string,
+    maxResponseChars: number,
+    memberMap?: Map<string, string>,
+    isValidUid?: (uid: string) => boolean,
+  ): Promise<void> {
+    // Accumulate all chunks, with truncation guard (Q32).
+    let accumulated = "";
+    let truncated = false;
+    // If the agent stream throws mid-way (network blip, non-recoverable SDK
+    // error after partial output), we still want to deliver what we have
+    // instead of dropping a real partial reply on the floor — then re-throw so
+    // the caller's error path still runs. Capture the error and flush below.
+    let streamError: unknown;
+    try {
+      for await (const chunk of chunks) {
+        accumulated += chunk;
+        // Q32: Stop accumulating once limit is reached to prevent unbounded memory.
+        if (accumulated.length > maxResponseChars) {
+          // P1-6: cut at code-unit boundary, but back off if it lands inside
+          // a surrogate pair (would produce an orphan high surrogate = invalid
+          // Unicode). Mirrors splitMessage's hard-cut surrogate guard.
+          let cutAt = maxResponseChars;
+          const code = accumulated.charCodeAt(cutAt - 1);
+          if (code >= 0xD800 && code <= 0xDBFF) cutAt--;
+          accumulated = accumulated.slice(0, cutAt) + TRUNCATION_SUFFIX;
+          truncated = true;
+          break;
         }
       }
-      // If accumulated is empty, the agent produced no output — nothing to send.
-      // If the stream threw mid-way, we've now flushed whatever partial text was
-      // accumulated; re-throw so the caller's error handling still runs (it will
-      // not double-send — the partial was delivered here, the caller only logs /
-      // surfaces the failure).
-      if (streamError !== undefined) throw streamError;
-    } finally {
-      clearInterval(typingTimer);
+    } catch (err) {
+      streamError = err;
+      console.error(`[stream-relay] agent stream threw after ${accumulated.length} char(s); flushing partial output: ${String(err)}`);
     }
+    if (truncated) {
+      console.warn(`[stream-relay] Response truncated at ${maxResponseChars} chars`);
+    }
+
+    // Send accumulated text via plain messages with splitting.
+    if (accumulated.length > 0) {
+      // P0-1: Resolve @[uid:name] structured mentions and @name ONCE on the
+      // full accumulated text, BEFORE splitting. This guarantees splitMessage
+      // cannot break a structured mention across segments — by the time
+      // splitMessage runs, @[uid:name] is already @name. We additionally
+      // pass each resolved @name as a ProtectedRange so splitMessage avoids
+      // cutting through names that contain spaces (e.g. "John Smith").
+      const {
+        finalContent,
+        mentionEntities: globalEntities,
+        mentionAll,
+      } = resolveMentions(accumulated, memberMap, isValidUid);
+
+      const protectedRanges = globalEntities.map(e => ({
+        start: e.offset,
+        end: e.offset + e.length,
+      }));
+
+      const segments = splitMessage(finalContent, undefined, protectedRanges);
+      let segStart = 0;
+      let mentionAllConsumed = false;
+      for (const segment of segments) {
+        const segEnd = segStart + segment.length;
+        // Partition entities falling within this segment, re-rebase to
+        // segment-local offsets. Server expects per-message offsets.
+        const segEntities = globalEntities
+          .filter(e => e.offset >= segStart && e.offset + e.length <= segEnd)
+          .map(e => ({ uid: e.uid, offset: e.offset - segStart, length: e.length }));
+        const segUids = segEntities.map(e => e.uid);
+
+        // mentionAll only applies to one segment (the first). Avoids spamming
+        // @所有人 notifications when a reply spans multiple chunks.
+        //
+        // Design choice (王大锤 PR#45 review note): we attach mentionAll to the
+        // FIRST segment unconditionally, not to the segment that actually
+        // contains the resolved "@all"/"@所有人" text. Three reasons:
+        //   1. mentionAll on the Octo API is a wire-level notification flag,
+        //      independent of where the literal "@all" text appears.
+        //   2. The first segment is always sent first — attaching the flag
+        //      there minimizes notification latency.
+        //   3. The literal text may have been resolved/rewritten by the LLM
+        //      into multiple positions; pinning to segment 0 is unambiguous.
+        // Alternative considered: scan each segment for @all literal and
+        // attach the flag only to segments containing it. Rejected because
+        // it would double-notify when @all appears more than once.
+        const useMentionAll = mentionAll && !mentionAllConsumed;
+        if (useMentionAll) mentionAllConsumed = true;
+
+        try {
+          await sendMessage({
+            apiUrl,
+            botToken,
+            channelId,
+            channelType,
+            content: segment,
+            ...(segUids.length > 0 ? { mentionUids: segUids } : {}),
+            ...(segEntities.length > 0 ? { mentionEntities: segEntities } : {}),
+            ...(useMentionAll ? { mentionAll: true } : {}),
+          });
+        } catch (err) {
+          console.error(`[stream-relay] sendMessage failed for segment (${segment.length} chars), continuing: ${String(err)}`);
+          // Continue sending remaining segments — don't let one failure drop the rest
+        }
+        segStart = segEnd;
+      }
+    }
+    // If accumulated is empty, the agent produced no output — nothing to send.
+    // If the stream threw mid-way, we've now flushed whatever partial text was
+    // accumulated; re-throw so the caller's error handling still runs (it will
+    // not double-send — the partial was delivered here, the caller only logs /
+    // surfaces the failure).
+    if (streamError !== undefined) throw streamError;
   }
 }


### PR DESCRIPTION
## Summary

Re-introduces the **incremental stream delivery path** in `StreamRelay`, removed in `b7139d2` (then dead — the server had no `/v1/bot/stream/*` routes). The server side landed in **OCT-31**, so the path now actually works: `StreamRelay` renders a live, token-by-token bubble and **always** emits a terminal END.

- **`src/octo/api.ts`** — re-add `streamStart() → { stream_no }` and `streamEnd()`; `sendMessage()` forwards an optional top-level `stream_no` (matches server `BotSendMessageReq.StreamNo`). `postJson` now throws `OctoApiError` carrying the HTTP `status` for 404 capability detection (back-compatible — still an `Error`).
- **`src/octo/types.ts`** — re-add `BotStreamStartReq`/`BotStreamStartResp`/`BotStreamEndReq` (start req matches the OCT-31 contract: `client_msg_no?`, `header?`, `payload?`).
- **`src/stream-relay.ts`** — two-tier `deliver()`:
  - **Stream path:** `stream/start` → per-chunk `sendMessage({ stream_no, content })` → `stream/end` in a **`finally`** so END fires on success / agent error / abort / truncation.
  - **Fallback:** 404 on `stream/start` → cached fallback to the existing plain `sendMessage` + `@mention` resolution + intelligent splitting path. A 404 is a capability signal, not a turn error; transient (non-404) start failures fall back for the turn without disabling streaming.
- **Tests** — restored `stream-relay` coverage (happy path start→chunks→end, forced END on mid-stream error/abort, truncation, fallback, capability caching); updated `e2e` + `p2-polish` mocks. Full suite: **996 passing**, typecheck + lint clean.
- **`ARCHITECTURE.md`** — documents the two-tier delivery.

## Contract notes (please review, Frontend)

- Incremental chunks reuse `POST /v1/bot/sendMessage` with top-level `stream_no` (per OCT-31 — server already forwards `StreamNo → MsgSendReq`). No `/stream/send` route is used.
- **Known limitation:** the stream path sends **raw** chunks and does **not** resolve `@mentions` (a mention can span chunk boundaries, and per-chunk entity offsets don't map onto octo-web's concatenated bubble). Full mention handling stays on the fallback path. Resolving mentions inside streamed bubbles is a proposed follow-up owned with Frontend — flagging for a decision before merge.

## Acceptance

- [x] Streams a bot reply incrementally via `stream_no` and always emits terminal END.
- [x] Falls back cleanly to plain `sendMessage` when stream routes are absent (404).
- [x] Tests cover happy path, forced END on mid-stream error/abort, and fallback.

## Test plan

- [x] `npm run type-check`
- [x] `npm run lint`
- [x] `npx vitest run` (996 passing)
- [ ] Frontend confirm streamed-bubble rendering + mention follow-up decision
- [ ] Integration smoke against an OCT-31 server build

Closes OCT-37.