### PR TITLE
feat: add configure subcommand and sdk.apiKey for one-click install

### DIFF
--- a/src/__tests__/agent-bridge-env.test.ts
+++ b/src/__tests__/agent-bridge-env.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest'
+import { buildSdkEnv } from '../agent-bridge.js'
+
+describe('buildSdkEnv', () => {
+  it('injects ANTHROPIC_API_KEY when sdk.apiKey set', () => {
+    const env = buildSdkEnv({ apiKey: 'sk-test', anthropicBaseUrl: 'https://gw.example.com' }, { HOME: '/h' })
+    expect(env?.ANTHROPIC_API_KEY).toBe('sk-test')
+    expect(env?.ANTHROPIC_BASE_URL).toBe('https://gw.example.com')
+    expect(env?.HOME).toBe('/h')
+  })
+  it('injects ANTHROPIC_BASE_URL only when apiKey absent', () => {
+    const env = buildSdkEnv({ anthropicBaseUrl: 'https://gw.example.com' }, { HOME: '/h' })
+    expect(env?.ANTHROPIC_BASE_URL).toBe('https://gw.example.com')
+    expect(env?.ANTHROPIC_API_KEY).toBeUndefined()
+  })
+  it('returns undefined when nothing to inject', () => {
+    expect(buildSdkEnv({}, { HOME: '/h' })).toBeUndefined()
+  })
+  it('apiKey alone (no baseUrl) still injects key', () => {
+    const env = buildSdkEnv({ apiKey: 'sk-only' }, { HOME: '/h' })
+    expect(env?.ANTHROPIC_API_KEY).toBe('sk-only')
+  })
+})

--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -133,6 +133,17 @@ describe('readVersion', () => {
   });
 });
 
+describe('parseArgs configure', () => {
+  it('parses --gateway-url and --api-key (space form)', () => {
+    const a = parseArgs(['configure', '--gateway-url', 'https://gw', '--api-key', 'sk-1'])
+    expect(a.cmd).toBe('configure'); expect(a.gatewayUrl).toBe('https://gw'); expect(a.apiKey).toBe('sk-1')
+  })
+  it('parses = form', () => {
+    const a = parseArgs(['configure', '--gateway-url=https://gw', '--api-key=sk-2'])
+    expect(a.gatewayUrl).toBe('https://gw'); expect(a.apiKey).toBe('sk-2')
+  })
+})
+
 describe('run version command', () => {
   it.each(['version', '--version', '-v'])('prints bare version and exits 0 for %s', async (arg) => {
     const spy = vi.spyOn(console, 'log').mockImplementation(() => {});

--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -142,6 +142,18 @@ describe('parseArgs configure', () => {
     const a = parseArgs(['configure', '--gateway-url=https://gw', '--api-key=sk-2'])
     expect(a.gatewayUrl).toBe('https://gw'); expect(a.apiKey).toBe('sk-2')
   })
+  it('throws when --gateway-url value is missing', () => {
+    expect(() => parseArgs(['configure', '--gateway-url'])).toThrow(/requires a value/)
+  })
+  it('throws when --gateway-url value is another flag', () => {
+    expect(() => parseArgs(['configure', '--gateway-url', '--api-key', 'sk'])).toThrow(/requires a value/)
+  })
+  it('throws when --api-key value is missing', () => {
+    expect(() => parseArgs(['configure', '--api-key'])).toThrow(/requires a value/)
+  })
+  it('throws when --api-key value is another flag', () => {
+    expect(() => parseArgs(['configure', '--api-key', '--gateway-url', 'https://gw'])).toThrow(/requires a value/)
+  })
 })
 
 describe('run configure with env var fallback', () => {

--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -144,6 +144,65 @@ describe('parseArgs configure', () => {
   })
 })
 
+describe('run configure with env var fallback', () => {
+  let dir: string;
+  let cfgPath: string;
+  const originalEnv = process.env.CC_OCTO_CONFIGURE_API_KEY;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'cc-cli-cfg-'));
+    cfgPath = join(dir, 'config.json');
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    if (originalEnv === undefined) {
+      delete process.env.CC_OCTO_CONFIGURE_API_KEY;
+    } else {
+      process.env.CC_OCTO_CONFIGURE_API_KEY = originalEnv;
+    }
+  });
+
+  it('reads API key from CC_OCTO_CONFIGURE_API_KEY when --api-key is absent', async () => {
+    process.env.CC_OCTO_CONFIGURE_API_KEY = 'sk-from-env';
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      const code = await run(['configure', '--gateway-url', 'https://gw'], dir);
+      expect(code).toBe(0);
+      const parsed = JSON.parse(readFileSync(cfgPath, 'utf-8'));
+      expect(parsed.sdk.apiKey).toBe('sk-from-env');
+      expect(parsed.sdk.anthropicBaseUrl).toBe('https://gw');
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('CLI --api-key flag takes precedence over env var', async () => {
+    process.env.CC_OCTO_CONFIGURE_API_KEY = 'sk-from-env';
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      const code = await run(['configure', '--gateway-url', 'https://gw', '--api-key', 'sk-from-cli'], dir);
+      expect(code).toBe(0);
+      const parsed = JSON.parse(readFileSync(cfgPath, 'utf-8'));
+      expect(parsed.sdk.apiKey).toBe('sk-from-cli');
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('exits 2 when both --api-key and env var are missing', async () => {
+    delete process.env.CC_OCTO_CONFIGURE_API_KEY;
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const code = await run(['configure', '--gateway-url', 'https://gw'], dir);
+      expect(code).toBe(2);
+      expect(spy).toHaveBeenCalledWith(expect.stringContaining('required'));
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+
 describe('run version command', () => {
   it.each(['version', '--version', '-v'])('prints bare version and exits 0 for %s', async (arg) => {
     const spy = vi.spyOn(console, 'log').mockImplementation(() => {});

--- a/src/__tests__/configure.test.ts
+++ b/src/__tests__/configure.test.ts
@@ -41,4 +41,25 @@ describe('configure', () => {
   it('rejects an unsafe (non-http/https) gateway url', () => {
     expect(() => configure('ftp://gw', 'sk', cfgPath)).toThrow()
   })
+  it('ensures final file mode is 0600 even when existing file has broader perms', () => {
+    // Pre-create config with mode 0644
+    writeFileSync(cfgPath, JSON.stringify({ sdk: {} }), { mode: 0o644 })
+    configure('https://gw', 'sk-secret', cfgPath)
+    const mode = statSync(cfgPath).mode & 0o777
+    expect(mode).toBe(0o600)
+    const content = JSON.parse(readFileSync(cfgPath, 'utf-8'))
+    expect(content.sdk.apiKey).toBe('sk-secret')
+  })
+  it('throws a clear error when existing config root is not a plain object', () => {
+    writeFileSync(cfgPath, JSON.stringify(null))
+    expect(() => configure('https://gw', 'sk', cfgPath)).toThrow(/is not a JSON object/)
+  })
+  it('throws a clear error when existing config root is an array', () => {
+    writeFileSync(cfgPath, JSON.stringify([1, 2, 3]))
+    expect(() => configure('https://gw', 'sk', cfgPath)).toThrow(/is not a JSON object/)
+  })
+  it('throws a clear error when existing config root is a number', () => {
+    writeFileSync(cfgPath, JSON.stringify(42))
+    expect(() => configure('https://gw', 'sk', cfgPath)).toThrow(/is not a JSON object/)
+  })
 })

--- a/src/__tests__/configure.test.ts
+++ b/src/__tests__/configure.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, statSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { configure } from '../configure.js'
+
+let dir: string
+let cfgPath: string
+beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'ccfg-')); cfgPath = join(dir, 'config.json') })
+afterEach(() => { rmSync(dir, { recursive: true, force: true }) })
+
+describe('configure', () => {
+  it('creates a fresh config with sdk gateway + apiKey', () => {
+    configure('https://gw.example.com', 'sk-test', cfgPath)
+    const parsed = JSON.parse(readFileSync(cfgPath, 'utf-8'))
+    expect(parsed.sdk.anthropicBaseUrl).toBe('https://gw.example.com')
+    expect(parsed.sdk.apiKey).toBe('sk-test')
+  })
+  it('merges into an existing config, preserving other fields', () => {
+    writeFileSync(cfgPath, JSON.stringify({ apiUrl: 'https://octo.example.com', sdk: { model: 'claude-x', anthropicBaseUrl: 'https://old' } }))
+    configure('https://new-gw', 'sk-new', cfgPath)
+    const parsed = JSON.parse(readFileSync(cfgPath, 'utf-8'))
+    expect(parsed.apiUrl).toBe('https://octo.example.com')
+    expect(parsed.sdk.model).toBe('claude-x')
+    expect(parsed.sdk.anthropicBaseUrl).toBe('https://new-gw')
+    expect(parsed.sdk.apiKey).toBe('sk-new')
+  })
+  it('writes the file mode 600', () => {
+    configure('https://gw', 'sk', cfgPath)
+    expect(statSync(cfgPath).mode & 0o777).toBe(0o600)
+  })
+  it('creates the parent dir if missing', () => {
+    const nested = join(dir, 'sub', 'config.json')
+    configure('https://gw', 'sk', nested)
+    expect(JSON.parse(readFileSync(nested, 'utf-8')).sdk.apiKey).toBe('sk')
+  })
+  it('throws on empty gatewayUrl or apiKey', () => {
+    expect(() => configure('', 'sk', cfgPath)).toThrow()
+    expect(() => configure('https://gw', '', cfgPath)).toThrow()
+  })
+  it('rejects an unsafe (non-http/https) gateway url', () => {
+    expect(() => configure('ftp://gw', 'sk', cfgPath)).toThrow()
+  })
+})

--- a/src/agent-bridge.ts
+++ b/src/agent-bridge.ts
@@ -19,6 +19,32 @@ import { trustedText, escapeSectionMarkers, CURRENT_MESSAGE_ANCHOR } from './pro
 import type { SafeText } from './prompt-safety.js';
 
 
+/**
+ * Build the SDK subprocess env overlay. The SDK's `env` option REPLACES the
+ * subprocess environment, so we spread the base env first to keep
+ * PATH/HOME/etc., then layer operator-declared vars and gateway routing.
+ * Returns undefined when there is nothing to add (subprocess just inherits).
+ * Pure (base env injected) so the injection matrix is unit-testable.
+ *
+ * Param is narrowed to the fields it reads (not the whole Config['sdk']) so
+ * tests pass plain literals — repo lint is `--max-warnings 0` with
+ * no-explicit-any, so an `as any` cast in the test would fail the build.
+ */
+export function buildSdkEnv(
+  sdk: Pick<Config['sdk'], 'apiKey' | 'anthropicBaseUrl' | 'env'>,
+  baseEnv: NodeJS.ProcessEnv,
+): NodeJS.ProcessEnv | undefined {
+  const extraEnv = sdk.env;
+  const hasExtraEnv = extraEnv !== undefined && Object.keys(extraEnv).length > 0;
+  if (!sdk.anthropicBaseUrl && !sdk.apiKey && !hasExtraEnv) return undefined;
+  return {
+    ...baseEnv,
+    ...(hasExtraEnv ? extraEnv : {}),
+    ...(sdk.anthropicBaseUrl ? { ANTHROPIC_BASE_URL: sdk.anthropicBaseUrl } : {}),
+    ...(sdk.apiKey ? { ANTHROPIC_API_KEY: sdk.apiKey } : {}),
+  };
+}
+
 const VALID_PERMISSION_MODES: Set<string> = new Set([
   'default', 'acceptEdits', 'bypassPermissions', 'plan', 'dontAsk', 'auto',
 ]);
@@ -225,25 +251,7 @@ export async function* queryAgent(
     if (sources.length > 0) linkSkillsIntoSandbox(cwd, sources);
   }
 
-  // Q1: forward scoped env to the SDK subprocess via the `env` option instead
-  // of mutating the gateway's global process.env. The SDK's `env` REPLACES the
-  // subprocess environment entirely, so spread process.env first to preserve
-  // PATH/HOME/ANTHROPIC_API_KEY. Scoping here means overrides never leak across
-  // requests. When nothing needs adding, omit `env` so the subprocess simply
-  // inherits process.env.
-  //   - sdk.env (#107): operator-declared extra vars (e.g. OCTO_BOT_ID so a
-  //     multi-bot deploy's octo-cli picks the right profile). Generic — cc does
-  //     not interpret them.
-  //   - ANTHROPIC_BASE_URL: model-gateway routing (set last so it wins).
-  const extraEnv = config.sdk.env;
-  const hasExtraEnv = extraEnv !== undefined && Object.keys(extraEnv).length > 0;
-  const env = config.sdk.anthropicBaseUrl || hasExtraEnv
-    ? {
-        ...process.env,
-        ...(hasExtraEnv ? extraEnv : {}),
-        ...(config.sdk.anthropicBaseUrl ? { ANTHROPIC_BASE_URL: config.sdk.anthropicBaseUrl } : {}),
-      }
-    : undefined;
+  const env = buildSdkEnv(config.sdk, process.env)
 
   // Build + iterate the SDK stream for a given resume id and prompt. Extracted so
   // a stale/expired `resume` (the SDK throws "No conversation found with session

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -312,7 +312,7 @@ Usage:
   cc-channel-octo restart                stop (if running) then start
   cc-channel-octo status                 show running state
   cc-channel-octo upgrade [<version>]    npm install -g the gateway (default latest) then restart
-  cc-channel-octo configure --gateway-url <url> --api-key <key>   write LLM gateway + key to config
+  cc-channel-octo configure --gateway-url <url> [--api-key <key>]   write LLM gateway + key to config (or set CC_OCTO_CONFIGURE_API_KEY)
   cc-channel-octo version                print the version
 
 Paths (under ~/.cc-channel-octo):
@@ -337,15 +337,18 @@ export async function run(argv: string[], baseDir?: string): Promise<number> {
       return cmdStatus(paths);
     case 'upgrade':
       return cmdUpgrade(paths, timeoutMs, version);
-    case 'configure':
+    case 'configure': {
+      const resolvedApiKey = apiKey ?? process.env.CC_OCTO_CONFIGURE_API_KEY ?? '';
+      const configPath = baseDir ? join(baseDir, 'config.json') : undefined;
       try {
-        configure(gatewayUrl ?? '', apiKey ?? '');
+        configure(gatewayUrl ?? '', resolvedApiKey, configPath);
         console.log('cc-channel-octo: configured gateway + api key');
         return 0;
       } catch (err) {
         console.error(`cc-channel-octo: ${(err as Error).message}`);
         return 2;
       }
+    }
     case 'version':
     case '--version':
     case '-v':

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -105,11 +105,19 @@ export function parseArgs(argv: string[]): ParsedArgs {
       const n = Number.parseInt(a.slice('--timeout='.length), 10);
       if (Number.isFinite(n) && n > 0) timeoutSec = n;
     } else if (a === '--gateway-url') {
-      gatewayUrl = rest[++i];
+      const next = rest[++i];
+      if (next === undefined || next.startsWith('--')) {
+        throw new Error('configure: --gateway-url requires a value')
+      }
+      gatewayUrl = next;
     } else if (a.startsWith('--gateway-url=')) {
       gatewayUrl = a.slice('--gateway-url='.length);
     } else if (a === '--api-key') {
-      apiKey = rest[++i];
+      const next = rest[++i];
+      if (next === undefined || next.startsWith('--')) {
+        throw new Error('configure: --api-key requires a value')
+      }
+      apiKey = next;
     } else if (a.startsWith('--api-key=')) {
       apiKey = a.slice('--api-key='.length);
     } else if (!a.startsWith('-') && version === undefined) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,6 +23,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { setTimeout as sleep } from 'node:timers/promises';
 import { DEFAULT_CONFIG_PATH } from './config.js';
+import { configure } from './configure.js';
 
 export interface SupervisorPaths {
   baseDir: string;
@@ -52,6 +53,10 @@ export interface ParsedArgs {
   timeoutMs: number;
   /** Positional version target for `upgrade` (e.g. `upgrade 1.2.3`); undefined → latest. */
   version?: string;
+  /** `configure --gateway-url <url>`. */
+  gatewayUrl?: string;
+  /** `configure --api-key <key>`. */
+  apiKey?: string;
 }
 
 /**
@@ -90,18 +95,28 @@ export function parseArgs(argv: string[]): ParsedArgs {
   let foreground = false;
   let timeoutSec = 10;
   let version: string | undefined;
-  for (const a of rest) {
+  let gatewayUrl: string | undefined;
+  let apiKey: string | undefined;
+  for (let i = 0; i < rest.length; i++) {
+    const a = rest[i];
     if (a === '--foreground' || a === '-f') {
       foreground = true;
     } else if (a.startsWith('--timeout=')) {
       const n = Number.parseInt(a.slice('--timeout='.length), 10);
       if (Number.isFinite(n) && n > 0) timeoutSec = n;
+    } else if (a === '--gateway-url') {
+      gatewayUrl = rest[++i];
+    } else if (a.startsWith('--gateway-url=')) {
+      gatewayUrl = a.slice('--gateway-url='.length);
+    } else if (a === '--api-key') {
+      apiKey = rest[++i];
+    } else if (a.startsWith('--api-key=')) {
+      apiKey = a.slice('--api-key='.length);
     } else if (!a.startsWith('-') && version === undefined) {
-      // First positional token (e.g. `upgrade 1.2.3`).
       version = a;
     }
   }
-  return { cmd, foreground, timeoutMs: timeoutSec * 1000, version };
+  return { cmd, foreground, timeoutMs: timeoutSec * 1000, version, gatewayUrl, apiKey };
 }
 
 /**
@@ -297,6 +312,7 @@ Usage:
   cc-channel-octo restart                stop (if running) then start
   cc-channel-octo status                 show running state
   cc-channel-octo upgrade [<version>]    npm install -g the gateway (default latest) then restart
+  cc-channel-octo configure --gateway-url <url> --api-key <key>   write LLM gateway + key to config
   cc-channel-octo version                print the version
 
 Paths (under ~/.cc-channel-octo):
@@ -307,7 +323,7 @@ POSIX only (macOS/Linux). On Windows, run under a service manager.`;
 }
 
 export async function run(argv: string[], baseDir?: string): Promise<number> {
-  const { cmd, foreground, timeoutMs, version } = parseArgs(argv);
+  const { cmd, foreground, timeoutMs, version, gatewayUrl, apiKey } = parseArgs(argv);
   const paths = resolveSupervisorPaths(baseDir);
   switch (cmd) {
     case 'start':
@@ -321,6 +337,15 @@ export async function run(argv: string[], baseDir?: string): Promise<number> {
       return cmdStatus(paths);
     case 'upgrade':
       return cmdUpgrade(paths, timeoutMs, version);
+    case 'configure':
+      try {
+        configure(gatewayUrl ?? '', apiKey ?? '');
+        console.log('cc-channel-octo: configured gateway + api key');
+        return 0;
+      } catch (err) {
+        console.error(`cc-channel-octo: ${(err as Error).message}`);
+        return 2;
+      }
     case 'version':
     case '--version':
     case '-v':

--- a/src/config.ts
+++ b/src/config.ts
@@ -135,6 +135,13 @@ export interface Config {
      */
     anthropicBaseUrl?: string;
     /**
+     * Q1b: Anthropic API key for the upstream gateway. When set, forwarded to
+     * the SDK subprocess via the standard `ANTHROPIC_API_KEY` env var (same
+     * mechanism as `anthropicBaseUrl`). Written by the `configure` subcommand
+     * during daemon-driven one-click install; persisted in the global config.
+     */
+    apiKey?: string;
+    /**
      * #107: extra environment variables injected verbatim into the agent's SDK
      * subprocess (on top of the inherited process.env). Generic and declarative
      * — cc knows nothing about what they mean. Use it to give a bot's skills the

--- a/src/configure.ts
+++ b/src/configure.ts
@@ -8,7 +8,7 @@
  * before any bot exists. So this does a raw read-merge-write of the JSON file,
  * touching only sdk.anthropicBaseUrl + sdk.apiKey.
  */
-import { readFileSync, writeFileSync, existsSync, mkdirSync, chmodSync } from 'node:fs'
+import { readFileSync, writeFileSync, existsSync, mkdirSync, chmodSync, renameSync, unlinkSync } from 'node:fs'
 import { dirname } from 'node:path'
 import { DEFAULT_CONFIG_PATH } from './config.js'
 import { isAllowedApiUrl } from './url-policy.js'
@@ -25,8 +25,17 @@ export function configure(gatewayUrl: string, apiKey: string, configPath?: strin
   let existing: Record<string, unknown> = {}
   if (existsSync(path)) {
     try {
-      existing = JSON.parse(readFileSync(path, 'utf-8')) as Record<string, unknown>
+      const parsed = JSON.parse(readFileSync(path, 'utf-8')) as unknown
+      // Validate that the root is a plain object before treating it as one.
+      if (!(parsed && typeof parsed === 'object' && !Array.isArray(parsed))) {
+        throw new Error(`configure: existing config at ${path} is not a JSON object`)
+      }
+      existing = parsed as Record<string, unknown>
     } catch (err) {
+      // Re-throw the clear "not a JSON object" error as-is; wrap parse errors.
+      if (err instanceof Error && err.message.includes('is not a JSON object')) {
+        throw err
+      }
       throw new Error(`configure: failed to parse ${path}: ${err instanceof Error ? err.message : String(err)}`)
     }
   }
@@ -41,7 +50,21 @@ export function configure(gatewayUrl: string, apiKey: string, configPath?: strin
     sdk: { ...existingSdk, anthropicBaseUrl: gatewayUrl, apiKey },
   }
   mkdirSync(dirname(path), { recursive: true })
-  writeFileSync(path, JSON.stringify(merged, null, 2) + '\n', { mode: 0o600 })
-  // writeFileSync mode only applies on create; force 600 on an existing file too.
-  chmodSync(path, 0o600)
+
+  // Atomic write: temp file in same directory with 0600 mode, then rename.
+  const tmpPath = `${path}.tmp-${process.pid}-${Date.now()}`
+  try {
+    writeFileSync(tmpPath, JSON.stringify(merged, null, 2) + '\n', { mode: 0o600 })
+    renameSync(tmpPath, path)
+    // Belt-and-suspenders: force 0600 on the final file too.
+    chmodSync(path, 0o600)
+  } catch (err) {
+    // Best-effort cleanup of the temp file on error.
+    try {
+      unlinkSync(tmpPath)
+    } catch {
+      /* already gone or never created — fine */
+    }
+    throw new Error(`configure: failed to write ${path}: ${err instanceof Error ? err.message : String(err)}`)
+  }
 }

--- a/src/configure.ts
+++ b/src/configure.ts
@@ -1,0 +1,47 @@
+/**
+ * `configure` subcommand backend: write the LLM gateway URL + API key into the
+ * global config's `sdk` block. Daemon-driven one-click install calls
+ * `cc-channel-octo configure --gateway-url <url> --api-key <key>`.
+ *
+ * Independent of loadConfig(): loadConfig requires apiUrl (bot binding comes
+ * later via the provision flow), but install must be able to write gateway+key
+ * before any bot exists. So this does a raw read-merge-write of the JSON file,
+ * touching only sdk.anthropicBaseUrl + sdk.apiKey.
+ */
+import { readFileSync, writeFileSync, existsSync, mkdirSync, chmodSync } from 'node:fs'
+import { dirname } from 'node:path'
+import { DEFAULT_CONFIG_PATH } from './config.js'
+import { isAllowedApiUrl } from './url-policy.js'
+
+export function configure(gatewayUrl: string, apiKey: string, configPath?: string): void {
+  if (!gatewayUrl) throw new Error('configure: --gateway-url is required')
+  if (!apiKey) throw new Error('configure: --api-key is required')
+  // The gateway receives the API key + all prompt/response content, so it gets
+  // the same SSRF policy as apiUrl (mirrors loadConfig's anthropicBaseUrl check).
+  if (!isAllowedApiUrl(gatewayUrl)) {
+    throw new Error(`configure: unsafe --gateway-url ${gatewayUrl} (must be https:// or http://localhost)`)
+  }
+  const path = configPath ?? DEFAULT_CONFIG_PATH
+  let existing: Record<string, unknown> = {}
+  if (existsSync(path)) {
+    try {
+      existing = JSON.parse(readFileSync(path, 'utf-8')) as Record<string, unknown>
+    } catch (err) {
+      throw new Error(`configure: failed to parse ${path}: ${err instanceof Error ? err.message : String(err)}`)
+    }
+  }
+  // Narrow the existing sdk block to a plain object before merging (the file is
+  // untyped JSON; repo lint forbids `any`, so read it as unknown + narrow).
+  const existingSdk =
+    existing.sdk && typeof existing.sdk === 'object' && !Array.isArray(existing.sdk)
+      ? (existing.sdk as Record<string, unknown>)
+      : {}
+  const merged = {
+    ...existing,
+    sdk: { ...existingSdk, anthropicBaseUrl: gatewayUrl, apiKey },
+  }
+  mkdirSync(dirname(path), { recursive: true })
+  writeFileSync(path, JSON.stringify(merged, null, 2) + '\n', { mode: 0o600 })
+  // writeFileSync mode only applies on create; force 600 on an existing file too.
+  chmodSync(path, 0o600)
+}


### PR DESCRIPTION
## Summary

Adds a `configure` subcommand and an `sdk.apiKey` config field so the gateway's LLM credentials can be set programmatically (for daemon-driven one-click install) instead of relying on an `ANTHROPIC_API_KEY` environment prerequisite.

## Changes

- `configure --gateway-url <url> [--api-key <key>]` subcommand: raw read-merge-write of the global `~/.cc-channel-octo/config.json`, setting `sdk.anthropicBaseUrl` + `sdk.apiKey`, then `chmod 600`. Independent of `loadConfig` (which requires `apiUrl`) so it can run before any bot/apiUrl exists. Reuses `isAllowedApiUrl` (SSRF policy) for the gateway URL.
- `sdk.apiKey` config field, forwarded to the SDK subprocess as `ANTHROPIC_API_KEY` via an extracted pure `buildSdkEnv` (mirrors the existing `ANTHROPIC_BASE_URL` forwarding).
- `configure` reads the key from the `CC_OCTO_CONFIGURE_API_KEY` env var when `--api-key` is omitted, so a caller need not pass the key in argv (keeps it out of `ps`).

## Testing

- `npm run build && npm test && npm run type-check && npm run lint` — all green (1035 tests).
- `configure` exercised end-to-end against a temp HOME: fresh write, merge-preserve, mode 600, missing-arg exit 2, unsafe-URL reject.

Backward compatible: new subcommand + new optional config field + new optional env var; existing behavior unchanged.
