### PR TITLE
feat(cc-octo): zero-bot idle startup and configurable gateway url/model

### DIFF
--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -38,6 +38,21 @@ describe('parseArgs', () => {
     expect(parseArgs(['stop', '--timeout=0']).timeoutMs).toBe(10_000);
     expect(parseArgs(['stop', '--timeout=abc']).timeoutMs).toBe(10_000);
   });
+
+  it('parses --model (space and = forms)', () => {
+    expect(parseArgs(['configure', '--model', 'm1']).model).toBe('m1');
+    expect(parseArgs(['configure', '--model=m2']).model).toBe('m2');
+  });
+
+  it('parses --api-url (space and = forms)', () => {
+    expect(parseArgs(['configure', '--api-url', 'http://127.0.0.1:8090']).apiUrl).toBe('http://127.0.0.1:8090');
+    expect(parseArgs(['configure', '--api-url=https://octo.test']).apiUrl).toBe('https://octo.test');
+  });
+
+  it('throws when --model or --api-url is missing a value', () => {
+    expect(() => parseArgs(['configure', '--model'])).toThrow(/--model requires a value/);
+    expect(() => parseArgs(['configure', '--api-url', '--api-key=k'])).toThrow(/--api-url requires a value/);
+  });
 });
 
 describe('isAlive', () => {

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -141,8 +141,11 @@ describe('required field validation', () => {
     expect(() => loadConfig(path)).toThrow(/apiUrl/);
   });
 
-  it('resolveBotConfigs throws when a bot has no token (single-bot)', () => {
-    const path = writeConfig({ apiUrl: 'https://api.test' });
+  it('resolveBotConfigs throws when a listed bot has no token', () => {
+    // A bots[] entry whose token is absent (no inline token, no per-bot file)
+    // still fails fast. Only the truly empty case (no bots[], no global token,
+    // no default per-bot token) idles — see the "zero-bot idle" suite.
+    const path = writeConfig({ apiUrl: 'https://api.test', bots: [{ id: 'a' }] });
     expect(() => resolveBotConfigs(loadConfig(path))).toThrow(/missing botToken/);
   });
 
@@ -695,5 +698,34 @@ describe('v1.1: SOUL.md personality (openclaw-style)', () => {
     });
     const bots = resolveBotConfigs(loadConfig(cfgPath));
     expect(bots[0].sdk.systemPrompt).toBe('file soul wins');
+  });
+});
+
+describe('resolveBotConfigs zero-bot idle', () => {
+  beforeEach(setup);
+  afterEach(teardown);
+
+  it('returns [] when no bots[], no global botToken, no default per-bot token', () => {
+    // A freshly-installed gateway has only gateway/apiUrl, no bot yet.
+    const cfg = loadConfig(writeConfig({ apiUrl: 'https://api.test' }));
+    expect(resolveBotConfigs(cfg)).toEqual([]);
+  });
+
+  it('still returns one default bot when a global botToken is set', () => {
+    const cfg = loadConfig(writeConfig({ apiUrl: 'https://api.test', botToken: 'bf_legacy' }));
+    const bots = resolveBotConfigs(cfg);
+    expect(bots).toHaveLength(1);
+    expect(bots[0].botId).toBe('default');
+    expect(bots[0].botToken).toBe('bf_legacy');
+  });
+
+  it('still starts the default bot when only <baseDir>/default/config.json has a token', () => {
+    // No global botToken and no bots[], but a legacy single bot keeps its token
+    // in the default per-bot file — must NOT idle, must start that bot.
+    writeBotConfig('default', { botToken: 'bf_perbot' });
+    const cfg = loadConfig(writeConfig({ apiUrl: 'https://api.test' }));
+    const bots = resolveBotConfigs(cfg);
+    expect(bots).toHaveLength(1);
+    expect(bots[0].botToken).toBe('bf_perbot');
   });
 });

--- a/src/__tests__/configure.test.ts
+++ b/src/__tests__/configure.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { mkdtempSync, rmSync, readFileSync, writeFileSync, statSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { configure } from '../configure.js'
+import { configure, normalizeGatewayUrl } from '../configure.js'
 
 let dir: string
 let cfgPath: string
@@ -61,5 +61,23 @@ describe('configure', () => {
   it('throws a clear error when existing config root is a number', () => {
     writeFileSync(cfgPath, JSON.stringify(42))
     expect(() => configure('https://gw', 'sk', cfgPath)).toThrow(/is not a JSON object/)
+  })
+  it('strips a trailing /v1 from the stored gateway url', () => {
+    configure('https://gw.test/v1', 'sk-test', cfgPath)
+    expect(JSON.parse(readFileSync(cfgPath, 'utf-8')).sdk.anthropicBaseUrl).toBe('https://gw.test')
+  })
+})
+
+describe('normalizeGatewayUrl', () => {
+  it('strips a trailing /v1 or /v1/', () => {
+    expect(normalizeGatewayUrl('https://gw.test/v1')).toBe('https://gw.test')
+    expect(normalizeGatewayUrl('https://gw.test/v1/')).toBe('https://gw.test')
+  })
+  it('leaves a bare host or non-version path intact', () => {
+    expect(normalizeGatewayUrl('https://gw.test')).toBe('https://gw.test')
+    expect(normalizeGatewayUrl('https://gw.test/api')).toBe('https://gw.test/api')
+  })
+  it('does not strip a mid-path v1', () => {
+    expect(normalizeGatewayUrl('https://gw.test/v1/foo')).toBe('https://gw.test/v1/foo')
   })
 })

--- a/src/__tests__/configure.test.ts
+++ b/src/__tests__/configure.test.ts
@@ -66,6 +66,22 @@ describe('configure', () => {
     configure('https://gw.test/v1', 'sk-test', cfgPath)
     expect(JSON.parse(readFileSync(cfgPath, 'utf-8')).sdk.anthropicBaseUrl).toBe('https://gw.test')
   })
+  it('writes sdk.model when a model is provided', () => {
+    configure('https://gw.test', 'sk', cfgPath, { model: 'vertexai/claude-opus-4-8' })
+    expect(JSON.parse(readFileSync(cfgPath, 'utf-8')).sdk.model).toBe('vertexai/claude-opus-4-8')
+  })
+  it('PRESERVES an existing sdk.model when no model is provided', () => {
+    writeFileSync(cfgPath, JSON.stringify({ sdk: { model: 'old/model' } }))
+    configure('https://gw.test', 'sk', cfgPath) // no model → keep existing
+    expect(JSON.parse(readFileSync(cfgPath, 'utf-8')).sdk.model).toBe('old/model')
+  })
+  it('writes the top-level apiUrl when provided', () => {
+    configure('https://gw.test', 'sk', cfgPath, { apiUrl: 'http://127.0.0.1:8090' })
+    expect(JSON.parse(readFileSync(cfgPath, 'utf-8')).apiUrl).toBe('http://127.0.0.1:8090')
+  })
+  it('rejects an unsafe --api-url', () => {
+    expect(() => configure('https://gw.test', 'sk', cfgPath, { apiUrl: 'ftp://evil' })).toThrow()
+  })
 })
 
 describe('normalizeGatewayUrl', () => {

--- a/src/__tests__/configure.test.ts
+++ b/src/__tests__/configure.test.ts
@@ -96,4 +96,8 @@ describe('normalizeGatewayUrl', () => {
   it('does not strip a mid-path v1', () => {
     expect(normalizeGatewayUrl('https://gw.test/v1/foo')).toBe('https://gw.test/v1/foo')
   })
+  it('strips a trailing /v1 case-insensitively and trims surrounding whitespace', () => {
+    expect(normalizeGatewayUrl('https://gw.test/V1')).toBe('https://gw.test')
+    expect(normalizeGatewayUrl('  https://gw.test/v1/  ')).toBe('https://gw.test')
+  })
 })

--- a/src/__tests__/index-idle.test.ts
+++ b/src/__tests__/index-idle.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { shouldRunIdle } from '../index.js';
+
+describe('shouldRunIdle', () => {
+  it('is true for an empty bot list (zero-bot idle)', () => {
+    expect(shouldRunIdle([])).toBe(true);
+  });
+
+  it('is false when at least one bot is configured', () => {
+    expect(shouldRunIdle([{ botId: 'default' }])).toBe(false);
+    expect(shouldRunIdle([{ botId: 'a' }, { botId: 'b' }])).toBe(false);
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -57,6 +57,10 @@ export interface ParsedArgs {
   gatewayUrl?: string;
   /** `configure --api-key <key>`. */
   apiKey?: string;
+  /** `configure --model <model>` — optional global sdk.model. */
+  model?: string;
+  /** `configure --api-url <url>` — Octo IM server url (cc top-level apiUrl). */
+  apiUrl?: string;
 }
 
 /**
@@ -97,6 +101,8 @@ export function parseArgs(argv: string[]): ParsedArgs {
   let version: string | undefined;
   let gatewayUrl: string | undefined;
   let apiKey: string | undefined;
+  let model: string | undefined;
+  let apiUrl: string | undefined;
   for (let i = 0; i < rest.length; i++) {
     const a = rest[i];
     if (a === '--foreground' || a === '-f') {
@@ -120,11 +126,27 @@ export function parseArgs(argv: string[]): ParsedArgs {
       apiKey = next;
     } else if (a.startsWith('--api-key=')) {
       apiKey = a.slice('--api-key='.length);
+    } else if (a === '--model') {
+      const next = rest[++i];
+      if (next === undefined || next.startsWith('--')) {
+        throw new Error('configure: --model requires a value')
+      }
+      model = next;
+    } else if (a.startsWith('--model=')) {
+      model = a.slice('--model='.length);
+    } else if (a === '--api-url') {
+      const next = rest[++i];
+      if (next === undefined || next.startsWith('--')) {
+        throw new Error('configure: --api-url requires a value')
+      }
+      apiUrl = next;
+    } else if (a.startsWith('--api-url=')) {
+      apiUrl = a.slice('--api-url='.length);
     } else if (!a.startsWith('-') && version === undefined) {
       version = a;
     }
   }
-  return { cmd, foreground, timeoutMs: timeoutSec * 1000, version, gatewayUrl, apiKey };
+  return { cmd, foreground, timeoutMs: timeoutSec * 1000, version, gatewayUrl, apiKey, model, apiUrl };
 }
 
 /**
@@ -398,7 +420,7 @@ Usage:
   cc-channel-octo restart                stop (if running) then start
   cc-channel-octo status                 show running state
   cc-channel-octo upgrade [<version>]    npm install -g the gateway (default latest) then restart
-  cc-channel-octo configure --gateway-url <url> [--api-key <key>]   write LLM gateway + key to config (or set CC_OCTO_CONFIGURE_API_KEY)
+  cc-channel-octo configure --gateway-url <url> [--api-key <key>] [--model <model>] [--api-url <octo-server-url>]   write LLM gateway + key (+ optional model / Octo server url) to config (key also via CC_OCTO_CONFIGURE_API_KEY)
   cc-channel-octo version                print the version
 
 Paths (under ~/.cc-channel-octo):
@@ -418,7 +440,7 @@ export async function run(argv: string[], baseDir?: string, procId: ProcIdentity
     console.error(`cc-channel-octo: ${(err as Error).message}`);
     return 2;
   }
-  const { cmd, foreground, timeoutMs, version, gatewayUrl, apiKey } = parsed;
+  const { cmd, foreground, timeoutMs, version, gatewayUrl, apiKey, model, apiUrl } = parsed;
   const paths = resolveSupervisorPaths(baseDir);
   switch (cmd) {
     case 'start':
@@ -436,7 +458,7 @@ export async function run(argv: string[], baseDir?: string, procId: ProcIdentity
       const resolvedApiKey = apiKey ?? process.env.CC_OCTO_CONFIGURE_API_KEY ?? '';
       const configPath = baseDir ? join(baseDir, 'config.json') : undefined;
       try {
-        configure(gatewayUrl ?? '', resolvedApiKey, configPath);
+        configure(gatewayUrl ?? '', resolvedApiKey, configPath, { model, apiUrl });
         console.log('cc-channel-octo: configured gateway + api key');
         return 0;
       } catch (err) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -495,6 +495,18 @@ function isPathInside(child: string, parent: string): boolean {
  * apiUrl (fail fast at boot).
  */
 export function resolveBotConfigs(config: Config): Config[] {
+  // Zero-bot idle: no bots[] list and no global botToken — and no token in the
+  // default per-bot file either. Return [] so the gateway can run idle (online,
+  // no bots) until the first bot is provisioned, instead of throwing. A legacy
+  // single bot may keep its token only in <baseDir>/default/config.json (read by
+  // the synthesized "default" entry below), so check that before idling.
+  const hasInlineBots = !!(config.bots && config.bots.length > 0);
+  if (!hasInlineBots && !config.botToken) {
+    const defaultPerBot = readConfigFile(pathJoin(config.baseDir, 'default', 'config.json'));
+    if (!defaultPerBot.botToken) {
+      return [];
+    }
+  }
   // Single-bot: synthesize one entry with id "default".
   const entries: BotOverride[] =
     config.bots && config.bots.length > 0

--- a/src/configure.ts
+++ b/src/configure.ts
@@ -23,13 +23,24 @@ export function normalizeGatewayUrl(raw: string): string {
   return raw.replace(/\/v1\/?$/, '')
 }
 
-export function configure(gatewayUrl: string, apiKey: string, configPath?: string): void {
+export function configure(
+  gatewayUrl: string,
+  apiKey: string,
+  configPath?: string,
+  opts?: { model?: string; apiUrl?: string },
+): void {
   if (!gatewayUrl) throw new Error('configure: --gateway-url is required')
   if (!apiKey) throw new Error('configure: --api-key is required')
   // The gateway receives the API key + all prompt/response content, so it gets
   // the same SSRF policy as apiUrl (mirrors loadConfig's anthropicBaseUrl check).
   if (!isAllowedApiUrl(gatewayUrl)) {
     throw new Error(`configure: unsafe --gateway-url ${gatewayUrl} (must be https:// or http://localhost)`)
+  }
+  // apiUrl is the Octo IM server (cc's top-level config.apiUrl). The daemon
+  // passes its server url at install time so the zero-bot idle gateway can boot
+  // (loadConfig requires apiUrl). Same SSRF policy as the gateway url.
+  if (opts?.apiUrl && !isAllowedApiUrl(opts.apiUrl)) {
+    throw new Error(`configure: unsafe --api-url ${opts.apiUrl} (must be https:// or http://localhost)`)
   }
   const normalizedUrl = normalizeGatewayUrl(gatewayUrl)
   const path = configPath ?? DEFAULT_CONFIG_PATH
@@ -56,9 +67,20 @@ export function configure(gatewayUrl: string, apiKey: string, configPath?: strin
     existing.sdk && typeof existing.sdk === 'object' && !Array.isArray(existing.sdk)
       ? (existing.sdk as Record<string, unknown>)
       : {}
-  const merged = {
+  const merged: Record<string, unknown> = {
     ...existing,
     sdk: { ...existingSdk, anthropicBaseUrl: normalizedUrl, apiKey },
+  }
+  // Write model only when provided; omitting it PRESERVES any existing sdk.model
+  // (the existingSdk spread above) so a re-configure that just rotates the key
+  // never wipes the model. Resetting model→default is intentionally not a
+  // configure feature (add an explicit --clear-model later if ever needed).
+  if (opts?.model) {
+    (merged.sdk as Record<string, unknown>).model = opts.model
+  }
+  // The Octo IM server url lives at the top level (not under sdk).
+  if (opts?.apiUrl) {
+    merged.apiUrl = opts.apiUrl
   }
   mkdirSync(dirname(path), { recursive: true })
 

--- a/src/configure.ts
+++ b/src/configure.ts
@@ -20,7 +20,7 @@ import { isAllowedApiUrl } from './url-policy.js'
  * slash) so the stored base is the host root. Pure for unit testing.
  */
 export function normalizeGatewayUrl(raw: string): string {
-  return raw.replace(/\/v1\/?$/, '')
+  return raw.trim().replace(/\/v1\/?$/i, '')
 }
 
 export function configure(

--- a/src/configure.ts
+++ b/src/configure.ts
@@ -13,6 +13,16 @@ import { dirname } from 'node:path'
 import { DEFAULT_CONFIG_PATH } from './config.js'
 import { isAllowedApiUrl } from './url-policy.js'
 
+/**
+ * The Anthropic SDK appends `/v1/messages` to ANTHROPIC_BASE_URL. A gateway
+ * pasted with a trailing `/v1` would otherwise yield `/v1/v1/messages` (404,
+ * misreported as a model error). Strip a trailing `/v1` (optionally with a
+ * slash) so the stored base is the host root. Pure for unit testing.
+ */
+export function normalizeGatewayUrl(raw: string): string {
+  return raw.replace(/\/v1\/?$/, '')
+}
+
 export function configure(gatewayUrl: string, apiKey: string, configPath?: string): void {
   if (!gatewayUrl) throw new Error('configure: --gateway-url is required')
   if (!apiKey) throw new Error('configure: --api-key is required')
@@ -21,6 +31,7 @@ export function configure(gatewayUrl: string, apiKey: string, configPath?: strin
   if (!isAllowedApiUrl(gatewayUrl)) {
     throw new Error(`configure: unsafe --gateway-url ${gatewayUrl} (must be https:// or http://localhost)`)
   }
+  const normalizedUrl = normalizeGatewayUrl(gatewayUrl)
   const path = configPath ?? DEFAULT_CONFIG_PATH
   let existing: Record<string, unknown> = {}
   if (existsSync(path)) {
@@ -47,7 +58,7 @@ export function configure(gatewayUrl: string, apiKey: string, configPath?: strin
       : {}
   const merged = {
     ...existing,
-    sdk: { ...existingSdk, anthropicBaseUrl: gatewayUrl, apiKey },
+    sdk: { ...existingSdk, anthropicBaseUrl: normalizedUrl, apiKey },
   }
   mkdirSync(dirname(path), { recursive: true })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,15 @@ import { join } from 'node:path';
 import { mkdirSync, realpathSync } from 'node:fs';
 import { pathToFileURL, fileURLToPath } from 'node:url';
 
+/**
+ * True when there are no bots to run — the gateway should idle (stay alive and
+ * online, with no sockets) until the first bot is provisioned. Pure for unit
+ * testing. See the idle branch in main().
+ */
+export function shouldRunIdle(botConfigs: { botId?: string }[]): boolean {
+  return botConfigs.length === 0;
+}
+
 async function main(): Promise<void> {
   // --- Q8: Global unhandled rejection handler ---
   process.on('unhandledRejection', (reason) => {
@@ -45,6 +54,26 @@ async function main(): Promise<void> {
   // v0.3 multi-bot: expand into one concrete Config per bot. Single-bot configs
   // resolve to a 1-element array, so the loop below is the same code path.
   const botConfigs = resolveBotConfigs(config);
+  if (shouldRunIdle(botConfigs)) {
+    console.log('[cc-channel-octo] idle (no bots configured) — awaiting provision');
+    // A pending Promise alone does NOT keep Node's event loop alive — the
+    // process would exit immediately and the supervisor would report "stopped"
+    // (claude runtime offline). Hold an explicit ref'd timer as keepalive and
+    // clear it on signal so shutdown stays clean. The first provision runs
+    // `cc-channel-octo restart`, respawning this process with a non-empty bots
+    // list, so the gateway transitions from idle to serving without manual steps.
+    await new Promise<void>((resolve) => {
+      const keepalive = setInterval(() => {}, 60_000); // ref'd (not unref'd) → keeps loop alive
+      const bye = (sig: string): void => {
+        console.log(`[cc-channel-octo] Received ${sig}, idle shutdown`);
+        clearInterval(keepalive);
+        resolve();
+      };
+      process.once('SIGINT', () => bye('SIGINT'));
+      process.once('SIGTERM', () => bye('SIGTERM'));
+    });
+    return;
+  }
   const multi = botConfigs.length > 1;
   if (multi) {
     console.log(`[cc-channel-octo] Multi-bot mode: starting ${botConfigs.length} bots`);


### PR DESCRIPTION
## Summary

Lets a freshly-installed cc-channel-octo gateway come online with zero bots and accept a gateway URL + model from the one-click installer, removing two blockers in the cc adapter install flow: the first-bot chicken-and-egg deadlock and the `/v1/v1/messages` URL doubling.

## Related Issue

Part of Mininglamp-OSS/octo-daemon-cli#65

## Changes

- Zero-bot idle: `resolveBotConfigs` returns `[]` when there is no inline bot, no global token, and no token in the default per-bot file; `main()` then runs an idle keepalive (ref'd timer, clean SIGINT/SIGTERM shutdown) so the runtime stays online until the first bot is provisioned.
- `configure` accepts `--gateway-url`, `--model` (preserved when omitted), and `--api-url`; the API key is read from an env var, never argv.
- Strip a trailing `/v1` from the gateway URL (case-insensitive, trims whitespace) so the SDK's appended `/v1/messages` does not double.

## Testing

- `npm run build && npm test` — 56 files, 1069 tests passing (pre-push hook also runs lint + type-check clean).

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] PR description is in English
- [x] Added tests for my changes
- [x] All tests pass
- [x] Followed commit message conventions (Conventional Commits)
