### PR TITLE
chore(release): v1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ While the major version is `0`, minor releases may carry breaking changes.
 
 ## [Unreleased]
 
+## [1.0.2] - 2026-06-24
+
 ### Added
 
 - **Process-supervisor CLI** — `cc-channel-octo start|stop|restart|status`
@@ -19,6 +21,26 @@ While the major version is `0`, minor releases may carry breaking changes.
 - **`version` / `--version` / `-v`** — prints the package version (read at
   runtime from `package.json`), and the `--help` banner now carries the version
   on its first line.
+- **`configure` subcommand** — `cc-channel-octo configure --gateway-url <url>
+  [--model <id>] [--api-url <url>]` writes the LLM gateway URL, optional model
+  id, and the Octo IM server URL (`apiUrl`) into the global config without
+  hand-editing JSON. The API key is read from the `CC_OCTO_CONFIGURE_API_KEY`
+  environment variable so it never appears in the process argument list. This is
+  what an automated installer invokes after a fresh global install to make the
+  gateway bootable.
+- **`upgrade` subcommand** — `cc-channel-octo upgrade <version>` performs an
+  in-place global npm reinstall to the target version and restarts the gateway,
+  so an installed gateway can self-update without an external script.
+- **Zero-bot idle startup** — the gateway now boots and stays up with no bound
+  bot (previously it required at least one bot to start). A bot bound later via
+  provisioning is picked up on the next restart, so a freshly installed gateway
+  can come online immediately and wait for its first bot.
+
+### Changed
+
+- **Configurable gateway URL and model** — the LLM gateway endpoint and model id
+  are now read from config (settable via `configure`) instead of being fixed, so
+  one build can target different gateways/models per deployment.
 
 ## [1.0.1] - 2026-06-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@ All notable changes to this project are documented here.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-While the major version is `0`, minor releases may carry breaking changes.
 
 ## [Unreleased]
 
@@ -41,6 +40,16 @@ While the major version is `0`, minor releases may carry breaking changes.
 - **Configurable gateway URL and model** — the LLM gateway endpoint and model id
   are now read from config (settable via `configure`) instead of being fixed, so
   one build can target different gateways/models per deployment.
+
+### Fixed
+
+- **Per-message dispatch timeout** — a hung session no longer blocks the bot
+  indefinitely; each message dispatch is now bounded by a timeout so a stuck turn
+  is released instead of wedging the session (#142).
+- **Outbound `@uid` mention validation** — mentions emitted by the agent are now
+  validated against the live group's member set, so invalid/hallucinated `@uid`s
+  are dropped instead of being sent (#144, reworked in #145 to use the
+  authoritative member set).
 
 ## [1.0.1] - 2026-06-10
 
@@ -377,6 +386,7 @@ hardening across the SSRF, prompt-injection, and protocol-DoS surfaces.
 Initial tagged baseline: text messaging, streaming output, SQLite session
 persistence, rate limiting, and the core security model.
 
+[1.0.2]: https://github.com/Mininglamp-OSS/cc-channel-octo/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/Mininglamp-OSS/cc-channel-octo/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/Mininglamp-OSS/cc-channel-octo/compare/v0.2.0...v1.0.0
 [0.2.0]: https://github.com/Mininglamp-OSS/cc-channel-octo/compare/v0.1.0...v0.2.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mininglamp-oss/cc-channel-octo",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mininglamp-oss/cc-channel-octo",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "better-sqlite3": "^12.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mininglamp-oss/cc-channel-octo",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Bridge Claude Code (via Claude Agent SDK) to Octo IM — independent Node.js gateway",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
## What & why

Cut the `1.0.2` release so the npm `latest` tag carries the agent-runtime tooling merged since `v1.0.1` — most importantly the `configure` subcommand. The current published `1.0.1` predates #152/#155, so a fresh global install has no `configure` and the gateway cannot be made bootable (`Missing required config: apiUrl`). This release makes `npm install -g @mininglamp-oss/cc-channel-octo@latest` produce a configurable, zero-bot-bootable gateway.

## Files modified

- `package.json` — version `1.0.1` → `1.0.2`
- `package-lock.json` — own package version bump (deps untouched)
- `CHANGELOG.md` — `[Unreleased]` cut to `[1.0.2]`; documents configure / upgrade / zero-bot idle / configurable gateway URL+model (from #152, #155) alongside the supervisor CLI and `version` command

## Test results

- `npm run type-check` — clean
- `npm run lint` — clean (max-warnings 0)
- `npm test` — 1069 passed (56 files)

## Release steps after merge

Tag `v1.0.2` on the merge commit and push the tag; `npm-publish.yml` publishes to npm on the tag push (tag must equal package.json version, commit must be an ancestor of main).

No breaking changes.