### PR TITLE
fix(agent-bridge): extend isResumeError to catch Bedrock ValidationException for orphan tool_use blocks

### DIFF
--- a/src/__tests__/agent-bridge-query.test.ts
+++ b/src/__tests__/agent-bridge-query.test.ts
@@ -639,7 +639,72 @@ describe('queryAgent', () => {
     expect(mockQuery).toHaveBeenCalledTimes(1); // no retry after a tool_use side effect
     expect(resumeFailed).toBe(true); // but the stale id was cleared
   });
+
+  // --- Issue #154: Bedrock ValidationException for orphaned tool_use blocks ---
+
+  it('recovers from Bedrock ValidationException: orphaned tool_use blocks (no prior output)', async () => {
+    // When an agent turn is interrupted mid-execution, the SDK session is left with
+    // tool_use blocks that have no corresponding tool_result. On the next turn,
+    // Bedrock rejects with ValidationException. isResumeError() must match this
+    // so onResumeFailed() is called to clear the corrupt sdk_session_id and retry.
+    const throwing = createMockStream([]);
+    throwing[Symbol.asyncIterator] = async function* () {
+      throw new Error(
+        'ValidationException: messages.805: `tool_use` ids were found without `tool_result` blocks\n' +
+        'immediately after: toolu_757190a2ce1b41e48ebf8ebd, toolu_c6e1a12e9f234cf493debbb5.\n' +
+        'Each `tool_use` block must have a corresponding `tool_result` block.',
+      );
+    };
+    const ok = createMockStream([
+      { type: 'assistant', session_id: 'fresh-sid', message: { content: [{ type: 'text', text: 'recovered' }] } },
+    ]);
+    mockQuery.mockReturnValueOnce(throwing).mockReturnValueOnce(ok);
+
+    let resumeFailed = false;
+    const chunks: string[] = [];
+    const retryPrompt =
+      '[Prior conversation history]\nprev turn\n---\n\n[Current message — respond to this ONLY]\nhello';
+    for await (const chunk of queryAgent('hello', makeConfig(), undefined, undefined, {
+      resume: 'corrupt-sid',
+      onSessionId: () => {},
+      onResumeFailed: () => { resumeFailed = true; },
+      fallbackRetryPrompt: retryPrompt,
+    })) {
+      chunks.push(chunk);
+    }
+
+    expect(resumeFailed).toBe(true);                                  // corrupt session cleared
+    expect(chunks).toEqual(['recovered']);                             // user sees a normal reply
+    expect(mockQuery).toHaveBeenCalledTimes(2);                       // one retry
+    expect(mockQuery.mock.calls[1][0].options).not.toHaveProperty('resume'); // retry without resume
+    expect(mockQuery.mock.calls[1][0].prompt).toBe(retryPrompt);     // uses caller's retry prompt
+  });
+
+  it('does NOT recover from ValidationException after tool_use output (no double side-effect) but DOES clear the corrupt id', async () => {
+    // If the corrupt session emitted a tool_use block before throwing, the turn
+    // must not retry (would re-run the tool), but the corrupt sdk_session_id must
+    // still be cleared so the NEXT turn can start fresh.
+    const partial = createMockStream([]);
+    partial[Symbol.asyncIterator] = async function* () {
+      yield { type: 'assistant', session_id: 's', message: { content: [{ type: 'tool_use', name: 'Bash', input: {} }] } };
+      throw new Error(
+        'ValidationException: messages.805: `tool_use` ids were found without `tool_result` blocks\n' +
+        'immediately after: toolu_aabb.\nEach `tool_use` block must have a corresponding `tool_result` block.',
+      );
+    };
+    mockQuery.mockReturnValue(partial);
+    let resumeFailed = false;
+    await expect(async () => {
+      for await (const _ of queryAgent('hi', makeConfig(), undefined, undefined, {
+        resume: 'corrupt-sid', onResumeFailed: () => { resumeFailed = true; },
+      })) { void _; }
+    }).rejects.toThrow('ValidationException');
+    expect(mockQuery).toHaveBeenCalledTimes(1); // no retry after side-effect output
+    expect(resumeFailed).toBe(true);             // but corrupt id cleared for next turn
+  });
 });
+
+
 
 describe('queryAgent — sdk.env injection (#107)', () => {
   beforeEach(() => vi.clearAllMocks());

--- a/src/agent-bridge.ts
+++ b/src/agent-bridge.ts
@@ -308,9 +308,14 @@ export async function* queryAgent(
 
   // Detect the SDK's stale/invalid-resume signal (verified via spike): it throws
   // an Error whose message names the missing/invalid session id.
+  // Also catches Bedrock ValidationException for orphaned tool_use blocks left
+  // by an interrupted turn (no corresponding tool_result), which surfaces as:
+  //   ValidationException: messages.N: `tool_use` ids were found without `tool_result` blocks
+  // Matching this here causes onResumeFailed() to clear the corrupt sdk_session_id
+  // and the turn to retry with fallbackRetryPrompt — same recovery path as stale sessions.
   const isResumeError = (err: unknown): boolean => {
     const m = err instanceof Error ? err.message : String(err);
-    return /No conversation found with session ID|--resume requires a valid session/i.test(m);
+    return /No conversation found with session ID|--resume requires a valid session|tool_use.*ids were found without.*tool_result|tool_result.*blocks.*immediately after/i.test(m);
   };
 
   const stream = runStream(opts?.resume, userMessage);


### PR DESCRIPTION
## Summary

Fixes #154

When an agent turn is interrupted mid-execution (process kill, timeout, or restart) while the Claude Agent SDK has already emitted `tool_use` blocks, the SDK session is left in a corrupt state. On the next message, the API rejects it with a `ValidationException`, and the user sees an error.

## Root Cause

`isResumeError()` in `agent-bridge.ts` only matched two specific strings:

```ts
return /No conversation found with session ID|--resume requires a valid session/i.test(m);
```

It did **not** match the Bedrock `ValidationException` for orphaned `tool_use` blocks, so the corrupt session was never cleared via `onResumeFailed()`.

## Fix

Extended `isResumeError()` to also match the Bedrock ValidationException pattern:

```ts
return /No conversation found with session ID|--resume requires a valid session|tool_use.*ids were found without.*tool_result|tool_result.*blocks.*immediately after/i.test(m);
```

This triggers the existing `onResumeFailed()` recovery path (clears the stale `sdk_session_id` from SQLite), allowing the next turn to start fresh with `fallbackRetryPrompt`.

## Testing

The fix uses the existing recovery path already validated for stale sessions. No new code paths are introduced — only the error detection regex is extended.

The test suite includes a passing test: `recovers from Bedrock ValidationException: orphaned tool_use blocks (no prior output)` which confirms the recovery path works end-to-end.

## Checklist
- [x] Extends isResumeError() to detect Bedrock ValidationException
- [x] Reuses existing onResumeFailed() cleanup path
- [x] Minimal change, no new code paths