### PR TITLE
fix(read-receipt): omit empty message_ids and silence best-effort failures

### DIFF
--- a/src/__tests__/api.test.ts
+++ b/src/__tests__/api.test.ts
@@ -3,7 +3,8 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest';
-import { getUploadCredentials } from '../octo/api.js';
+import { getUploadCredentials, sendReadReceipt } from '../octo/api.js';
+import { ChannelType } from '../octo/types.js';
 
 // Mock global fetch
 const fetchMock = vi.fn();
@@ -135,5 +136,47 @@ describe('getUploadCredentials', () => {
     // Error prefix + 200 chars max + nothing more
     expect(captured!.message.length).toBeLessThan(300);
     expect(captured!.message).not.toMatch(/x{300,}/);
+  });
+});
+
+describe('sendReadReceipt — message_ids guard', () => {
+  const RR_BASE = {
+    apiUrl: 'https://api.example.com',
+    botToken: 'test-token',
+    channelId: 'chan-1',
+    channelType: ChannelType.DM,
+  };
+
+  function bodyOf(callIndex = 0): Record<string, unknown> {
+    const init = fetchMock.mock.calls[callIndex][1] as RequestInit;
+    return JSON.parse(init.body as string);
+  }
+
+  it('includes message_ids when non-empty', async () => {
+    fetchMock.mockResolvedValueOnce(mockJsonResponse({}));
+    await sendReadReceipt({ ...RR_BASE, messageIds: ['123', '456'] });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(bodyOf()).toMatchObject({ message_ids: ['123', '456'] });
+  });
+
+  it('omits message_ids when the array is empty', async () => {
+    fetchMock.mockResolvedValueOnce(mockJsonResponse({}));
+    await sendReadReceipt({ ...RR_BASE, messageIds: [] });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect('message_ids' in bodyOf()).toBe(false);
+    // still clears the unread badge — channel_id is present
+    expect(bodyOf()).toMatchObject({ channel_id: 'chan-1' });
+  });
+
+  it('omits message_ids when every id is empty or blank', async () => {
+    fetchMock.mockResolvedValueOnce(mockJsonResponse({}));
+    await sendReadReceipt({ ...RR_BASE, messageIds: ['', '   '] });
+    expect('message_ids' in bodyOf()).toBe(false);
+  });
+
+  it('filters out blank ids and keeps the real ones', async () => {
+    fetchMock.mockResolvedValueOnce(mockJsonResponse({}));
+    await sendReadReceipt({ ...RR_BASE, messageIds: ['x', '', '  '] });
+    expect(bodyOf()).toMatchObject({ message_ids: ['x'] });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -416,7 +416,7 @@ export async function handleMessage(
               channelId: msg.channel_id,
               channelType: msg.channel_type,
               messageIds: [msg.message_id],
-            }).catch((err) => console.error(`[cc-channel-octo] readReceipt failed: ${String(err)}`));
+            }).catch(() => { /* read receipt is best-effort; never surface failures */ });
           }
           return; // skip context, history, and the agent query entirely
         }
@@ -852,7 +852,7 @@ export async function handleMessage(
           channelId: msg.channel_id,
           channelType: msg.channel_type,
           messageIds: [msg.message_id],
-        }).catch((err) => console.error(`[cc-channel-octo] readReceipt failed: ${String(err)}`));
+        }).catch(() => { /* read receipt is best-effort; never surface failures */ });
       }
 
       // --- Store assistant response in history ---

--- a/src/octo/api.ts
+++ b/src/octo/api.ts
@@ -293,10 +293,15 @@ export async function sendReadReceipt(params: {
   messageIds: string[];
   signal?: AbortSignal;
 }): Promise<void> {
+  // Only send message-level ids that are actually present. An empty / blank id
+  // makes the server resolve a message_seq it cannot find, which the IM backend
+  // rejects — so omit message_ids entirely when there is nothing valid to ack
+  // (the request then just clears the conversation unread badge).
+  const ids = (params.messageIds ?? []).filter((id) => id && id.trim() !== '');
   await postJson(params.apiUrl, params.botToken, '/v1/bot/readReceipt', {
     channel_id: params.channelId,
     channel_type: params.channelType,
-    message_ids: params.messageIds,
+    ...(ids.length > 0 ? { message_ids: ids } : {}),
   }, params.signal);
 }
 


### PR DESCRIPTION
## What

Harden the bot read-receipt path so an empty / unresolvable message id can never produce a 400 or log noise.

- `sendReadReceipt` filters out empty/blank ids and omits `message_ids` entirely when none are valid (the request still clears the conversation unread badge).
- Both call sites' `.catch` are now true no-ops — a read receipt is fire-and-forget and must never surface failures.
- Tests: empty / blank / mixed / non-empty message id cases assert the `message_ids` field presence and contents.

## Why

Read receipts are best-effort and decoupled from message delivery (no `await`, failures already caught). But the gateway sends `message_ids` unconditionally; when an id can't be resolved to a message_seq the server returns 400 and the gateway logged an error each time. Chatting was never affected, but the error log was noise.

Verified against the server handler: with no `message_ids`, the readReceipt path only clears the unread badge and returns 2xx — it never reaches the message-level lookup that can fail. Omitting the field is therefore the correct way to avoid the failure at the source.

This is a defensive guard ahead of going to production. The server-side error-downgrade (returning 400 instead of skipping an unresolvable id) is tracked separately in its own repository.

## Test

- `npm run type-check` / `npm run build` / `npm test` (1096 passing) / `npm run lint` (0 warnings)