### PR TITLE
ci(octo-issue-feed): standardize issue triage workflow

### DIFF
--- a/.github/workflows/octo-issue-feed.yml
+++ b/.github/workflows/octo-issue-feed.yml
@@ -1,0 +1,22 @@
+name: Octo Issue Feed
+
+on:
+  issues:
+    types: [opened, reopened]
+
+permissions: {}
+
+jobs:
+  notify:
+    uses: Mininglamp-OSS/.github/.github/workflows/octo-issue-notify.yml@v1
+    with:
+      repo_name: ${{ github.event.repository.name }}
+      issue_number: ${{ github.event.issue.number }}
+      issue_title: ${{ github.event.issue.title }}
+      issue_url: ${{ github.event.issue.html_url }}
+      issue_author: ${{ github.event.issue.user.login }}
+      event_action: ${{ github.event.action }}
+      enable_im_notify: false
+    secrets:
+      OCTO_BOT_TOKEN: ${{ secrets.OCTO_BOT_TOKEN }}
+      TRIAGE_WEBHOOK_URL: ${{ secrets.TRIAGE_WEBHOOK_URL }}


### PR DESCRIPTION
Adds .github/workflows/octo-issue-feed.yml that calls the org reusable workflow with enable_im_notify=false and TRIAGE_WEBHOOK_URL. Brings this repo to parity with the 19 already-migrated repos. Backed by Mininglamp-OSS/.github#80.