### PR TITLE
fix(agent-bridge): match Bedrock ValidationException in isResumeError (#154)

### DIFF
--- a/src/__tests__/agent-bridge-query.test.ts
+++ b/src/__tests__/agent-bridge-query.test.ts
@@ -639,6 +639,94 @@ describe('queryAgent', () => {
     expect(mockQuery).toHaveBeenCalledTimes(1); // no retry after a tool_use side effect
     expect(resumeFailed).toBe(true); // but the stale id was cleared
   });
+
+  // --- orphaned tool_use ValidationException recovery (#154) ---
+  // Bedrock's ValidationException when a session carries tool_use blocks without
+  // corresponding tool_result blocks was NOT matched by isResumeError, so
+  // onResumeFailed was never called and the corrupt session id persisted.
+
+  it('recovers from a Bedrock ValidationException for orphaned tool_use blocks (no prior output)', async () => {
+    // The exact error shape Bedrock returns when a session carries tool_use
+    // blocks without matching tool_result blocks (observed in production, #154).
+    const bedrockErr = new Error(
+      'ValidationException: messages.805: `tool_use` ids were found without ' +
+      '`tool_result` blocks immediately after: toolu_757190a2ce1b41e48ebf8ebd, ' +
+      'toolu_c6e1a12e9f234cf493debbb5. Each `tool_use` block must have a ' +
+      'corresponding `tool_result` block.',
+    );
+    const throwing = createMockStream([]);
+    throwing[Symbol.asyncIterator] = async function* () { throw bedrockErr; };
+    const ok = createMockStream([
+      { type: 'assistant', session_id: 'fresh-sid', message: { content: [{ type: 'text', text: 'recovered' }] } },
+    ]);
+    mockQuery.mockReturnValueOnce(throwing).mockReturnValueOnce(ok);
+
+    let resumeFailed = false;
+    const ids: string[] = [];
+    const chunks: string[] = [];
+    for await (const chunk of queryAgent('hi', makeConfig(), undefined, undefined, {
+      resume: 'stale-sid',
+      onSessionId: (id) => ids.push(id),
+      onResumeFailed: () => { resumeFailed = true; },
+      fallbackRetryPrompt: 'fallback',
+    })) {
+      chunks.push(chunk);
+    }
+
+    expect(resumeFailed).toBe(true);
+    expect(chunks).toEqual(['recovered']);
+    expect(mockQuery).toHaveBeenCalledTimes(2);
+    expect(mockQuery.mock.calls[0][0].options.resume).toBe('stale-sid');
+    expect(mockQuery.mock.calls[1][0].options).not.toHaveProperty('resume');
+    expect(ids).toEqual(['fresh-sid']);
+  });
+
+  it('clears the stale id when a Bedrock ValidationException arrives AFTER output (no retry)', async () => {
+    const partial = createMockStream([]);
+    partial[Symbol.asyncIterator] = async function* () {
+      yield { type: 'assistant', session_id: 's', message: { content: [{ type: 'text', text: 'partial' }] } };
+      throw new Error(
+        'ValidationException: messages.12: `tool_use` ids were found without ' +
+        '`tool_result` blocks immediately after: toolu_abc. Each `tool_use` block ' +
+        'must have a corresponding `tool_result` block.',
+      );
+    };
+    mockQuery.mockReturnValue(partial);
+    const chunks: string[] = [];
+    let resumeFailed = false;
+    await expect(async () => {
+      for await (const chunk of queryAgent('hi', makeConfig(), undefined, undefined, {
+        resume: 'sid', onResumeFailed: () => { resumeFailed = true; },
+      })) { chunks.push(chunk); }
+    }).rejects.toThrow('ValidationException');
+    expect(chunks).toEqual(['partial']);
+    expect(mockQuery).toHaveBeenCalledTimes(1); // no retry after partial output
+    expect(resumeFailed).toBe(true); // stale id still cleared
+  });
+
+  it('matches Anthropic-direct error shape for orphaned tool_use (variant wording)', async () => {
+    // The Anthropic-direct API may phrase it differently. The regex must cover:
+    // "tool_result blocks immediately after" variant too.
+    const throwing = createMockStream([]);
+    throwing[Symbol.asyncIterator] = async function* () {
+      throw new Error('tool_result blocks immediately after: toolu_xyz');
+    };
+    const ok = createMockStream([
+      { type: 'assistant', session_id: 'new', message: { content: [{ type: 'text', text: 'ok' }] } },
+    ]);
+    mockQuery.mockReturnValueOnce(throwing).mockReturnValueOnce(ok);
+
+    let resumeFailed = false;
+    const chunks: string[] = [];
+    for await (const chunk of queryAgent('hi', makeConfig(), undefined, undefined, {
+      resume: 'stale',
+      onResumeFailed: () => { resumeFailed = true; },
+    })) {
+      chunks.push(chunk);
+    }
+    expect(resumeFailed).toBe(true);
+    expect(chunks).toEqual(['ok']);
+  });
 });
 
 describe('queryAgent — sdk.env injection (#107)', () => {

--- a/src/agent-bridge.ts
+++ b/src/agent-bridge.ts
@@ -307,10 +307,14 @@ export async function* queryAgent(
     });
 
   // Detect the SDK's stale/invalid-resume signal (verified via spike): it throws
-  // an Error whose message names the missing/invalid session id.
+  // an Error whose message names the missing/invalid session id. Also matches
+  // the Bedrock/Anthropic-direct ValidationException for orphaned tool_use
+  // blocks — when a turn is interrupted mid-execution, the SDK session is left
+  // with tool_use blocks that have no matching tool_result, and the next resume
+  // attempt must be treated as stale (#154).
   const isResumeError = (err: unknown): boolean => {
     const m = err instanceof Error ? err.message : String(err);
-    return /No conversation found with session ID|--resume requires a valid session/i.test(m);
+    return /No conversation found with session ID|--resume requires a valid session|tool_use.*ids were found without.*tool_result|tool_result.*blocks.*immediately after/i.test(m);
   };
 
   const stream = runStream(opts?.resume, userMessage);


### PR DESCRIPTION
## Summary

When an agent turn is interrupted mid-execution (process kill, timeout, or restart) while the Claude Agent SDK has already emitted `tool_use` blocks, the SDK session is left with orphaned `tool_use` blocks (no corresponding `tool_result`). On the next resume, the API returns a `ValidationException` that `isResumeError()` did not match, so `onResumeFailed()` was never called, the corrupt `sdk_session_id` was never cleared, and every subsequent turn failed with the same error.

## Root Cause

`isResumeError()` in `agent-bridge.ts` only matched:
```
/No conversation found with session ID|--resume requires a valid session/i
```

It did **not** match the Bedrock `ValidationException`:
```
ValidationException: messages.805: `tool_use` ids were found without `tool_result` blocks immediately after: toolu_...
```

## Fix

Extended the `isResumeError` regex to also match:
- `tool_use.*ids were found without.*tool_result` — Bedrock error shape
- `tool_result.*blocks.*immediately after` — Anthropic-direct variant

The existing recovery path (clear stale `sdk_session_id` → retry once without resume using `fallbackRetryPrompt`) now fires for this error class, matching the behavior for stale/expired sessions.

## Tests

Added 3 regression tests to `agent-bridge-query.test.ts`:

1. **`recovers from a Bedrock ValidationException for orphaned tool_use blocks (no prior output)`** — full recovery: `onResumeFailed` called, retry WITHOUT resume, fresh session id captured
2. **`clears the stale id when a Bedrock ValidationException arrives AFTER output (no retry)`** — no retry (partial output already streamed), but stale id still cleared so next turn recovers
3. **`matches Anthropic-direct error shape for orphaned tool_use (variant wording)`** — covers alternative phrasing from Anthropic-direct API

All 1099 tests pass.

## Verification

- Pre-commit hook (eslint + type-check): ✅
- Pre-push hook (full vitest run, 1099 tests): ✅
- TypeScript build (`tsc`): ✅

Fixes #154