### PR TITLE
feat(thread): route community-topic threads + restore lifecycle endpoints (P1 of #88)

### DIFF
--- a/src/__tests__/channel-id.test.ts
+++ b/src/__tests__/channel-id.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Tests for octo/channel-id.ts — composite (thread) channel-id parsing.
+ *
+ * Thread channelId format: `<groupNo>____<shortId>` (THREAD_ID_SEPARATOR, 4
+ * underscores). Group channelId has no separator.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  THREAD_ID_SEPARATOR,
+  extractParentGroupNo,
+  extractThreadShortId,
+  isThreadChannelId,
+} from '../octo/channel-id.js';
+
+describe('THREAD_ID_SEPARATOR', () => {
+  it('is exactly four underscores', () => {
+    expect(THREAD_ID_SEPARATOR).toBe('____');
+    expect(THREAD_ID_SEPARATOR.length).toBe(4);
+  });
+});
+
+describe('isThreadChannelId', () => {
+  it('is true for a composite id', () => {
+    expect(isThreadChannelId('12345____67890')).toBe(true);
+  });
+
+  it('is false for a plain group id (no separator)', () => {
+    expect(isThreadChannelId('12345')).toBe(false);
+    expect(isThreadChannelId('s1_group99')).toBe(false);
+  });
+
+  it('does not treat fewer than four underscores as a separator', () => {
+    expect(isThreadChannelId('a_b')).toBe(false);
+    expect(isThreadChannelId('a__b')).toBe(false);
+    expect(isThreadChannelId('a___b')).toBe(false);
+  });
+});
+
+describe('extractParentGroupNo', () => {
+  it('returns the left segment of a composite id', () => {
+    expect(extractParentGroupNo('12345____67890')).toBe('12345');
+  });
+
+  it('returns the id unchanged when there is no separator', () => {
+    expect(extractParentGroupNo('12345')).toBe('12345');
+  });
+
+  it('splits on the FIRST separator when several are present', () => {
+    // Right-hand side keeps its own separator; only the first split matters.
+    expect(extractParentGroupNo('12345____67890____extra')).toBe('12345');
+  });
+
+  it('returns an empty parent when the id starts with the separator', () => {
+    expect(extractParentGroupNo('____67890')).toBe('');
+  });
+});
+
+describe('extractThreadShortId', () => {
+  it('returns the right segment of a composite id', () => {
+    expect(extractThreadShortId('12345____67890')).toBe('67890');
+  });
+
+  it('returns null for a plain group id (no separator)', () => {
+    expect(extractThreadShortId('12345')).toBeNull();
+  });
+
+  it('keeps embedded separators in the short id (first split only)', () => {
+    expect(extractThreadShortId('12345____67890____extra')).toBe('67890____extra');
+  });
+
+  it('returns null when the short-id segment is empty (trailing separator)', () => {
+    expect(extractThreadShortId('12345____')).toBeNull();
+  });
+
+  it('returns the short id even when the parent segment is empty', () => {
+    expect(extractThreadShortId('____67890')).toBe('67890');
+  });
+});

--- a/src/__tests__/group-config.test.ts
+++ b/src/__tests__/group-config.test.ts
@@ -92,3 +92,43 @@ describe('loadGroupConfig', () => {
     expect(loadGroupConfig(dir, 'g1')).toBe('instructions');
   });
 });
+
+describe('loadGroupConfig — thread (composite channel_id) routing [#88 redline 5]', () => {
+  const GROUP = 'g123';
+  const SHORT = 't789';
+  const COMPOSITE = `${GROUP}____${SHORT}`;
+
+  it('a plain group id is unaffected (byte-identical to prior behavior)', () => {
+    writeFileSync(join(dir, `${GROUP}.md`), 'group rules');
+    expect(loadGroupConfig(dir, GROUP)).toBe('group rules');
+  });
+
+  it('NEW semantics: a thread reads its own <shortId>.md', () => {
+    writeFileSync(join(dir, `${SHORT}.md`), 'thread rules');
+    expect(loadGroupConfig(dir, COMPOSITE)).toBe('thread rules');
+  });
+
+  it('a thread does NOT inherit the parent group <groupNo>.md (decision A)', () => {
+    writeFileSync(join(dir, `${GROUP}.md`), 'group rules');
+    // No <shortId>.md and no legacy file → undefined, not the parent's file.
+    expect(loadGroupConfig(dir, COMPOSITE)).toBeUndefined();
+  });
+
+  it('COMPAT fallback: legacy whole-composite <groupNo____shortId>.md still loads', () => {
+    writeFileSync(join(dir, `${COMPOSITE}.md`), 'legacy thread file');
+    expect(loadGroupConfig(dir, COMPOSITE)).toBe('legacy thread file');
+  });
+
+  it('NEW semantics wins over the legacy whole-composite file', () => {
+    writeFileSync(join(dir, `${SHORT}.md`), 'new');
+    writeFileSync(join(dir, `${COMPOSITE}.md`), 'legacy');
+    expect(loadGroupConfig(dir, COMPOSITE)).toBe('new');
+  });
+
+  it('thread short id and parent group resolve to different files', () => {
+    writeFileSync(join(dir, `${GROUP}.md`), 'group rules');
+    writeFileSync(join(dir, `${SHORT}.md`), 'thread rules');
+    expect(loadGroupConfig(dir, GROUP)).toBe('group rules');
+    expect(loadGroupConfig(dir, COMPOSITE)).toBe('thread rules');
+  });
+});

--- a/src/__tests__/group-context.test.ts
+++ b/src/__tests__/group-context.test.ts
@@ -507,3 +507,34 @@ describe('G23: robot flag', () => {
     expect(ctx.isMember('ch-empty', 'u2')).toBe(true);
   });
 });
+
+describe('GroupContext.refreshMembers — thread roster uses parent group [#88 redline 6]', () => {
+  let adapter: DbAdapter;
+  let ctx: GroupContext;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    adapter = createTestAdapter();
+    ctx = new GroupContext(adapter, 6000);
+  });
+
+  it('queries the PARENT group number, not the composite thread channel_id', async () => {
+    const GROUP = '99dc18164a29435f9791dc37023f98e1';
+    const COMPOSITE = `${GROUP}____2071488441815666688`;
+    (getGroupMembers as ReturnType<typeof vi.fn>).mockResolvedValueOnce([]);
+
+    await ctx.refreshMembers(COMPOSITE, 'https://test.example.com', 'bf_test');
+
+    expect(getGroupMembers).toHaveBeenCalledTimes(1);
+    const arg = (getGroupMembers as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    // Hitting /groups/<composite>/members would 404 — must use the parent group.
+    expect(arg.groupNo).toBe(GROUP);
+    expect(arg.groupNo).not.toContain('____');
+  });
+
+  it('passes a plain group channel_id through unchanged', async () => {
+    (getGroupMembers as ReturnType<typeof vi.fn>).mockResolvedValueOnce([]);
+    await ctx.refreshMembers('plain-group', 'https://test.example.com', 'bf_test');
+    expect((getGroupMembers as ReturnType<typeof vi.fn>).mock.calls[0][0].groupNo).toBe('plain-group');
+  });
+});

--- a/src/__tests__/session-router.test.ts
+++ b/src/__tests__/session-router.test.ts
@@ -943,3 +943,32 @@ describe('unsupported channel types (system messages)', () => {
     expect(result?.shouldProcess).toBe(true);
   });
 });
+
+describe('SessionRouter — thread (CommunityTopic) session isolation [#88]', () => {
+  let router: SessionRouter;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    router = new SessionRouter(makeConfig(), ROBOT_ID);
+  });
+
+  it('a thread composite channel_id keys a session distinct from its parent group', () => {
+    const GROUP = '99dc18164a29435f9791dc37023f98e1';
+    const COMPOSITE = `${GROUP}____2071488441815666688`;
+
+    const parent = makeMsg({ channel_type: ChannelType.Group, channel_id: GROUP, from_uid: 'u1' });
+    const thread = makeMsg({ channel_type: ChannelType.CommunityTopic, channel_id: COMPOSITE, from_uid: 'u1' });
+
+    // The composite id IS the session key, so the thread never shares the
+    // parent group's session/history/cwd/memory partition.
+    expect(router.sessionKey(thread)).toBe(COMPOSITE);
+    expect(router.sessionKey(thread)).not.toBe(router.sessionKey(parent));
+  });
+
+  it('two threads under the same parent get independent sessions', () => {
+    const GROUP = 'g1';
+    const a = makeMsg({ channel_type: ChannelType.CommunityTopic, channel_id: `${GROUP}____aaa`, from_uid: 'u1' });
+    const b = makeMsg({ channel_type: ChannelType.CommunityTopic, channel_id: `${GROUP}____bbb`, from_uid: 'u1' });
+    expect(router.sessionKey(a)).not.toBe(router.sessionKey(b));
+  });
+});

--- a/src/__tests__/thread-api.test.ts
+++ b/src/__tests__/thread-api.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Tests for octo/api.ts — thread lifecycle endpoints.
+ *
+ * Each test asserts the restored endpoint hits the correct path + method and
+ * carries `Authorization: Bearer <botToken>` (parity restore of openclaw
+ * api-fetch.ts; see #88 acceptance criteria).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest';
+import {
+  createThread,
+  listThreads,
+  getThread,
+  deleteThread,
+  listThreadMembers,
+  joinThread,
+  leaveThread,
+} from '../octo/api.js';
+
+const fetchMock = vi.fn();
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+});
+
+afterAll(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function mockJsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function mockEmptyResponse(status = 200): Response {
+  // null body — a 204 (and other null-body statuses) rejects a non-null body.
+  return new Response(null, { status, statusText: 'OK' });
+}
+
+const BASE = { apiUrl: 'https://test.example.com', botToken: 'bf_test' };
+const GROUP = '99dc18164a29435f9791dc37023f98e1';
+const SHORT = '2071488441815666688';
+
+/** Pull (url, init) of the Nth fetch call. */
+function call(n = 0): { url: string; init: RequestInit } {
+  const [url, init] = fetchMock.mock.calls[n] as [string, RequestInit];
+  return { url, init };
+}
+
+function authHeader(init: RequestInit): string | undefined {
+  const h = init.headers as Record<string, string> | undefined;
+  return h?.Authorization;
+}
+
+describe('createThread', () => {
+  it('POSTs to /v1/bot/groups/{groupNo}/threads with Bearer auth and name body', async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockJsonResponse({ short_id: SHORT, name: 'topic', creator_uid: 'u1' }),
+    );
+
+    const out = await createThread({ ...BASE, groupNo: GROUP, name: 'topic' });
+
+    const { url, init } = call();
+    expect(url).toBe(`${BASE.apiUrl}/v1/bot/groups/${GROUP}/threads`);
+    expect(init.method).toBe('POST');
+    expect(authHeader(init)).toBe(`Bearer ${BASE.botToken}`);
+    expect(JSON.parse(init.body as string)).toEqual({ name: 'topic' });
+    expect(out).toEqual({ short_id: SHORT, name: 'topic', creator_uid: 'u1' });
+  });
+
+  it('includes source_message_id only when provided', async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockJsonResponse({ short_id: SHORT, name: 'topic', creator_uid: 'u1' }),
+    );
+    await createThread({ ...BASE, groupNo: GROUP, name: 'topic', sourceMessageId: 42 });
+    expect(JSON.parse(call().init.body as string)).toEqual({
+      name: 'topic',
+      source_message_id: 42,
+    });
+  });
+});
+
+describe('listThreads', () => {
+  it('GETs the threads collection with Bearer auth', async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockJsonResponse([{ short_id: SHORT, name: 't', creator_uid: 'u1', status: 0 }]),
+    );
+
+    const out = await listThreads({ ...BASE, groupNo: GROUP });
+
+    const { url, init } = call();
+    expect(url).toBe(`${BASE.apiUrl}/v1/bot/groups/${GROUP}/threads`);
+    expect(init.method ?? 'GET').toBe('GET');
+    expect(authHeader(init)).toBe(`Bearer ${BASE.botToken}`);
+    expect(out).toHaveLength(1);
+    expect(out[0].short_id).toBe(SHORT);
+  });
+
+  it('tolerates a { threads: [...] } envelope', async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockJsonResponse({ threads: [{ short_id: SHORT, name: 't', creator_uid: 'u1', status: 0 }] }),
+    );
+    const out = await listThreads({ ...BASE, groupNo: GROUP });
+    expect(out).toHaveLength(1);
+  });
+
+  it('returns [] for an unexpected shape', async () => {
+    fetchMock.mockResolvedValueOnce(mockJsonResponse({ unexpected: true }));
+    expect(await listThreads({ ...BASE, groupNo: GROUP })).toEqual([]);
+  });
+});
+
+describe('getThread', () => {
+  it('GETs a single thread by short id with Bearer auth', async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockJsonResponse({ short_id: SHORT, name: 't', creator_uid: 'u1', status: 0, member_count: 3 }),
+    );
+
+    const out = await getThread({ ...BASE, groupNo: GROUP, shortId: SHORT });
+
+    const { url, init } = call();
+    expect(url).toBe(`${BASE.apiUrl}/v1/bot/groups/${GROUP}/threads/${SHORT}`);
+    expect(init.method ?? 'GET').toBe('GET');
+    expect(authHeader(init)).toBe(`Bearer ${BASE.botToken}`);
+    expect(out.member_count).toBe(3);
+  });
+});
+
+describe('deleteThread', () => {
+  it('DELETEs a thread by short id with Bearer auth', async () => {
+    fetchMock.mockResolvedValueOnce(mockEmptyResponse(204));
+
+    await deleteThread({ ...BASE, groupNo: GROUP, shortId: SHORT });
+
+    const { url, init } = call();
+    expect(url).toBe(`${BASE.apiUrl}/v1/bot/groups/${GROUP}/threads/${SHORT}`);
+    expect(init.method).toBe('DELETE');
+    expect(authHeader(init)).toBe(`Bearer ${BASE.botToken}`);
+  });
+});
+
+describe('listThreadMembers', () => {
+  it('GETs the thread members with Bearer auth', async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockJsonResponse([{ uid: 'u1', role: 1 }, { uid: 'u2', role: 0 }]),
+    );
+
+    const out = await listThreadMembers({ ...BASE, groupNo: GROUP, shortId: SHORT });
+
+    const { url, init } = call();
+    expect(url).toBe(`${BASE.apiUrl}/v1/bot/groups/${GROUP}/threads/${SHORT}/members`);
+    expect(init.method ?? 'GET').toBe('GET');
+    expect(authHeader(init)).toBe(`Bearer ${BASE.botToken}`);
+    expect(out).toHaveLength(2);
+    expect(out[0]).toEqual({ uid: 'u1', role: 1 });
+  });
+
+  it('tolerates a { members: [...] } envelope', async () => {
+    fetchMock.mockResolvedValueOnce(mockJsonResponse({ members: [{ uid: 'u1', role: 1 }] }));
+    const out = await listThreadMembers({ ...BASE, groupNo: GROUP, shortId: SHORT });
+    expect(out).toHaveLength(1);
+  });
+});
+
+describe('joinThread', () => {
+  it('POSTs to .../join with Bearer auth', async () => {
+    fetchMock.mockResolvedValueOnce(mockEmptyResponse(200));
+
+    await joinThread({ ...BASE, groupNo: GROUP, shortId: SHORT });
+
+    const { url, init } = call();
+    expect(url).toBe(`${BASE.apiUrl}/v1/bot/groups/${GROUP}/threads/${SHORT}/join`);
+    expect(init.method).toBe('POST');
+    expect(authHeader(init)).toBe(`Bearer ${BASE.botToken}`);
+  });
+});
+
+describe('leaveThread', () => {
+  it('POSTs to .../leave with Bearer auth', async () => {
+    fetchMock.mockResolvedValueOnce(mockEmptyResponse(200));
+
+    await leaveThread({ ...BASE, groupNo: GROUP, shortId: SHORT });
+
+    const { url, init } = call();
+    expect(url).toBe(`${BASE.apiUrl}/v1/bot/groups/${GROUP}/threads/${SHORT}/leave`);
+    expect(init.method).toBe('POST');
+    expect(authHeader(init)).toBe(`Bearer ${BASE.botToken}`);
+  });
+});
+
+describe('thread endpoints — error handling', () => {
+  it('throws a descriptive error on a non-2xx response', async () => {
+    fetchMock.mockResolvedValueOnce(new Response('nope', { status: 404, statusText: 'Not Found' }));
+    await expect(getThread({ ...BASE, groupNo: GROUP, shortId: SHORT })).rejects.toThrow(/404/);
+  });
+
+  it('url-encodes group and short ids', async () => {
+    fetchMock.mockResolvedValueOnce(mockEmptyResponse(200));
+    await joinThread({ ...BASE, groupNo: 'g/1', shortId: 's 2' });
+    expect(call().url).toBe(`${BASE.apiUrl}/v1/bot/groups/g%2F1/threads/s%202/join`);
+  });
+});

--- a/src/group-config.ts
+++ b/src/group-config.ts
@@ -27,6 +27,7 @@
 
 import { closeSync, existsSync, openSync, readSync, statSync } from 'node:fs';
 import { join } from 'node:path';
+import { extractThreadShortId, isThreadChannelId } from './octo/channel-id.js';
 
 /** Max bytes of an instruction file we will inject (keeps the prompt bounded). */
 export const MAX_GROUP_CONFIG_BYTES = 16_384; // 16 KiB
@@ -41,25 +42,65 @@ function isSafeId(id: string): boolean {
 }
 
 /**
- * Load the instruction file for a group, or undefined when none applies.
+ * Load the instruction file for a channel, or undefined when none applies.
  *
- * Looks for `<groupConfigDir>/<groupId>.md`. Returns the trimmed contents,
- * truncated to MAX_GROUP_CONFIG_BYTES. Returns undefined when:
- *   - groupConfigDir is not configured,
- *   - groupId is empty or unsafe as a path segment,
+ * Routing by channel-id shape:
+ *   - Plain group (`<groupNo>`, no separator): looks for `<groupNo>.md`.
+ *     Byte-identical to the pre-thread behavior.
+ *   - Thread (`<groupNo>____<shortId>`, CommunityTopic): a thread carries its
+ *     OWN instructions, not the parent group's, so the NEW semantics looks for
+ *     `<shortId>.md` (the thread's own slug). To avoid breaking deployments
+ *     that dropped a whole-composite `<groupNo>____<shortId>.md` file under the
+ *     old "channel_id as filename" behavior, it then falls back to that legacy
+ *     name when the short-id file is absent (compat lookup — see #88 redline 5).
+ *
+ * ⚠️ Path-semantics change (redline 5): before this change a thread channel_id
+ * was used verbatim as the filename; now the short id is the primary slug and
+ * the whole-composite name is only a fallback. A thread no longer inherits its
+ * parent group's `<groupNo>.md` (decision A: thread injects its own file only).
+ *
+ * Returns the trimmed contents, truncated to MAX_GROUP_CONFIG_BYTES, or
+ * undefined when no file applies. Never throws.
+ */
+export function loadGroupConfig(
+  groupConfigDir: string | undefined,
+  channelId: string,
+): string | undefined {
+  if (!groupConfigDir) return undefined;
+  if (!channelId) return undefined;
+
+  if (isThreadChannelId(channelId)) {
+    // New semantics: the thread's own short-id file first…
+    const shortId = extractThreadShortId(channelId);
+    if (shortId) {
+      const byShortId = loadConfigFile(groupConfigDir, shortId);
+      if (byShortId !== undefined) return byShortId;
+    }
+    // …then the legacy whole-composite filename for backward compatibility.
+    return loadConfigFile(groupConfigDir, channelId);
+  }
+
+  return loadConfigFile(groupConfigDir, channelId);
+}
+
+/**
+ * Read a single instruction file `<groupConfigDir>/<slug>.md`, or undefined.
+ *
+ * Returns the trimmed contents, truncated to MAX_GROUP_CONFIG_BYTES. Returns
+ * undefined when:
+ *   - slug is empty or unsafe as a path segment,
  *   - the file does not exist or is unreadable.
  *
  * Never throws — a misconfigured dir or unreadable file degrades to "no custom
  * instructions" rather than failing the turn.
  */
-export function loadGroupConfig(
-  groupConfigDir: string | undefined,
-  groupId: string,
+function loadConfigFile(
+  groupConfigDir: string,
+  slug: string,
 ): string | undefined {
-  if (!groupConfigDir) return undefined;
-  if (!groupId || !isSafeId(groupId)) return undefined;
+  if (!slug || !isSafeId(slug)) return undefined;
 
-  const path = join(groupConfigDir, `${groupId}.md`);
+  const path = join(groupConfigDir, `${slug}.md`);
   try {
     if (!existsSync(path)) return undefined;
     const st = statSync(path);

--- a/src/group-context.ts
+++ b/src/group-context.ts
@@ -4,6 +4,7 @@
 
 import type { DbAdapter, PreparedStatement } from './db-adapter.js';
 import { getGroupMembers, fetchUserInfo } from './octo/api.js';
+import { extractParentGroupNo } from './octo/channel-id.js';
 import { sanitizeDisplayName } from './prompt-safety.js';
 
 interface GroupMessage {
@@ -202,7 +203,14 @@ export class GroupContext {
     // Don't set lastRefresh here — only on success
 
     try {
-      const members = await getGroupMembers({ apiUrl, botToken, groupNo: channelId });
+      // Redline 6 (#88): the roster endpoint is keyed by the PARENT group number.
+      // A thread channelId is the composite `<groupNo>____<shortId>`; hitting
+      // `/groups/<groupNo>____<shortId>/members` 404s. Resolve the parent group
+      // number for the API call while keeping every cache (memory + DB + robot
+      // flags) keyed by the full channelId, so a thread keeps its own isolated
+      // roster view. For a plain group channelId extractParentGroupNo is identity.
+      const groupNo = extractParentGroupNo(channelId);
+      const members = await getGroupMembers({ apiUrl, botToken, groupNo });
       this.lastRefresh.set(channelId, now); // Record only on success
       const memberMap = this.getMemberMap(channelId);
       const nameMap = this.getNameToUid(channelId);

--- a/src/octo/api.ts
+++ b/src/octo/api.ts
@@ -1,13 +1,17 @@
 // Forked from openclaw-channel-octo v1.0.13 (2026-06-04)
 // Source: https://github.com/Mininglamp-OSS/openclaw-channel-octo
-// Removed: COS upload, GROUP.md API, OBO, rich text, media, thread/group management,
+// Removed: COS upload, GROUP.md API, OBO, rich text, media, group management,
 //          read receipts, bot groups list, group info, mention prefs, space members.
+// Restored: thread lifecycle (create/list/get/delete/members/join/leave) — see
+//          "Thread Lifecycle" section below; group/server-md APIs stay removed.
 
 import {
   ChannelType,
   MessageType,
   type MentionEntity,
   type SendMessageResult,
+  type Thread,
+  type ThreadMember,
 } from "./types.js";
 import { randomUUID } from "node:crypto";
 
@@ -494,4 +498,171 @@ export async function getChannelMessages(params: {
     console.error(`octo: getChannelMessages error: ${String(err)}`);
     return [];
   }
+}
+
+// ─── Thread Lifecycle ────────────────────────────────────────────────────────
+//
+// Restores the bot thread (CommunityTopic) lifecycle endpoints that were removed
+// at fork time (see file header). Path / method / auth are a verbatim restore of
+// openclaw-channel-octo api-fetch.ts (createThread … leaveThread); each call is
+// routed through this client's postJson/getJson/requestNoBody helpers so it
+// shares the same timeout, Bearer auth, int64-safe JSON parse, and error-message
+// format as the rest of the API surface.
+
+/**
+ * Issue a request that carries neither a request body nor a meaningful response
+ * body (thread delete / join / leave). Mirrors postJson's timeout, Bearer auth,
+ * and error-message format. A 2xx with an empty body resolves to void.
+ */
+async function requestNoBody(
+  apiUrl: string,
+  botToken: string,
+  method: "POST" | "DELETE",
+  path: string,
+  signal?: AbortSignal,
+): Promise<void> {
+  const url = `${apiUrl.replace(/\/+$/, "")}${path}`;
+  const effectiveSignal = signal ?? AbortSignal.timeout(DEFAULT_TIMEOUT_MS);
+  const resp = await fetch(url, {
+    method,
+    headers: { Authorization: `Bearer ${botToken}` },
+    signal: effectiveSignal,
+  });
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => "");
+    throw new Error(`Octo API ${path} failed (${resp.status}): ${text || resp.statusText}`);
+  }
+}
+
+/** Create a thread under a parent group. POST /v1/bot/groups/{groupNo}/threads */
+export async function createThread(params: {
+  apiUrl: string;
+  botToken: string;
+  groupNo: string;
+  name: string;
+  /** Optional: anchor the thread to the message it was started from. */
+  sourceMessageId?: number;
+  signal?: AbortSignal;
+}): Promise<Thread | undefined> {
+  const body: Record<string, unknown> = { name: params.name };
+  if (params.sourceMessageId != null) body.source_message_id = params.sourceMessageId;
+  return await postJson<Thread>(
+    params.apiUrl,
+    params.botToken,
+    `/v1/bot/groups/${encodeURIComponent(params.groupNo)}/threads`,
+    body,
+    params.signal,
+  );
+}
+
+/** List threads under a parent group. GET /v1/bot/groups/{groupNo}/threads */
+export async function listThreads(params: {
+  apiUrl: string;
+  botToken: string;
+  groupNo: string;
+  signal?: AbortSignal;
+}): Promise<Thread[]> {
+  const data = await getJson<Record<string, unknown>>(
+    params.apiUrl,
+    params.botToken,
+    `/v1/bot/groups/${encodeURIComponent(params.groupNo)}/threads`,
+    params.signal,
+  );
+  // Tolerate both a bare array and a `{ threads: [...] }` envelope, mirroring
+  // getGroupMembers' defensive shape handling.
+  const threads = Array.isArray(data?.threads)
+    ? data.threads
+    : Array.isArray(data)
+      ? data
+      : [];
+  return threads as Thread[];
+}
+
+/** Get a single thread. GET /v1/bot/groups/{groupNo}/threads/{shortId} */
+export async function getThread(params: {
+  apiUrl: string;
+  botToken: string;
+  groupNo: string;
+  shortId: string;
+  signal?: AbortSignal;
+}): Promise<Thread> {
+  return await getJson<Thread>(
+    params.apiUrl,
+    params.botToken,
+    `/v1/bot/groups/${encodeURIComponent(params.groupNo)}/threads/${encodeURIComponent(params.shortId)}`,
+    params.signal,
+  );
+}
+
+/** Delete a thread. DELETE /v1/bot/groups/{groupNo}/threads/{shortId} */
+export async function deleteThread(params: {
+  apiUrl: string;
+  botToken: string;
+  groupNo: string;
+  shortId: string;
+  signal?: AbortSignal;
+}): Promise<void> {
+  await requestNoBody(
+    params.apiUrl,
+    params.botToken,
+    "DELETE",
+    `/v1/bot/groups/${encodeURIComponent(params.groupNo)}/threads/${encodeURIComponent(params.shortId)}`,
+    params.signal,
+  );
+}
+
+/** List a thread's members. GET /v1/bot/groups/{groupNo}/threads/{shortId}/members */
+export async function listThreadMembers(params: {
+  apiUrl: string;
+  botToken: string;
+  groupNo: string;
+  shortId: string;
+  signal?: AbortSignal;
+}): Promise<ThreadMember[]> {
+  const data = await getJson<Record<string, unknown>>(
+    params.apiUrl,
+    params.botToken,
+    `/v1/bot/groups/${encodeURIComponent(params.groupNo)}/threads/${encodeURIComponent(params.shortId)}/members`,
+    params.signal,
+  );
+  const members = Array.isArray(data?.members)
+    ? data.members
+    : Array.isArray(data)
+      ? data
+      : [];
+  return members as ThreadMember[];
+}
+
+/** Join a thread. POST /v1/bot/groups/{groupNo}/threads/{shortId}/join */
+export async function joinThread(params: {
+  apiUrl: string;
+  botToken: string;
+  groupNo: string;
+  shortId: string;
+  signal?: AbortSignal;
+}): Promise<void> {
+  await requestNoBody(
+    params.apiUrl,
+    params.botToken,
+    "POST",
+    `/v1/bot/groups/${encodeURIComponent(params.groupNo)}/threads/${encodeURIComponent(params.shortId)}/join`,
+    params.signal,
+  );
+}
+
+/** Leave a thread. POST /v1/bot/groups/{groupNo}/threads/{shortId}/leave */
+export async function leaveThread(params: {
+  apiUrl: string;
+  botToken: string;
+  groupNo: string;
+  shortId: string;
+  signal?: AbortSignal;
+}): Promise<void> {
+  await requestNoBody(
+    params.apiUrl,
+    params.botToken,
+    "POST",
+    `/v1/bot/groups/${encodeURIComponent(params.groupNo)}/threads/${encodeURIComponent(params.shortId)}/leave`,
+    params.signal,
+  );
 }

--- a/src/octo/channel-id.ts
+++ b/src/octo/channel-id.ts
@@ -1,0 +1,55 @@
+// Forked from openclaw-channel-octo v1.0.13 (2026-06-04)
+// Source: https://github.com/Mininglamp-OSS/openclaw-channel-octo
+//   - constants.ts (THREAD_ID_SEPARATOR)
+//   - group-md.ts (extractParentGroupNo / extractThreadShortId / isThreadChannelId)
+
+/**
+ * CommunityTopic (thread) channel-id helpers.
+ *
+ * Octo encodes a thread's channel_id as `<groupNo>____<shortId>` — the parent
+ * group number, four underscores, then the thread short id. A plain group's
+ * channel_id has no separator. These pure functions are the single place that
+ * knows the composite format, so callers that need the parent group number
+ * (e.g. roster / @-mention lookups that must hit `/groups/{groupNo}/members`)
+ * or the thread short id never re-implement the split and drift apart.
+ *
+ * Splitting always uses the FIRST `____` occurrence (`indexOf`), so a shortId
+ * that itself contains the separator stays intact on the right-hand side.
+ */
+
+/**
+ * Separator between parent group_no and thread short_id in Octo's
+ * CommunityTopic channel-id format (`<groupNo>____<shortId>`, 4 underscores).
+ */
+export const THREAD_ID_SEPARATOR = "____";
+
+/**
+ * Extract the parent group number from a channelId.
+ * Thread channelId format: "groupNo____shortId" → "groupNo".
+ * Group channelId format: "groupNo" → "groupNo" (returned unchanged).
+ */
+export function extractParentGroupNo(channelId: string): string {
+  const sep = channelId.indexOf(THREAD_ID_SEPARATOR);
+  return sep >= 0 ? channelId.slice(0, sep) : channelId;
+}
+
+/**
+ * Extract the thread shortId from a channelId.
+ * Only thread channelIds contain a shortId; group channelIds return null.
+ *
+ * Edge case: if channelId ends with "____" (no shortId portion), returns null.
+ * Callers that require a non-empty shortId should check for falsy values.
+ */
+export function extractThreadShortId(channelId: string): string | null {
+  const sep = channelId.indexOf(THREAD_ID_SEPARATOR);
+  if (sep < 0) return null;
+  const id = channelId.slice(sep + THREAD_ID_SEPARATOR.length);
+  return id || null;
+}
+
+/**
+ * Check if a channelId is a thread (CommunityTopic) composite id.
+ */
+export function isThreadChannelId(channelId: string): boolean {
+  return channelId.includes(THREAD_ID_SEPARATOR);
+}

--- a/src/octo/types.ts
+++ b/src/octo/types.ts
@@ -95,6 +95,30 @@ export enum ChannelType {
   CommunityTopic = 5,
 }
 
+/**
+ * A thread (CommunityTopic) under a parent group, as returned by the Octo bot
+ * thread lifecycle endpoints. A thread's channel_id is the composite
+ * `<groupNo>____<shortId>` (see octo/channel-id.ts).
+ */
+export interface Thread {
+  /** Thread short id; the right-hand side of the composite channel_id. */
+  short_id: string;
+  name: string;
+  /** uid of the member who created the thread. */
+  creator_uid: string;
+  /** Lifecycle status flag (server-defined). Absent on the create response. */
+  status?: number;
+  /** Current member count. Present on getThread. */
+  member_count?: number;
+}
+
+/** A single member of a thread, as returned by listThreadMembers. */
+export interface ThreadMember {
+  uid: string;
+  /** Member role within the thread (server-defined). */
+  role: number;
+}
+
 /** Message content types */
 export enum MessageType {
   Text = 1,


### PR DESCRIPTION
## Phase 1 of #88 — thread routing + composite channel_id parsing + thread lifecycle endpoints

Parity with `openclaw-channel-octo`. This is the first of three serial phases
(`P1 → P2 → P3`); it deliberately does **not** touch server-driven GROUP.md /
THREAD.md injection (P2/P3). Scope is routing + endpoints + types only.

### What changed

- **`src/octo/channel-id.ts`** (new) — `THREAD_ID_SEPARATOR = "____"` plus pure
  helpers `extractParentGroupNo` / `extractThreadShortId` / `isThreadChannelId`.
  Splitting always uses the first `____` occurrence, so a short id that itself
  contains the separator stays intact.
- **`src/octo/api.ts`** — restores the seven bot thread lifecycle endpoints that
  were removed at fork time (`create` / `list` / `get` / `delete` / `members` /
  `join` / `leave`). Path / method / auth are a verbatim restore of upstream;
  each call is routed through the existing `postJson` / `getJson` helpers (and a
  small no-body helper) so it shares the same timeout, `Bearer` auth, int64-safe
  JSON parse, and error-message format as the rest of the client. Adds
  `Thread` / `ThreadMember` types.
- **`src/group-context.ts`** — `refreshMembers` now resolves the **parent group
  number** before calling `/v1/bot/groups/{groupNo}/members`. A thread roster
  lookup with the composite id would otherwise 404. All caches (memory + DB +
  robot flags) stay keyed by the full `channel_id`, so a thread keeps its own
  isolated roster view.
- **`src/group-config.ts`** — `loadGroupConfig` now splits a composite thread
  `channel_id` (see path-semantics note below).

Threads get per-channel session / cwd / memory isolation for free: the composite
`channel_id` is already the session key, so a thread never shares its parent
group's partition.

### ⚠️ Path-semantics change (redline 5)

Previously a thread `channel_id` was used verbatim as the group-config filename
(`<groupNo>____<shortId>.md`). After this change:

- A plain group is unchanged: `<groupNo>.md`.
- A thread reads its **own** `<shortId>.md` and does **not** inherit the parent
  group's `<groupNo>.md` (decision A from the approved plan: a thread injects its
  own file only).
- **Backward compatibility:** if `<shortId>.md` is absent, `loadGroupConfig`
  falls back to the legacy whole-composite `<groupNo>____<shortId>.md` filename,
  so existing deployments that dropped a file under the old name keep working.

Operators who relied on the old whole-composite filename get a transparent
fallback; new thread instruction files should be named by short id.

### Testing

- `____` parsing boundary cases (no separator, multiple separators → first wins,
  empty segments).
- All seven thread endpoints assert correct path, method, and
  `Authorization: Bearer <botToken>`.
- Thread composite id routes to a session distinct from its parent group.
- Legacy whole-composite filename still loads (redline 5 compat).
- Thread roster resolves to the parent group number (redline 6).
- Full suite green: **1132 tests / 58 files** (baseline 1096 / 56, no regression).

Part of #88 (Phase 1; P2/P3 tracked separately).

> Draft: opened for line-by-line review. Promotion to a ready PR happens only
> after review + deploy + green tests are confirmed.

