### PR TITLE
fix(thread): carry createThread sourceMessageId as int64-safe string

### DIFF
--- a/src/__tests__/thread-api.test.ts
+++ b/src/__tests__/thread-api.test.ts
@@ -76,10 +76,10 @@ describe('createThread', () => {
     fetchMock.mockResolvedValueOnce(
       mockJsonResponse({ short_id: SHORT, name: 'topic', creator_uid: 'u1' }),
     );
-    await createThread({ ...BASE, groupNo: GROUP, name: 'topic', sourceMessageId: 42 });
+    await createThread({ ...BASE, groupNo: GROUP, name: 'topic', sourceMessageId: '42' });
     expect(JSON.parse(call().init.body as string)).toEqual({
       name: 'topic',
-      source_message_id: 42,
+      source_message_id: '42',
     });
   });
 });

--- a/src/__tests__/thread-api.test.ts
+++ b/src/__tests__/thread-api.test.ts
@@ -72,15 +72,34 @@ describe('createThread', () => {
     expect(out).toEqual({ short_id: SHORT, name: 'topic', creator_uid: 'u1' });
   });
 
-  it('includes source_message_id only when provided', async () => {
+  it('serializes source_message_id as a bare int64 number with full precision', async () => {
     fetchMock.mockResolvedValueOnce(
       mockJsonResponse({ short_id: SHORT, name: 'topic', creator_uid: 'u1' }),
     );
-    await createThread({ ...BASE, groupNo: GROUP, name: 'topic', sourceMessageId: '42' });
-    expect(JSON.parse(call().init.body as string)).toEqual({
-      name: 'topic',
-      source_message_id: '42',
-    });
+    // 19-digit snowflake well beyond Number.MAX_SAFE_INTEGER (2^53-1 = 9007199254740991).
+    const bigId = '2071497871135346688';
+    await createThread({ ...BASE, groupNo: GROUP, name: 'topic', sourceMessageId: bigId });
+
+    // Assert on the raw JSON *text* (not JSON.parse, which would itself truncate
+    // the id through a JS number): the id is a bare number literal, not quoted.
+    const rawBody = call().init.body as string;
+    expect(rawBody).toBe(`{"name":"topic","source_message_id":${bigId}}`);
+    expect(rawBody).not.toContain('"source_message_id":"');
+    const idMatch = rawBody.match(/"source_message_id":(-?\d+)/);
+    expect(idMatch?.[1]).toBe(bigId);
+  });
+
+  it('does not truncate ids that exceed 2^53 (precision boundary)', async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockJsonResponse({ short_id: SHORT, name: 'topic', creator_uid: 'u1' }),
+    );
+    // 2^53 + 1 — the canonical value a JS number rounds down to 9007199254740992.
+    const boundaryId = '9007199254740993';
+    await createThread({ ...BASE, groupNo: GROUP, name: 'topic', sourceMessageId: boundaryId });
+
+    const rawBody = call().init.body as string;
+    expect(rawBody).toContain(`"source_message_id":${boundaryId}`);
+    expect(rawBody).not.toContain('9007199254740992');
   });
 });
 

--- a/src/octo/api.ts
+++ b/src/octo/api.ts
@@ -540,8 +540,9 @@ export async function createThread(params: {
   botToken: string;
   groupNo: string;
   name: string;
-  /** Optional: anchor the thread to the message it was started from. */
-  sourceMessageId?: number;
+  /** Optional: anchor the thread to the message it was started from.
+   *  Carried as a string to stay int64-safe (avoids JS number precision loss). */
+  sourceMessageId?: string;
   signal?: AbortSignal;
 }): Promise<Thread | undefined> {
   const body: Record<string, unknown> = { name: params.name };

--- a/src/octo/api.ts
+++ b/src/octo/api.ts
@@ -534,19 +534,41 @@ async function requestNoBody(
   }
 }
 
+/**
+ * Serialize an int64 id (e.g. a snowflake message id) into a request body as a
+ * *bare JSON number* with full precision preserved.
+ *
+ * The Octo backend requires `source_message_id` to be a JSON number — a quoted
+ * string is rejected with 400 request_invalid. But a 19-digit snowflake exceeds
+ * Number.MAX_SAFE_INTEGER (2^53-1), so the value must never pass through a JS
+ * `number`, which would silently truncate it. We therefore keep it as a string
+ * end-to-end and hand it to JSON.stringify verbatim via JSON.rawJSON (Node >=21),
+ * yielding wire JSON such as `"source_message_id":2071497871135346688`.
+ *
+ * JSON.rawJSON is not in the ES2022 lib typings yet, so it is accessed through a
+ * narrow cast rather than `any`.
+ */
+function rawInt64(value: string): unknown {
+  if (!/^-?[0-9]+$/.test(value)) {
+    throw new Error(`int64 id must be a base-10 integer string, got: ${value}`);
+  }
+  return (JSON as unknown as { rawJSON(text: string): unknown }).rawJSON(value);
+}
+
 /** Create a thread under a parent group. POST /v1/bot/groups/{groupNo}/threads */
 export async function createThread(params: {
   apiUrl: string;
   botToken: string;
   groupNo: string;
   name: string;
-  /** Optional: anchor the thread to the message it was started from.
-   *  Carried as a string to stay int64-safe (avoids JS number precision loss). */
+  /** Optional: anchor the thread to the message it was started from. Accepted as
+   *  a string to stay int64-safe, but emitted on the wire as a bare JSON number
+   *  (the server rejects a quoted value); see rawInt64. */
   sourceMessageId?: string;
   signal?: AbortSignal;
 }): Promise<Thread | undefined> {
   const body: Record<string, unknown> = { name: params.name };
-  if (params.sourceMessageId != null) body.source_message_id = params.sourceMessageId;
+  if (params.sourceMessageId != null) body.source_message_id = rawInt64(params.sourceMessageId);
   return await postJson<Thread>(
     params.apiUrl,
     params.botToken,


### PR DESCRIPTION
Part of #88

## What

`createThread` anchors a thread to a `source_message_id`. Live testing (XIN-173) established the server contract:

- The backend requires `source_message_id` to be a **JSON number** — a quoted string is rejected with `400 request_invalid`.
- The id is an int64 snowflake (19 digits) that exceeds `Number.MAX_SAFE_INTEGER` (2^53-1), so it must **never** pass through a JS `number`, which would silently truncate it.

The earlier pass-through (`body.source_message_id = params.sourceMessageId`) produced a quoted string (→ 400), so this reworks the serialization.

## Changes

- `src/octo/api.ts` — `createThread.sourceMessageId` stays typed `string` (safe for JS callers, no 2^53 truncation), but is now serialized verbatim as a **bare JSON number literal** via `JSON.rawJSON` (Node ≥21; engines requires `>=22`). New `rawInt64` helper validates the value is a base-10 integer string and hands it to `JSON.stringify` unquoted. `postJson` is untouched — `rawJSON` is recognized by the native stringify.
- `src/__tests__/thread-api.test.ts` — assertions now run on the **raw request body text** (not `JSON.parse`, which would itself truncate via a JS number): a 19-digit snowflake (`2071497871135346688`) and the 2^53+1 boundary (`9007199254740993`) are emitted as unquoted number literals with full precision intact.

Scope held to the `source_message_id` serialization path + its test — no other fields touched. Still zero production callers.

## Wire format (verified by test)

```
{"name":"topic","source_message_id":2071497871135346688}
```

Bare int64 number, no quotes, full 19-digit precision.

## Verification

- `npm run type-check` — clean
- `npm run lint` — clean (`--max-warnings 0`)
- `npm test` — 1133 passed (58 files), no regressions
