### PR TITLE
fix(session-store): dedupe cold-start double-write via partial unique index

### DIFF
--- a/src/__tests__/e2e.test.ts
+++ b/src/__tests__/e2e.test.ts
@@ -595,11 +595,16 @@ describe('E2E smoke tests', () => {
   // --- 6. Multi-turn history accumulates ---
 
   it('Multi-turn DM: history accumulates across messages', async () => {
+    // message_seq is monotonic per channel in WuKongIM, so two distinct inbound
+    // messages always carry distinct seqs. Use realistic seqs here — the
+    // (session_id, role, message_seq) uniqueness contract treats a repeated
+    // (user, seq) as the same message (seq236 double-write guard), which would
+    // otherwise drop the second turn if both reused the makeDmMsg default seq.
     mockQueryYield('First reply');
-    await simulateMessage(makeDmMsg('Hello'), config, store, router, groupContext, streamRelay);
+    await simulateMessage(makeDmMsg('Hello', { message_seq: 1 }), config, store, router, groupContext, streamRelay);
 
     mockQueryYield('Second reply');
-    await simulateMessage(makeDmMsg('Follow up'), config, store, router, groupContext, streamRelay);
+    await simulateMessage(makeDmMsg('Follow up', { message_seq: 2 }), config, store, router, groupContext, streamRelay);
 
     expect(queryAgent).toHaveBeenCalledTimes(2);
 

--- a/src/__tests__/session-store.test.ts
+++ b/src/__tests__/session-store.test.ts
@@ -333,6 +333,215 @@ describe('SessionStore G10 message_seq migration (Q1-2)', () => {
   });
 });
 
+// XIN-145 root cause / XIN-154 fix: the G4 cold-start backfill (seedHistoryFromApi)
+// and the live inbound path both persist the SAME triggering message. With a plain
+// INSERT and no uniqueness, that left two identical (session_id, role, message_seq)
+// rows (the seq236 double-write). The fix is a PARTIAL unique index on
+// (session_id, role, message_seq) WHERE message_seq IS NOT NULL + INSERT OR IGNORE.
+//
+// The index is keyed on role (not just session_id+seq): a user turn and the bot's
+// reply legitimately share the inbound seq (agent-bridge stores the assistant turn
+// with msg.message_seq — see appendAssistant at index.ts), so collapsing on seq
+// alone would drop every bot reply. The index is partial (WHERE message_seq IS NOT
+// NULL) because assistant / legacy / no-seq turns carry NULL seq and must remain
+// unconstrained.
+describe('SessionStore — seq236 double-write root-cause fix (partial unique index)', () => {
+  let adapter: DbAdapter;
+  let store: SessionStore;
+
+  beforeEach(() => {
+    adapter = createAdapter(':memory:');
+    store = new SessionStore(adapter);
+    store.init();
+  });
+
+  afterEach(() => {
+    store.close();
+  });
+
+  function countSeq(sessionId: string, role: string, seq: number): number {
+    return (
+      adapter
+        .prepare(
+          'SELECT COUNT(*) AS n FROM messages WHERE session_id = ? AND role = ? AND message_seq = ?',
+        )
+        .get(sessionId, role, seq) as { n: number }
+    ).n;
+  }
+
+  it('cold-start double-write of the same inbound (seq 236) collapses to ONE row', () => {
+    store.getOrCreate('g1', 'ch1', 2);
+    // Path 1 — G4 cold-start backfill seeds the just-arrived inbound from the API.
+    store.appendUser('g1', 'message at seq 236', 236, 'Alice');
+    // Path 2 — the live inbound handler appends the very same message moments later.
+    store.appendUser('g1', 'message at seq 236', 236, 'Alice');
+
+    // Pre-fix this was 2 rows (the bug). The partial unique index + INSERT OR
+    // IGNORE make the second write a no-op, so seq 236 is no longer doubled.
+    expect(countSeq('g1', 'user', 236)).toBe(1);
+  });
+
+  it('keeps the FIRST write when a duplicate seq arrives (INSERT OR IGNORE, earliest wins)', () => {
+    store.getOrCreate('g1', 'ch1', 2);
+    store.appendUser('g1', 'first copy', 236, 'Alice');
+    store.appendUser('g1', 'second copy (ignored)', 236, 'Alice');
+
+    const history = store.buildHistoryPrefix('g1', 10);
+    expect(history).toContain('first copy');
+    expect(history).not.toContain('second copy (ignored)');
+  });
+
+  it('a user turn and the bot reply may SHARE a seq — role keeps them distinct', () => {
+    store.getOrCreate('g1', 'ch1', 2);
+    store.appendUser('g1', 'the question', 236, 'Alice');
+    // The assistant reply is stored with the inbound seq (segmentation relies on
+    // this). It must NOT be swallowed by the user row at the same seq.
+    store.appendAssistant('g1', 'the answer', 236, 'OctoBot');
+
+    expect(countSeq('g1', 'user', 236)).toBe(1);
+    expect(countSeq('g1', 'assistant', 236)).toBe(1);
+  });
+
+  it('the index is genuinely PARTIAL — NULL message_seq rows are never constrained', () => {
+    store.getOrCreate('g1', 'ch1', 2);
+    // assistant / legacy / no-seq turns all carry NULL seq; any number of them
+    // must insert fine (WHERE message_seq IS NOT NULL exempts them).
+    store.appendAssistant('g1', 'reply A', undefined, 'OctoBot');
+    store.appendAssistant('g1', 'reply B', undefined, 'OctoBot');
+    store.appendUser('g1', 'no-seq one', undefined, 'Alice');
+    store.appendUser('g1', 'no-seq two', undefined, 'Alice');
+
+    const nullCount = (
+      adapter
+        .prepare('SELECT COUNT(*) AS n FROM messages WHERE message_seq IS NULL')
+        .get() as { n: number }
+    ).n;
+    expect(nullCount).toBe(4);
+  });
+});
+
+describe('SessionStore — existing-row dedup migration (seq236 backfill)', () => {
+  // Build a pre-fix messages table (current columns, NO unique index) and seed it
+  // with the duplicate rows the bug produced, so we can exercise the migration.
+  function seedDirtyDb(): DbAdapter {
+    const adapter = createAdapter(':memory:');
+    adapter.exec(`
+      CREATE TABLE sessions (
+        id TEXT PRIMARY KEY,
+        channel_id TEXT NOT NULL,
+        channel_type INTEGER NOT NULL,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
+      CREATE TABLE messages (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        session_id TEXT NOT NULL,
+        role TEXT NOT NULL,
+        content TEXT NOT NULL,
+        timestamp INTEGER NOT NULL,
+        message_seq INTEGER,
+        from_name TEXT
+      );
+      INSERT INTO sessions VALUES ('g1', 'ch1', 2, 0, 0);
+      -- Doubled user inbound at seq 236 (the bug). Earliest id must survive.
+      INSERT INTO messages (session_id, role, content, timestamp, message_seq, from_name)
+        VALUES ('g1', 'user', 'seq236 first', 10, 236, 'Alice');
+      INSERT INTO messages (session_id, role, content, timestamp, message_seq, from_name)
+        VALUES ('g1', 'user', 'seq236 second', 11, 236, 'Alice');
+      -- Assistant reply sharing seq 236 — NOT a duplicate, must be preserved.
+      INSERT INTO messages (session_id, role, content, timestamp, message_seq, from_name)
+        VALUES ('g1', 'assistant', 'seq236 answer', 12, 236, 'OctoBot');
+      -- A distinct user seq — untouched.
+      INSERT INTO messages (session_id, role, content, timestamp, message_seq, from_name)
+        VALUES ('g1', 'user', 'seq237', 13, 237, 'Alice');
+      -- NULL-seq rows (assistant / legacy) — never part of the uniqueness contract.
+      INSERT INTO messages (session_id, role, content, timestamp, message_seq, from_name)
+        VALUES ('g1', 'assistant', 'no-seq A', 14, NULL, 'OctoBot');
+      INSERT INTO messages (session_id, role, content, timestamp, message_seq, from_name)
+        VALUES ('g1', 'assistant', 'no-seq B', 15, NULL, 'OctoBot');
+    `);
+    return adapter;
+  }
+
+  it('collapses duplicate (session_id, role, seq) rows, preserves everything else, and is idempotent', () => {
+    const adapter = seedDirtyDb();
+    const store = new SessionStore(adapter);
+
+    // First pass: one duplicate user row removed; row accounting reported.
+    const first = store.dedupeMessagesBySeq();
+    expect(first.before).toBe(6);
+    expect(first.removed).toBe(1);
+    expect(first.after).toBe(5);
+    expect(first.after).toBe(first.before - first.removed);
+
+    // Idempotent re-entrancy: a second pass over clean data removes nothing.
+    const second = store.dedupeMessagesBySeq();
+    expect(second.before).toBe(5);
+    expect(second.removed).toBe(0);
+    expect(second.after).toBe(5);
+
+    // The earliest (MIN id) duplicate survives.
+    const userSeq236 = adapter
+      .prepare(
+        "SELECT content FROM messages WHERE session_id = 'g1' AND role = 'user' AND message_seq = 236",
+      )
+      .all() as Array<{ content: string }>;
+    expect(userSeq236).toHaveLength(1);
+    expect(userSeq236[0].content).toBe('seq236 first');
+
+    // The assistant reply sharing seq 236 is preserved (role keeps it distinct).
+    const asstSeq236 = (
+      adapter
+        .prepare(
+          "SELECT COUNT(*) AS n FROM messages WHERE session_id = 'g1' AND role = 'assistant' AND message_seq = 236",
+        )
+        .get() as { n: number }
+    ).n;
+    expect(asstSeq236).toBe(1);
+
+    // NULL-seq rows are untouched by the migration.
+    const nullCount = (
+      adapter
+        .prepare('SELECT COUNT(*) AS n FROM messages WHERE message_seq IS NULL')
+        .get() as { n: number }
+    ).n;
+    expect(nullCount).toBe(2);
+
+    store.close();
+  });
+
+  it('init() dedupes a dirty DB then enforces uniqueness on subsequent writes', () => {
+    const adapter = seedDirtyDb();
+    const store = new SessionStore(adapter);
+
+    // init() must dedupe BEFORE creating the unique index (else index creation
+    // would fail on the pre-existing duplicates).
+    expect(() => store.init()).not.toThrow();
+
+    const userSeq236 = (
+      adapter
+        .prepare(
+          "SELECT COUNT(*) AS n FROM messages WHERE session_id = 'g1' AND role = 'user' AND message_seq = 236",
+        )
+        .get() as { n: number }
+    ).n;
+    expect(userSeq236).toBe(1);
+
+    // Going forward, a re-arriving duplicate inbound is ignored, not doubled.
+    store.appendUser('g1', 'seq236 re-arrival', 236, 'Alice');
+    const afterAppend = (
+      adapter
+        .prepare(
+          "SELECT COUNT(*) AS n FROM messages WHERE session_id = 'g1' AND role = 'user' AND message_seq = 236",
+        )
+        .get() as { n: number }
+    ).n;
+    expect(afterAppend).toBe(1);
+
+    store.close();
+  });
+});
+
 describe('SessionStore — v0.3 SDK session ids (persistent sessions)', () => {
   let adapter: DbAdapter;
   let store: SessionStore;

--- a/src/__tests__/session-store.test.ts
+++ b/src/__tests__/session-store.test.ts
@@ -418,6 +418,25 @@ describe('SessionStore — seq236 double-write root-cause fix (partial unique in
     ).n;
     expect(nullCount).toBe(4);
   });
+
+  it('does NOT constrain the seq=0 cron sentinel — multiple cron rounds all persist', () => {
+    // A synthetic cron fire carries message_seq=0 (no real wire seq; see
+    // index.ts). Multiple rounds share seq=0 and are legitimately distinct. The
+    // partial index is `WHERE message_seq > 0`, so the sentinel is exempt and
+    // INSERT OR IGNORE must NOT collapse these (reviewer's data-loss blocker).
+    store.getOrCreate('g1', 'ch1', 2);
+    store.appendUser('g1', 'cron round 1', 0, 'Scheduler');
+    store.appendAssistant('g1', 'cron reply 1', 0, 'OctoBot');
+    store.appendUser('g1', 'cron round 2', 0, 'Scheduler');
+    store.appendAssistant('g1', 'cron reply 2', 0, 'OctoBot');
+
+    const count = (
+      adapter
+        .prepare("SELECT COUNT(*) AS n FROM messages WHERE session_id = 'g1' AND message_seq = 0")
+        .get() as { n: number }
+    ).n;
+    expect(count).toBe(4);
+  });
 });
 
 describe('SessionStore — existing-row dedup migration (seq236 backfill)', () => {
@@ -459,6 +478,17 @@ describe('SessionStore — existing-row dedup migration (seq236 backfill)', () =
         VALUES ('g1', 'assistant', 'no-seq A', 14, NULL, 'OctoBot');
       INSERT INTO messages (session_id, role, content, timestamp, message_seq, from_name)
         VALUES ('g1', 'assistant', 'no-seq B', 15, NULL, 'OctoBot');
+      -- seq=0 SENTINEL: synthetic cron fires carry message_seq=0 (no real wire
+      -- seq; see index.ts). Multiple cron rounds legitimately share seq=0 and are
+      -- DISTINCT rows. Folding them on (session, role, seq) would delete real
+      -- data — the reviewer's data-loss blocker. The migration must leave all of
+      -- these intact (predicate is message_seq > 0, not IS NOT NULL).
+      INSERT INTO messages (session_id, role, content, timestamp, message_seq, from_name)
+        VALUES ('g1', 'user', 'cron round 1', 16, 0, 'Scheduler');
+      INSERT INTO messages (session_id, role, content, timestamp, message_seq, from_name)
+        VALUES ('g1', 'user', 'cron round 2', 17, 0, 'Scheduler');
+      INSERT INTO messages (session_id, role, content, timestamp, message_seq, from_name)
+        VALUES ('g1', 'assistant', 'cron reply 1', 18, 0, 'OctoBot');
     `);
     return adapter;
   }
@@ -467,18 +497,19 @@ describe('SessionStore — existing-row dedup migration (seq236 backfill)', () =
     const adapter = seedDirtyDb();
     const store = new SessionStore(adapter);
 
-    // First pass: one duplicate user row removed; row accounting reported.
+    // First pass: one duplicate user row removed (seq236 only); row accounting
+    // reported. The three seq=0 cron rounds are NOT touched.
     const first = store.dedupeMessagesBySeq();
-    expect(first.before).toBe(6);
+    expect(first.before).toBe(9);
     expect(first.removed).toBe(1);
-    expect(first.after).toBe(5);
+    expect(first.after).toBe(8);
     expect(first.after).toBe(first.before - first.removed);
 
     // Idempotent re-entrancy: a second pass over clean data removes nothing.
     const second = store.dedupeMessagesBySeq();
-    expect(second.before).toBe(5);
+    expect(second.before).toBe(8);
     expect(second.removed).toBe(0);
-    expect(second.after).toBe(5);
+    expect(second.after).toBe(8);
 
     // The earliest (MIN id) duplicate survives.
     const userSeq236 = adapter
@@ -506,6 +537,19 @@ describe('SessionStore — existing-row dedup migration (seq236 backfill)', () =
         .get() as { n: number }
     ).n;
     expect(nullCount).toBe(2);
+
+    // DATA-LOSS GUARD (reviewer blocker): every seq=0 cron round survives — the
+    // migration never folds the sentinel. All three (2 user + 1 assistant) remain.
+    const cronRows = adapter
+      .prepare(
+        "SELECT content FROM messages WHERE session_id = 'g1' AND message_seq = 0 ORDER BY id",
+      )
+      .all() as Array<{ content: string }>;
+    expect(cronRows.map((r) => r.content)).toEqual([
+      'cron round 1',
+      'cron round 2',
+      'cron reply 1',
+    ]);
 
     store.close();
   });
@@ -537,6 +581,17 @@ describe('SessionStore — existing-row dedup migration (seq236 backfill)', () =
         .get() as { n: number }
     ).n;
     expect(afterAppend).toBe(1);
+
+    // The seq=0 cron rounds survived init()'s migration AND a fresh seq=0 round
+    // appends fine afterwards (the partial index excludes the sentinel, so
+    // INSERT OR IGNORE does not suppress it).
+    store.appendUser('g1', 'cron round 3', 0, 'Scheduler');
+    const cronCount = (
+      adapter
+        .prepare("SELECT COUNT(*) AS n FROM messages WHERE session_id = 'g1' AND message_seq = 0")
+        .get() as { n: number }
+    ).n;
+    expect(cronCount).toBe(4);
 
     store.close();
   });

--- a/src/session-store.ts
+++ b/src/session-store.ts
@@ -149,13 +149,15 @@ export class SessionStore {
     // idempotent. Keyed on role because a user turn and the bot's reply
     // legitimately share the inbound seq (appendAssistant is called with the
     // inbound message_seq), so a session_id+seq-only index would wrongly forbid
-    // the reply. WHERE message_seq IS NOT NULL keeps it partial: assistant /
-    // legacy / no-seq turns carry NULL seq and stay unconstrained (NULLs are
-    // never equal to one another, but the explicit predicate documents intent and
-    // keeps the index small).
+    // the reply. The predicate is `message_seq > 0` (not merely IS NOT NULL):
+    // a synthetic cron fire carries the seq=0 SENTINEL (no real wire seq; see
+    // index.ts), and multiple cron rounds legitimately share seq=0 — constraining
+    // them would silently drop real rounds via INSERT OR IGNORE. So only real
+    // positive wire seqs are deduped; NULL- and 0/negative-seq turns stay
+    // unconstrained. `> 0` matches the existing "real seq" predicate in index.ts.
     this.adapter.exec(
       'CREATE UNIQUE INDEX IF NOT EXISTS idx_messages_session_role_seq ' +
-        'ON messages(session_id, role, message_seq) WHERE message_seq IS NOT NULL',
+        'ON messages(session_id, role, message_seq) WHERE message_seq > 0',
     );
 
     this.selectSession = this.adapter.prepare('SELECT * FROM sessions WHERE id = ?');
@@ -168,8 +170,9 @@ export class SessionStore {
     // row at its message_seq (the "seq236" bug). The cure is a PARTIAL unique
     // index (created above) plus INSERT OR IGNORE here: a re-write of an already
     // stored (session_id, role, message_seq) is silently dropped, making append()
-    // idempotent. NULL-seq rows (assistant / legacy / no-seq turns) are exempt
-    // from the index, so OR IGNORE never suppresses them.
+    // idempotent. The index is partial on `message_seq > 0`, so NULL-seq turns
+    // AND the seq=0 cron sentinel (multiple legit rounds share it) are exempt —
+    // OR IGNORE never suppresses them.
     this.insertMessage = this.adapter.prepare(
       'INSERT OR IGNORE INTO messages (session_id, role, content, timestamp, message_seq, from_name) VALUES (?, ?, ?, ?, ?, ?)',
     );
@@ -205,11 +208,17 @@ export class SessionStore {
   /**
    * XIN-154 existing-row migration: collapse duplicate
    * (session_id, role, message_seq) rows left by the pre-fix seq236 double-write,
-   * keeping the lowest id (the earliest insert) in each group. Rows with NULL
-   * message_seq (assistant / legacy / no-seq turns) are never touched — they are
-   * not part of the uniqueness contract — and rows that merely share a seq across
-   * roles (a user turn and the bot's reply) are preserved because role is part of
-   * the grouping key.
+   * keeping the lowest id (the earliest insert) in each group.
+   *
+   * Only REAL wire seqs (message_seq > 0) participate. Rows are exempt when:
+   *   - message_seq IS NULL (assistant / legacy / no-seq turns), or
+   *   - message_seq <= 0 — notably the seq=0 SENTINEL a synthetic cron fire
+   *     carries (no real wire seq; see index.ts where the cron round stores
+   *     seq=0). Multiple cron rounds legitimately share seq=0, so folding on it
+   *     would delete real data — hence `> 0`, matching the codebase's existing
+   *     "real seq" predicate (`msg.message_seq > 0`).
+   * Rows that merely share a seq across roles (a user turn and the bot's reply)
+   * are preserved because role is part of the grouping key.
    *
    * Wrapped in a single transaction with explicit before/after row accounting: a
    * mismatch between the delete count and the row delta means the table was
@@ -226,8 +235,8 @@ export class SessionStore {
       ).n;
       const result = this.adapter
         .prepare(
-          'DELETE FROM messages WHERE message_seq IS NOT NULL AND id NOT IN (' +
-            'SELECT MIN(id) FROM messages WHERE message_seq IS NOT NULL ' +
+          'DELETE FROM messages WHERE message_seq > 0 AND id NOT IN (' +
+            'SELECT MIN(id) FROM messages WHERE message_seq > 0 ' +
             'GROUP BY session_id, role, message_seq)',
         )
         .run();

--- a/src/session-store.ts
+++ b/src/session-store.ts
@@ -138,13 +138,40 @@ export class SessionStore {
       );
     }
 
+    // XIN-154: collapse any pre-existing seq236-style duplicate rows BEFORE
+    // creating the partial unique index — a unique index cannot be built over a
+    // table that already violates it. Idempotent + transactional (see the method),
+    // so it is safe to run on every startup; on an already-clean DB it deletes
+    // nothing. After this, INSERT OR IGNORE (insertMessage) keeps the table clean.
+    this.dedupeMessagesBySeq();
+
+    // Partial unique index that makes the (session_id, role, message_seq) write
+    // idempotent. Keyed on role because a user turn and the bot's reply
+    // legitimately share the inbound seq (appendAssistant is called with the
+    // inbound message_seq), so a session_id+seq-only index would wrongly forbid
+    // the reply. WHERE message_seq IS NOT NULL keeps it partial: assistant /
+    // legacy / no-seq turns carry NULL seq and stay unconstrained (NULLs are
+    // never equal to one another, but the explicit predicate documents intent and
+    // keeps the index small).
+    this.adapter.exec(
+      'CREATE UNIQUE INDEX IF NOT EXISTS idx_messages_session_role_seq ' +
+        'ON messages(session_id, role, message_seq) WHERE message_seq IS NOT NULL',
+    );
+
     this.selectSession = this.adapter.prepare('SELECT * FROM sessions WHERE id = ?');
     this.insertSession = this.adapter.prepare(
       'INSERT INTO sessions (id, channel_id, channel_type, created_at, updated_at) VALUES (?, ?, ?, ?, ?)',
     );
     this.touchSession = this.adapter.prepare('UPDATE sessions SET updated_at = ? WHERE id = ?');
+    // XIN-145 root cause: the G4 cold-start backfill (seedHistoryFromApi) and the
+    // live inbound path both persisted the SAME triggering message, doubling the
+    // row at its message_seq (the "seq236" bug). The cure is a PARTIAL unique
+    // index (created above) plus INSERT OR IGNORE here: a re-write of an already
+    // stored (session_id, role, message_seq) is silently dropped, making append()
+    // idempotent. NULL-seq rows (assistant / legacy / no-seq turns) are exempt
+    // from the index, so OR IGNORE never suppresses them.
     this.insertMessage = this.adapter.prepare(
-      'INSERT INTO messages (session_id, role, content, timestamp, message_seq, from_name) VALUES (?, ?, ?, ?, ?, ?)',
+      'INSERT OR IGNORE INTO messages (session_id, role, content, timestamp, message_seq, from_name) VALUES (?, ?, ?, ?, ?, ?)',
     );
     this.selectRecentMessages = this.adapter.prepare(
       'SELECT role, content, message_seq, from_name FROM messages WHERE session_id = ? ORDER BY id DESC LIMIT ?',
@@ -173,6 +200,50 @@ export class SessionStore {
     this.deleteExpiredSdkSessions = this.adapter.prepare(
       'DELETE FROM sdk_sessions WHERE updated_at < ?',
     );
+  }
+
+  /**
+   * XIN-154 existing-row migration: collapse duplicate
+   * (session_id, role, message_seq) rows left by the pre-fix seq236 double-write,
+   * keeping the lowest id (the earliest insert) in each group. Rows with NULL
+   * message_seq (assistant / legacy / no-seq turns) are never touched — they are
+   * not part of the uniqueness contract — and rows that merely share a seq across
+   * roles (a user turn and the bot's reply) are preserved because role is part of
+   * the grouping key.
+   *
+   * Wrapped in a single transaction with explicit before/after row accounting: a
+   * mismatch between the delete count and the row delta means the table was
+   * mutated concurrently, so we throw and roll back rather than report a clean
+   * migration over an inconsistent result (防丢数据). Idempotent: a second run over
+   * already-clean data deletes nothing and leaves counts unchanged.
+   */
+  dedupeMessagesBySeq(): { before: number; removed: number; after: number } {
+    const tx = this.adapter.transaction(() => {
+      const before = (
+        this.adapter.prepare('SELECT COUNT(*) AS n FROM messages').get() as {
+          n: number;
+        }
+      ).n;
+      const result = this.adapter
+        .prepare(
+          'DELETE FROM messages WHERE message_seq IS NOT NULL AND id NOT IN (' +
+            'SELECT MIN(id) FROM messages WHERE message_seq IS NOT NULL ' +
+            'GROUP BY session_id, role, message_seq)',
+        )
+        .run();
+      const after = (
+        this.adapter.prepare('SELECT COUNT(*) AS n FROM messages').get() as {
+          n: number;
+        }
+      ).n;
+      if (before - after !== result.changes) {
+        throw new Error(
+          `session-store: dedup row accounting mismatch (before=${before}, after=${after}, deleted=${result.changes}) — rolling back`,
+        );
+      }
+      return { before, removed: result.changes, after };
+    });
+    return tx();
   }
 
   getOrCreate(id: string, channelId: string, channelType: number): Session {


### PR DESCRIPTION
Part of #88

## Problem

On a group cold start, the G4 history backfill (`seedHistoryFromApi`) and the
live inbound handler both persist the *same* triggering message into the
`messages` table. With a plain `INSERT` and no uniqueness, that left two
identical `(session_id, role, message_seq)` rows — the "seq236" double-write
(root cause tracked in the linked issue). `append()` was not idempotent and
`messages` had no `(session_id, message_seq)` constraint.

## Fix

1. **Partial unique index** on `messages(session_id, role, message_seq)
   WHERE message_seq IS NOT NULL`.
   - Keyed on `role`: a user turn and the bot's reply legitimately share the
     inbound `message_seq` (the assistant turn is stored with `msg.message_seq`),
     so a `session_id + message_seq`-only index would wrongly forbid the reply —
     and the existing-row migration would delete every bot reply that shares a
     seq with its user message. Including `role` collapses only the true
     duplicate (the inbound counted twice, always same role).
   - **Partial** (`WHERE message_seq IS NOT NULL`): assistant / legacy / no-seq
     turns carry `NULL` seq and must remain unconstrained.
2. **`append()` → `INSERT OR IGNORE`**: a re-write of an already stored
   `(session_id, role, message_seq)` is silently dropped, so the cold-start
   double-write is a no-op. `NULL`-seq rows are exempt from the index, so
   `OR IGNORE` never suppresses them.
3. **Existing-row dedup migration** (`dedupeMessagesBySeq`, run in `init()`
   before the index is created — a unique index cannot be built over a table
   that already violates it):
   - Keeps the earliest row (`MIN(id)`) per `(session_id, role, message_seq)`,
     deletes the rest; `NULL`-seq rows are never touched.
   - Wrapped in a single transaction with explicit before/after row accounting
     that throws and rolls back on a delta mismatch (no partial migration, no
     lost data).
   - Idempotent: a second run over clean data deletes nothing.

Scope is limited to the session store + migration; no changes to
server-md / events / write-back.

## Tests

New `session-store` tests:
- seq236 cold-start double-write repro → collapses to one row.
- INSERT OR IGNORE keeps the first write (earliest wins).
- user turn + bot reply sharing a seq are preserved (role keeps them distinct).
- the index is genuinely partial — multiple `NULL`-seq rows all insert.
- dedup migration: before/after row accounting, preserves the assistant
  same-seq row and `NULL`-seq rows, and is idempotent across two runs.
- `init()` on a dirty DB dedupes then enforces uniqueness on subsequent writes.

The multi-turn DM e2e fixture now uses realistic monotonic seqs (WuKongIM
assigns `message_seq` monotonically per channel; two distinct inbound messages
never share a seq).

Full suite green: 1138 passed. `type-check` and `lint` clean.
