### PR TITLE
feat(group-md): server-first GROUP.md fetch with cache and local fallback

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -9,6 +9,8 @@
 
   "_comment_group_config_dir": "v1.0: optional directory of per-group instruction files (<groupId>.md), injected as trusted custom instructions. Operator-controlled — keep it OUTSIDE every bot's workspace (the agent can write there) AND non-writable by the gateway user. Omit to disable.",
 
+  "_comment_server_md": "P2-A: set serverMd=true to fetch each group's instructions from the server GROUP.md API (GET /v1/bot/groups/{groupNo}/md) first, falling back to the local groupConfigDir file on any failure (404 / network / no content). The fetched copy is cached under <dataDir>/group-md-cache. Default false = pure local-file behavior (flip off to roll back).",
+
   "sdk": {
     "_comment_anthropic_base_url": "Q1: Optional self-hosted Claude API gateway base URL. Forwarded to the SDK subprocess (scoped). Must be https:// (or http://localhost for dev) — SSRF-validated at boot. Omit to use Anthropic's public endpoint.",
     "_comment_allowed_tools": "Q2: either '*' (allow every tool the SDK exposes) or an explicit string[] whitelist.",

--- a/config.example.json
+++ b/config.example.json
@@ -9,7 +9,7 @@
 
   "_comment_group_config_dir": "v1.0: optional directory of per-group instruction files (<groupId>.md), injected as trusted custom instructions. Operator-controlled — keep it OUTSIDE every bot's workspace (the agent can write there) AND non-writable by the gateway user. Omit to disable.",
 
-  "_comment_server_md": "P2-A: set serverMd=true to fetch each group's instructions from the server GROUP.md API (GET /v1/bot/groups/{groupNo}/md) first, falling back to the local groupConfigDir file on any failure (404 / network / no content). The fetched copy is cached under <dataDir>/group-md-cache. Default false = pure local-file behavior (flip off to roll back).",
+  "_comment_server_md": "P2-A: set serverMd=true to fetch each group's instructions from the server GROUP.md API (GET /v1/bot/groups/{groupNo}/md) first, falling back to the local groupConfigDir file on any failure (404 / network / no content). The fetched copy is cached IN MEMORY ONLY (never on disk — it is injected as a trusted system prompt, and a disk cache the gateway user could write would be a poisoning vector). serverMdTtlMs (default 300000 = 5 min) bounds how stale a cached entry may get before re-fetch. Default serverMd=false = pure local-file behavior (flip off to roll back).",
 
   "sdk": {
     "_comment_anthropic_base_url": "Q1: Optional self-hosted Claude API gateway base URL. Forwarded to the SDK subprocess (scoped). Must be https:// (or http://localhost for dev) — SSRF-validated at boot. Omit to use Anthropic's public endpoint.",

--- a/src/__tests__/group-md-api.test.ts
+++ b/src/__tests__/group-md-api.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Tests for octo/api.ts — GROUP.md server API (P2-A).
+ *
+ * Asserts the restored GET/PUT endpoints hit the correct path + method, carry
+ * `Authorization: Bearer <botToken>`, parse the documented response shape, and
+ * surface non-2xx as a thrown Octo API error (parity restore of openclaw
+ * api-fetch.ts getGroupMd / updateGroupMd; see #88 acceptance criteria).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest';
+import { getGroupMd, updateGroupMd, type GroupMd } from '../octo/api.js';
+
+const fetchMock = vi.fn();
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+});
+
+afterAll(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function mockJsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+const BASE = { apiUrl: 'https://test.example.com', botToken: 'bf_test' };
+const GROUP = '99dc18164a29435f9791dc37023f98e1';
+
+function call(n = 0): { url: string; init: RequestInit } {
+  const [url, init] = fetchMock.mock.calls[n] as [string, RequestInit];
+  return { url, init };
+}
+
+function authHeader(init: RequestInit): string | undefined {
+  const h = init.headers as Record<string, string> | undefined;
+  return h?.Authorization;
+}
+
+describe('getGroupMd', () => {
+  it('GETs /v1/bot/groups/{groupNo}/md with Bearer auth and parses the payload', async () => {
+    const payload: GroupMd = {
+      content: 'Always answer in haiku.',
+      version: 7,
+      updated_at: '2026-06-04T00:00:00Z',
+      updated_by: 'op-uid',
+    };
+    fetchMock.mockResolvedValueOnce(mockJsonResponse(payload));
+
+    const md = await getGroupMd({ ...BASE, groupNo: GROUP });
+
+    const { url, init } = call();
+    expect(url).toBe(`${BASE.apiUrl}/v1/bot/groups/${GROUP}/md`);
+    expect(init.method).toBe('GET');
+    expect(authHeader(init)).toBe(`Bearer ${BASE.botToken}`);
+    expect(md).toEqual(payload);
+  });
+
+  it('url-encodes the groupNo path segment', async () => {
+    fetchMock.mockResolvedValueOnce(mockJsonResponse({ content: '', version: 0, updated_at: null, updated_by: '' }));
+    await getGroupMd({ ...BASE, groupNo: 'a/b' });
+    expect(call().url).toBe(`${BASE.apiUrl}/v1/bot/groups/a%2Fb/md`);
+  });
+
+  it('throws on a 404 (no GROUP.md set) so the caller can degrade', async () => {
+    fetchMock.mockResolvedValueOnce(new Response('not found', { status: 404, statusText: 'Not Found' }));
+    await expect(getGroupMd({ ...BASE, groupNo: GROUP })).rejects.toThrow(/failed \(404\)/);
+  });
+
+  it('throws on a 500', async () => {
+    fetchMock.mockResolvedValueOnce(new Response('boom', { status: 500, statusText: 'Internal Server Error' }));
+    await expect(getGroupMd({ ...BASE, groupNo: GROUP })).rejects.toThrow(/failed \(500\)/);
+  });
+});
+
+describe('updateGroupMd', () => {
+  it('PUTs /v1/bot/groups/{groupNo}/md with Bearer auth and a {content} body', async () => {
+    fetchMock.mockResolvedValueOnce(mockJsonResponse({ version: 8 }));
+
+    const res = await updateGroupMd({ ...BASE, groupNo: GROUP, content: 'New rules.' });
+
+    const { url, init } = call();
+    expect(url).toBe(`${BASE.apiUrl}/v1/bot/groups/${GROUP}/md`);
+    expect(init.method).toBe('PUT');
+    expect(authHeader(init)).toBe(`Bearer ${BASE.botToken}`);
+    expect(JSON.parse(init.body as string)).toEqual({ content: 'New rules.' });
+    expect(res).toEqual({ version: 8 });
+  });
+
+  it('throws on a non-2xx', async () => {
+    fetchMock.mockResolvedValueOnce(new Response('forbidden', { status: 403, statusText: 'Forbidden' }));
+    await expect(
+      updateGroupMd({ ...BASE, groupNo: GROUP, content: 'x' }),
+    ).rejects.toThrow(/failed \(403\)/);
+  });
+});

--- a/src/__tests__/group-md.test.ts
+++ b/src/__tests__/group-md.test.ts
@@ -1,0 +1,259 @@
+/**
+ * Tests for the GROUP.md server cache + server-first resolver (P2-A).
+ *
+ * Covers:
+ *   - GroupMdCache: memory + disk persistence, invalidate, path-safe groupNo.
+ *   - resolveGroupInstructions: feature-flag gating, server-first preference,
+ *     never-lose local-file fallback (404 / empty / no-cache), cache reuse, and
+ *     thread (CommunityTopic) parent-group routing.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach, afterAll } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, existsSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { GroupMdCache } from '../group-md-cache.js';
+import { resolveGroupInstructions } from '../group-md.js';
+
+const fetchMock = vi.fn();
+const originalFetch = globalThis.fetch;
+
+let cfgDir: string;
+let cacheDir: string;
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+  cfgDir = mkdtempSync(join(tmpdir(), 'group-md-cfg-'));
+  cacheDir = mkdtempSync(join(tmpdir(), 'group-md-cache-'));
+});
+
+afterEach(() => {
+  rmSync(cfgDir, { recursive: true, force: true });
+  rmSync(cacheDir, { recursive: true, force: true });
+});
+
+afterAll(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function mockMd(content: string, version = 1): Response {
+  return new Response(
+    JSON.stringify({ content, version, updated_at: '2026-06-04T00:00:00Z', updated_by: 'op' }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } },
+  );
+}
+
+const BASE = { apiUrl: 'https://test.example.com', botToken: 'bf_test' };
+const GROUP = 'grp001';
+
+// ─── GroupMdCache ────────────────────────────────────────────────────────────
+
+describe('GroupMdCache', () => {
+  it('stores and reads an entry from memory', () => {
+    const cache = new GroupMdCache(cacheDir);
+    cache.set(GROUP, { content: 'hi', version: 3, updated_at: null });
+    expect(cache.get(GROUP)).toEqual({ content: 'hi', version: 3, updated_at: null, updated_by: undefined });
+  });
+
+  it('persists to disk (content + meta) and survives a new instance', () => {
+    const a = new GroupMdCache(cacheDir);
+    a.set(GROUP, { content: 'durable', version: 9, updated_at: '2026-06-04T00:00:00Z', updated_by: 'op' });
+    expect(existsSync(join(cacheDir, `${GROUP}.md`))).toBe(true);
+    expect(existsSync(join(cacheDir, `${GROUP}.meta.json`))).toBe(true);
+    expect(readFileSync(join(cacheDir, `${GROUP}.md`), 'utf-8')).toBe('durable');
+
+    // A fresh instance (cold start) reads the durable copy from disk.
+    const b = new GroupMdCache(cacheDir);
+    expect(b.get(GROUP)).toEqual({
+      content: 'durable',
+      version: 9,
+      updated_at: '2026-06-04T00:00:00Z',
+      updated_by: 'op',
+    });
+  });
+
+  it('invalidate clears memory and disk', () => {
+    const cache = new GroupMdCache(cacheDir);
+    cache.set(GROUP, { content: 'x', version: 1, updated_at: null });
+    cache.invalidate(GROUP);
+    expect(cache.get(GROUP)).toBeUndefined();
+    expect(existsSync(join(cacheDir, `${GROUP}.md`))).toBe(false);
+    expect(existsSync(join(cacheDir, `${GROUP}.meta.json`))).toBe(false);
+  });
+
+  it('rejects an unsafe groupNo (no read, no write outside the dir)', () => {
+    const cache = new GroupMdCache(cacheDir);
+    cache.set('../escape', { content: 'evil', version: 1, updated_at: null });
+    expect(cache.get('../escape')).toBeUndefined();
+    expect(existsSync(join(cacheDir, '..', 'escape.md'))).toBe(false);
+  });
+
+  it('works memory-only when no cacheDir is given', () => {
+    const cache = new GroupMdCache();
+    cache.set(GROUP, { content: 'mem', version: 1, updated_at: null });
+    expect(cache.get(GROUP)?.content).toBe('mem');
+  });
+});
+
+// ─── resolveGroupInstructions ─────────────────────────────────────────────────
+
+describe('resolveGroupInstructions', () => {
+  it('flag OFF → reads the local file only, never hits the server', async () => {
+    writeFileSync(join(cfgDir, `${GROUP}.md`), 'local rules');
+    const cache = new GroupMdCache(cacheDir);
+
+    const out = await resolveGroupInstructions({
+      groupConfigDir: cfgDir,
+      serverMd: false,
+      ...BASE,
+      channelId: GROUP,
+      cache,
+    });
+
+    expect(out).toBe('local rules');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('flag ON but no cache wired → local file only, no server call', async () => {
+    writeFileSync(join(cfgDir, `${GROUP}.md`), 'local rules');
+    const out = await resolveGroupInstructions({
+      groupConfigDir: cfgDir,
+      serverMd: true,
+      ...BASE,
+      channelId: GROUP,
+    });
+    expect(out).toBe('local rules');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('flag ON → server content wins over the local file (server-first)', async () => {
+    writeFileSync(join(cfgDir, `${GROUP}.md`), 'local rules');
+    fetchMock.mockResolvedValueOnce(mockMd('server rules'));
+    const cache = new GroupMdCache(cacheDir);
+
+    const out = await resolveGroupInstructions({
+      groupConfigDir: cfgDir,
+      serverMd: true,
+      ...BASE,
+      channelId: GROUP,
+      cache,
+    });
+
+    expect(out).toBe('server rules');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(call0Url()).toBe(`${BASE.apiUrl}/v1/bot/groups/${GROUP}/md`);
+  });
+
+  it('caches the server fetch — a second call serves from cache (no second fetch)', async () => {
+    fetchMock.mockResolvedValueOnce(mockMd('server rules'));
+    const cache = new GroupMdCache(cacheDir);
+    const args = { groupConfigDir: cfgDir, serverMd: true, ...BASE, channelId: GROUP, cache };
+
+    expect(await resolveGroupInstructions(args)).toBe('server rules');
+    expect(await resolveGroupInstructions(args)).toBe('server rules');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('server 404 → falls back to the local file (fallback never lost)', async () => {
+    writeFileSync(join(cfgDir, `${GROUP}.md`), 'local rules');
+    fetchMock.mockResolvedValueOnce(new Response('nope', { status: 404, statusText: 'Not Found' }));
+    const cache = new GroupMdCache(cacheDir);
+
+    const out = await resolveGroupInstructions({
+      groupConfigDir: cfgDir,
+      serverMd: true,
+      ...BASE,
+      channelId: GROUP,
+      cache,
+    });
+
+    expect(out).toBe('local rules');
+  });
+
+  it('server reachable but empty content → local fallback', async () => {
+    writeFileSync(join(cfgDir, `${GROUP}.md`), 'local rules');
+    fetchMock.mockResolvedValueOnce(mockMd('   '));
+    const cache = new GroupMdCache(cacheDir);
+
+    const out = await resolveGroupInstructions({
+      groupConfigDir: cfgDir,
+      serverMd: true,
+      ...BASE,
+      channelId: GROUP,
+      cache,
+    });
+
+    expect(out).toBe('local rules');
+  });
+
+  it('server network error → local fallback, never throws', async () => {
+    writeFileSync(join(cfgDir, `${GROUP}.md`), 'local rules');
+    fetchMock.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+    const cache = new GroupMdCache(cacheDir);
+
+    const out = await resolveGroupInstructions({
+      groupConfigDir: cfgDir,
+      serverMd: true,
+      ...BASE,
+      channelId: GROUP,
+      cache,
+    });
+
+    expect(out).toBe('local rules');
+  });
+
+  it('no server md and no local file → undefined', async () => {
+    fetchMock.mockResolvedValueOnce(new Response('nope', { status: 404, statusText: 'Not Found' }));
+    const cache = new GroupMdCache(cacheDir);
+
+    const out = await resolveGroupInstructions({
+      groupConfigDir: cfgDir,
+      serverMd: true,
+      ...BASE,
+      channelId: GROUP,
+      cache,
+    });
+
+    expect(out).toBeUndefined();
+  });
+
+  it('thread channelId → server fetch uses the PARENT groupNo (P1 routing preserved)', async () => {
+    const channelId = `${GROUP}____tid123`;
+    fetchMock.mockResolvedValueOnce(mockMd('server rules'));
+    const cache = new GroupMdCache(cacheDir);
+
+    const out = await resolveGroupInstructions({
+      groupConfigDir: cfgDir,
+      serverMd: true,
+      ...BASE,
+      channelId,
+      cache,
+    });
+
+    expect(out).toBe('server rules');
+    // URL is keyed by the parent group number, NOT the composite channelId.
+    expect(call0Url()).toBe(`${BASE.apiUrl}/v1/bot/groups/${GROUP}/md`);
+  });
+
+  it('thread channelId → local fallback still routes by the thread short-id file', async () => {
+    // Thread's own short-id instruction file (loadGroupConfig new semantics).
+    writeFileSync(join(cfgDir, 'tid123.md'), 'thread-local rules');
+    fetchMock.mockResolvedValueOnce(new Response('nope', { status: 404, statusText: 'Not Found' }));
+    const cache = new GroupMdCache(cacheDir);
+
+    const out = await resolveGroupInstructions({
+      groupConfigDir: cfgDir,
+      serverMd: true,
+      ...BASE,
+      channelId: `${GROUP}____tid123`,
+      cache,
+    });
+
+    expect(out).toBe('thread-local rules');
+  });
+});
+
+function call0Url(): string {
+  return (fetchMock.mock.calls[0] as [string, RequestInit])[0];
+}

--- a/src/__tests__/group-md.test.ts
+++ b/src/__tests__/group-md.test.ts
@@ -2,35 +2,34 @@
  * Tests for the GROUP.md server cache + server-first resolver (P2-A).
  *
  * Covers:
- *   - GroupMdCache: memory + disk persistence, invalidate, path-safe groupNo.
+ *   - GroupMdCache: in-memory store/read, TTL expiry (staleness backstop),
+ *     invalidate, path-safe groupNo, and that NOTHING is written to disk
+ *     (review #172 🔴 — no durable poisoning surface).
  *   - resolveGroupInstructions: feature-flag gating, server-first preference,
- *     never-lose local-file fallback (404 / empty / no-cache), cache reuse, and
- *     thread (CommunityTopic) parent-group routing.
+ *     never-lose local-file fallback (404 / empty / network / no-cache), cache
+ *     reuse, TTL-driven re-fetch, and thread parent-group routing.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach, afterAll } from 'vitest';
-import { mkdtempSync, rmSync, writeFileSync, existsSync, readFileSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { GroupMdCache } from '../group-md-cache.js';
+import { GroupMdCache, DEFAULT_GROUP_MD_TTL_MS } from '../group-md-cache.js';
 import { resolveGroupInstructions } from '../group-md.js';
 
 const fetchMock = vi.fn();
 const originalFetch = globalThis.fetch;
 
 let cfgDir: string;
-let cacheDir: string;
 
 beforeEach(() => {
   fetchMock.mockReset();
   globalThis.fetch = fetchMock as unknown as typeof fetch;
   cfgDir = mkdtempSync(join(tmpdir(), 'group-md-cfg-'));
-  cacheDir = mkdtempSync(join(tmpdir(), 'group-md-cache-'));
 });
 
 afterEach(() => {
   rmSync(cfgDir, { recursive: true, force: true });
-  rmSync(cacheDir, { recursive: true, force: true });
 });
 
 afterAll(() => {
@@ -47,52 +46,70 @@ function mockMd(content: string, version = 1): Response {
 const BASE = { apiUrl: 'https://test.example.com', botToken: 'bf_test' };
 const GROUP = 'grp001';
 
+/** A controllable clock for deterministic TTL tests. */
+function fakeClock(start = 1_000_000) {
+  let t = start;
+  return { now: () => t, advance: (ms: number) => { t += ms; } };
+}
+
 // ─── GroupMdCache ────────────────────────────────────────────────────────────
 
 describe('GroupMdCache', () => {
   it('stores and reads an entry from memory', () => {
-    const cache = new GroupMdCache(cacheDir);
+    const cache = new GroupMdCache();
     cache.set(GROUP, { content: 'hi', version: 3, updated_at: null });
     expect(cache.get(GROUP)).toEqual({ content: 'hi', version: 3, updated_at: null, updated_by: undefined });
   });
 
-  it('persists to disk (content + meta) and survives a new instance', () => {
-    const a = new GroupMdCache(cacheDir);
-    a.set(GROUP, { content: 'durable', version: 9, updated_at: '2026-06-04T00:00:00Z', updated_by: 'op' });
-    expect(existsSync(join(cacheDir, `${GROUP}.md`))).toBe(true);
-    expect(existsSync(join(cacheDir, `${GROUP}.meta.json`))).toBe(true);
-    expect(readFileSync(join(cacheDir, `${GROUP}.md`), 'utf-8')).toBe('durable');
+  it('expires an entry once it is older than the TTL (staleness backstop)', () => {
+    const clock = fakeClock();
+    const cache = new GroupMdCache(1000, clock.now);
+    cache.set(GROUP, { content: 'x', version: 1, updated_at: null });
 
-    // A fresh instance (cold start) reads the durable copy from disk.
-    const b = new GroupMdCache(cacheDir);
-    expect(b.get(GROUP)).toEqual({
-      content: 'durable',
-      version: 9,
-      updated_at: '2026-06-04T00:00:00Z',
-      updated_by: 'op',
-    });
+    clock.advance(999);
+    expect(cache.get(GROUP)?.content).toBe('x'); // still fresh
+
+    clock.advance(1); // now exactly at TTL → expired
+    expect(cache.get(GROUP)).toBeUndefined();
   });
 
-  it('invalidate clears memory and disk', () => {
-    const cache = new GroupMdCache(cacheDir);
+  it('a non-positive TTL disables expiry', () => {
+    const clock = fakeClock();
+    const cache = new GroupMdCache(0, clock.now);
+    cache.set(GROUP, { content: 'x', version: 1, updated_at: null });
+    clock.advance(10 * 365 * 24 * 3600 * 1000);
+    expect(cache.get(GROUP)?.content).toBe('x');
+  });
+
+  it('invalidate clears the entry', () => {
+    const cache = new GroupMdCache();
     cache.set(GROUP, { content: 'x', version: 1, updated_at: null });
     cache.invalidate(GROUP);
     expect(cache.get(GROUP)).toBeUndefined();
-    expect(existsSync(join(cacheDir, `${GROUP}.md`))).toBe(false);
-    expect(existsSync(join(cacheDir, `${GROUP}.meta.json`))).toBe(false);
   });
 
-  it('rejects an unsafe groupNo (no read, no write outside the dir)', () => {
-    const cache = new GroupMdCache(cacheDir);
+  it('rejects an unsafe groupNo (never stored)', () => {
+    const cache = new GroupMdCache();
     cache.set('../escape', { content: 'evil', version: 1, updated_at: null });
     expect(cache.get('../escape')).toBeUndefined();
-    expect(existsSync(join(cacheDir, '..', 'escape.md'))).toBe(false);
   });
 
-  it('works memory-only when no cacheDir is given', () => {
-    const cache = new GroupMdCache();
-    cache.set(GROUP, { content: 'mem', version: 1, updated_at: null });
-    expect(cache.get(GROUP)?.content).toBe('mem');
+  it('persists nothing across instances — a fresh cache shares no state (no durable backing)', () => {
+    // Regression guard for review #172 🔴: the cache must have NO durable backing
+    // (memory-only). If it persisted anywhere, a brand-new instance could read a
+    // prior instance's entry — and a chat-driven Write to that backing would be a
+    // trusted-prompt poisoning vector surviving restart. A fresh instance must
+    // come up empty.
+    const a = new GroupMdCache();
+    a.set(GROUP, { content: 'durable?', version: 9, updated_at: '2026-06-04T00:00:00Z', updated_by: 'op' });
+    expect(a.get(GROUP)?.content).toBe('durable?');
+
+    const b = new GroupMdCache();
+    expect(b.get(GROUP)).toBeUndefined();
+  });
+
+  it('default TTL constant is exported and positive', () => {
+    expect(DEFAULT_GROUP_MD_TTL_MS).toBeGreaterThan(0);
   });
 });
 
@@ -101,7 +118,7 @@ describe('GroupMdCache', () => {
 describe('resolveGroupInstructions', () => {
   it('flag OFF → reads the local file only, never hits the server', async () => {
     writeFileSync(join(cfgDir, `${GROUP}.md`), 'local rules');
-    const cache = new GroupMdCache(cacheDir);
+    const cache = new GroupMdCache();
 
     const out = await resolveGroupInstructions({
       groupConfigDir: cfgDir,
@@ -130,7 +147,7 @@ describe('resolveGroupInstructions', () => {
   it('flag ON → server content wins over the local file (server-first)', async () => {
     writeFileSync(join(cfgDir, `${GROUP}.md`), 'local rules');
     fetchMock.mockResolvedValueOnce(mockMd('server rules'));
-    const cache = new GroupMdCache(cacheDir);
+    const cache = new GroupMdCache();
 
     const out = await resolveGroupInstructions({
       groupConfigDir: cfgDir,
@@ -147,7 +164,7 @@ describe('resolveGroupInstructions', () => {
 
   it('caches the server fetch — a second call serves from cache (no second fetch)', async () => {
     fetchMock.mockResolvedValueOnce(mockMd('server rules'));
-    const cache = new GroupMdCache(cacheDir);
+    const cache = new GroupMdCache();
     const args = { groupConfigDir: cfgDir, serverMd: true, ...BASE, channelId: GROUP, cache };
 
     expect(await resolveGroupInstructions(args)).toBe('server rules');
@@ -155,10 +172,24 @@ describe('resolveGroupInstructions', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it('re-fetches after the cache entry expires (TTL backstop picks up edits)', async () => {
+    const clock = fakeClock();
+    const cache = new GroupMdCache(1000, clock.now);
+    const args = { groupConfigDir: cfgDir, serverMd: true, ...BASE, channelId: GROUP, cache };
+
+    fetchMock.mockResolvedValueOnce(mockMd('old rules'));
+    expect(await resolveGroupInstructions(args)).toBe('old rules');
+
+    clock.advance(1000); // expire the cached entry
+    fetchMock.mockResolvedValueOnce(mockMd('new rules'));
+    expect(await resolveGroupInstructions(args)).toBe('new rules');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
   it('server 404 → falls back to the local file (fallback never lost)', async () => {
     writeFileSync(join(cfgDir, `${GROUP}.md`), 'local rules');
     fetchMock.mockResolvedValueOnce(new Response('nope', { status: 404, statusText: 'Not Found' }));
-    const cache = new GroupMdCache(cacheDir);
+    const cache = new GroupMdCache();
 
     const out = await resolveGroupInstructions({
       groupConfigDir: cfgDir,
@@ -174,7 +205,7 @@ describe('resolveGroupInstructions', () => {
   it('server reachable but empty content → local fallback', async () => {
     writeFileSync(join(cfgDir, `${GROUP}.md`), 'local rules');
     fetchMock.mockResolvedValueOnce(mockMd('   '));
-    const cache = new GroupMdCache(cacheDir);
+    const cache = new GroupMdCache();
 
     const out = await resolveGroupInstructions({
       groupConfigDir: cfgDir,
@@ -190,7 +221,7 @@ describe('resolveGroupInstructions', () => {
   it('server network error → local fallback, never throws', async () => {
     writeFileSync(join(cfgDir, `${GROUP}.md`), 'local rules');
     fetchMock.mockRejectedValueOnce(new Error('ECONNREFUSED'));
-    const cache = new GroupMdCache(cacheDir);
+    const cache = new GroupMdCache();
 
     const out = await resolveGroupInstructions({
       groupConfigDir: cfgDir,
@@ -205,7 +236,7 @@ describe('resolveGroupInstructions', () => {
 
   it('no server md and no local file → undefined', async () => {
     fetchMock.mockResolvedValueOnce(new Response('nope', { status: 404, statusText: 'Not Found' }));
-    const cache = new GroupMdCache(cacheDir);
+    const cache = new GroupMdCache();
 
     const out = await resolveGroupInstructions({
       groupConfigDir: cfgDir,
@@ -221,7 +252,7 @@ describe('resolveGroupInstructions', () => {
   it('thread channelId → server fetch uses the PARENT groupNo (P1 routing preserved)', async () => {
     const channelId = `${GROUP}____tid123`;
     fetchMock.mockResolvedValueOnce(mockMd('server rules'));
-    const cache = new GroupMdCache(cacheDir);
+    const cache = new GroupMdCache();
 
     const out = await resolveGroupInstructions({
       groupConfigDir: cfgDir,
@@ -240,7 +271,7 @@ describe('resolveGroupInstructions', () => {
     // Thread's own short-id instruction file (loadGroupConfig new semantics).
     writeFileSync(join(cfgDir, 'tid123.md'), 'thread-local rules');
     fetchMock.mockResolvedValueOnce(new Response('nope', { status: 404, statusText: 'Not Found' }));
-    const cache = new GroupMdCache(cacheDir);
+    const cache = new GroupMdCache();
 
     const out = await resolveGroupInstructions({
       groupConfigDir: cfgDir,

--- a/src/config.ts
+++ b/src/config.ts
@@ -89,6 +89,15 @@ export interface Config {
    * per-session cwd sandbox (which the agent can write). Unset = feature off.
    */
   groupConfigDir?: string;
+  /**
+   * P2-A feature flag: when true, per-group instructions are fetched from the
+   * server GROUP.md API (`GET /v1/bot/groups/{groupNo}/md`) first, falling back
+   * to the local `groupConfigDir` file on any failure (404 / network / no
+   * content). When false/unset (default) only the local file is used — flip it
+   * off to roll back to pure local-file behavior. The fetched copy is cached in
+   * `<dataDir>/group-md-cache`.
+   */
+  serverMd?: boolean;
   sdk: {
     model?: string;
     /**
@@ -259,6 +268,7 @@ type PartialConfig = {
   botToken?: string;
   apiUrl?: string;
   groupConfigDir?: string;
+  serverMd?: boolean;
   sdk?: Partial<Config['sdk']>;
   rateLimit?: Partial<Config['rateLimit']>;
   context?: Partial<Config['context']>;
@@ -350,6 +360,7 @@ function mergeConfig(base: Config, override: PartialConfig): Config {
     dataDir: base.dataDir,
     memoryBase: base.memoryBase,
     groupConfigDir: override.groupConfigDir ?? base.groupConfigDir,
+    serverMd: override.serverMd ?? base.serverMd,
     sdk: {
       ...base.sdk,
       ...(override.sdk ?? {}),
@@ -582,6 +593,7 @@ export function resolveBotConfigs(config: Config): Config[] {
       mentionFreeGroups:
         perBotFile.mentionFreeGroups ?? bot.mentionFreeGroups ?? config.mentionFreeGroups,
       groupConfigDir: perBotFile.groupConfigDir ?? config.groupConfigDir,
+      serverMd: perBotFile.serverMd ?? config.serverMd,
       sdk: {
         ...config.sdk,
         ...(perBotFile.sdk ?? {}),

--- a/src/config.ts
+++ b/src/config.ts
@@ -94,10 +94,19 @@ export interface Config {
    * server GROUP.md API (`GET /v1/bot/groups/{groupNo}/md`) first, falling back
    * to the local `groupConfigDir` file on any failure (404 / network / no
    * content). When false/unset (default) only the local file is used — flip it
-   * off to roll back to pure local-file behavior. The fetched copy is cached in
-   * `<dataDir>/group-md-cache`.
+   * off to roll back to pure local-file behavior. The fetched copy is cached
+   * IN MEMORY ONLY (never on disk — the content is injected as a trusted system
+   * prompt and a disk cache the gateway user can write would be a poisoning
+   * vector), with a TTL staleness backstop (`serverMdTtlMs`).
    */
   serverMd?: boolean;
+  /**
+   * P2-A: TTL in ms for the in-memory server GROUP.md cache — a cached entry is
+   * re-fetched once it is this old, so an operator's server-side edit eventually
+   * takes effect even before item B's event-driven refresh lands. Defaults to
+   * `DEFAULT_GROUP_MD_TTL_MS` (5 min). Only meaningful when `serverMd` is true.
+   */
+  serverMdTtlMs?: number;
   sdk: {
     model?: string;
     /**
@@ -269,6 +278,7 @@ type PartialConfig = {
   apiUrl?: string;
   groupConfigDir?: string;
   serverMd?: boolean;
+  serverMdTtlMs?: number;
   sdk?: Partial<Config['sdk']>;
   rateLimit?: Partial<Config['rateLimit']>;
   context?: Partial<Config['context']>;
@@ -361,6 +371,7 @@ function mergeConfig(base: Config, override: PartialConfig): Config {
     memoryBase: base.memoryBase,
     groupConfigDir: override.groupConfigDir ?? base.groupConfigDir,
     serverMd: override.serverMd ?? base.serverMd,
+    serverMdTtlMs: override.serverMdTtlMs ?? base.serverMdTtlMs,
     sdk: {
       ...base.sdk,
       ...(override.sdk ?? {}),
@@ -594,6 +605,7 @@ export function resolveBotConfigs(config: Config): Config[] {
         perBotFile.mentionFreeGroups ?? bot.mentionFreeGroups ?? config.mentionFreeGroups,
       groupConfigDir: perBotFile.groupConfigDir ?? config.groupConfigDir,
       serverMd: perBotFile.serverMd ?? config.serverMd,
+      serverMdTtlMs: perBotFile.serverMdTtlMs ?? config.serverMdTtlMs,
       sdk: {
         ...config.sdk,
         ...(perBotFile.sdk ?? {}),

--- a/src/group-md-cache.ts
+++ b/src/group-md-cache.ts
@@ -1,0 +1,159 @@
+/**
+ * GROUP.md server cache (P2-A).
+ *
+ * A two-tier cache for server-fetched GROUP.md, keyed by groupNo:
+ *   - in-memory Map (hot path: read on every group turn),
+ *   - on-disk durable copy (`<groupNo>.md` for content + `<groupNo>.meta.json`
+ *     for version / updated_at / updated_by) so a fetched GROUP.md survives a
+ *     restart and can serve as a fallback when the server is unreachable.
+ *
+ * This module is deliberately INDEPENDENT of the P1 GroupContext caches
+ * (group_messages / group_members in SQLite): those hold per-channel chat
+ * history + roster; this holds operator-authored instruction text. Keeping them
+ * decoupled means a GROUP.md refresh never touches the message DB and vice
+ * versa.
+ *
+ * Freshness: this class only stores and serves; it does not expire entries on a
+ * timer. A populated entry is returned until `invalidate()` is called — the
+ * event-driven refresh that decides WHEN to invalidate is a separate work item.
+ * Holding a stable value between invalidations is also what keeps the agent's
+ * cached system prompt byte-identical turn-to-turn (see CLAUDE.md "Frozen system
+ * prompt").
+ *
+ * Never throws — disk I/O failures degrade to "memory only" (or "no cache"),
+ * never failing the turn.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { join } from 'node:path';
+
+/** A cached GROUP.md plus the server metadata that came with it. */
+export interface GroupMdEntry {
+  content: string;
+  version: number;
+  updated_at: string | null;
+  updated_by?: string;
+}
+
+/**
+ * Only allow groupNos that are safe as a single path segment, so a crafted id
+ * can never escape the cache dir. Same policy as group-config.ts isSafeId.
+ */
+function isSafeGroupNo(groupNo: string): boolean {
+  return /^[a-zA-Z0-9._-]+$/.test(groupNo) && groupNo !== '.' && groupNo !== '..';
+}
+
+export class GroupMdCache {
+  private readonly mem = new Map<string, GroupMdEntry>();
+  private readonly cacheDir?: string;
+  /** Set once we've successfully created cacheDir (lazy: only when first written). */
+  private dirReady = false;
+
+  /**
+   * @param cacheDir directory for the durable copy. When undefined the cache is
+   *   memory-only (still correct, just not restart-durable).
+   */
+  constructor(cacheDir?: string) {
+    this.cacheDir = cacheDir;
+  }
+
+  /**
+   * Read a cached entry. Checks memory first, then the on-disk copy (hydrating
+   * memory on a disk hit so the next read is hot). Returns undefined on a miss
+   * or for an unsafe groupNo.
+   */
+  get(groupNo: string): GroupMdEntry | undefined {
+    if (!isSafeGroupNo(groupNo)) return undefined;
+    const hot = this.mem.get(groupNo);
+    if (hot) return hot;
+    const fromDisk = this.readDisk(groupNo);
+    if (fromDisk) this.mem.set(groupNo, fromDisk);
+    return fromDisk;
+  }
+
+  /** Store an entry in memory and (best-effort) on disk. */
+  set(groupNo: string, entry: GroupMdEntry): void {
+    if (!isSafeGroupNo(groupNo)) return;
+    this.mem.set(groupNo, entry);
+    this.writeDisk(groupNo, entry);
+  }
+
+  /**
+   * Drop a cached entry from memory and disk. The hook the event-driven refresh
+   * (separate work item) calls when the server reports a GROUP.md changed, so
+   * the next turn re-fetches.
+   */
+  invalidate(groupNo: string): void {
+    if (!isSafeGroupNo(groupNo)) return;
+    this.mem.delete(groupNo);
+    if (!this.cacheDir) return;
+    for (const name of [`${groupNo}.md`, `${groupNo}.meta.json`]) {
+      try {
+        rmSync(join(this.cacheDir, name), { force: true });
+      } catch (err) {
+        console.error(`[cc-channel-octo] group-md-cache: invalidate ${name} failed: ${String(err)}`);
+      }
+    }
+  }
+
+  private ensureDir(): boolean {
+    if (!this.cacheDir) return false;
+    if (this.dirReady) return true;
+    try {
+      mkdirSync(this.cacheDir, { recursive: true });
+      this.dirReady = true;
+      return true;
+    } catch (err) {
+      console.error(`[cc-channel-octo] group-md-cache: mkdir ${this.cacheDir} failed: ${String(err)}`);
+      return false;
+    }
+  }
+
+  private readDisk(groupNo: string): GroupMdEntry | undefined {
+    if (!this.cacheDir) return undefined;
+    const contentPath = join(this.cacheDir, `${groupNo}.md`);
+    const metaPath = join(this.cacheDir, `${groupNo}.meta.json`);
+    try {
+      if (!existsSync(contentPath)) return undefined;
+      const content = readFileSync(contentPath, 'utf-8');
+      let version = 0;
+      let updatedAt: string | null = null;
+      let updatedBy: string | undefined;
+      if (existsSync(metaPath)) {
+        try {
+          const meta = JSON.parse(readFileSync(metaPath, 'utf-8')) as Partial<GroupMdEntry>;
+          if (typeof meta.version === 'number') version = meta.version;
+          if (typeof meta.updated_at === 'string' || meta.updated_at === null) updatedAt = meta.updated_at ?? null;
+          if (typeof meta.updated_by === 'string') updatedBy = meta.updated_by;
+        } catch {
+          // Corrupt meta — keep the content, default the metadata.
+        }
+      }
+      return { content, version, updated_at: updatedAt, updated_by: updatedBy };
+    } catch (err) {
+      console.error(`[cc-channel-octo] group-md-cache: read ${groupNo} failed: ${String(err)}`);
+      return undefined;
+    }
+  }
+
+  private writeDisk(groupNo: string, entry: GroupMdEntry): void {
+    if (!this.ensureDir() || !this.cacheDir) return;
+    try {
+      writeFileSync(join(this.cacheDir, `${groupNo}.md`), entry.content, 'utf-8');
+      const meta = {
+        version: entry.version,
+        updated_at: entry.updated_at,
+        updated_by: entry.updated_by,
+      };
+      writeFileSync(join(this.cacheDir, `${groupNo}.meta.json`), JSON.stringify(meta), 'utf-8');
+    } catch (err) {
+      console.error(`[cc-channel-octo] group-md-cache: write ${groupNo} failed: ${String(err)}`);
+    }
+  }
+}

--- a/src/group-md-cache.ts
+++ b/src/group-md-cache.ts
@@ -1,37 +1,39 @@
 /**
- * GROUP.md server cache (P2-A).
+ * GROUP.md server cache (P2-A) — IN-MEMORY ONLY, with a TTL.
  *
- * A two-tier cache for server-fetched GROUP.md, keyed by groupNo:
- *   - in-memory Map (hot path: read on every group turn),
- *   - on-disk durable copy (`<groupNo>.md` for content + `<groupNo>.meta.json`
- *     for version / updated_at / updated_by) so a fetched GROUP.md survives a
- *     restart and can serve as a fallback when the server is unreachable.
+ * Holds server-fetched GROUP.md keyed by groupNo, in a process-local Map. There
+ * is deliberately **no on-disk persistence** (see SECURITY below).
  *
- * This module is deliberately INDEPENDENT of the P1 GroupContext caches
- * (group_messages / group_members in SQLite): those hold per-channel chat
- * history + roster; this holds operator-authored instruction text. Keeping them
- * decoupled means a GROUP.md refresh never touches the message DB and vice
- * versa.
+ * Independent of the P1 GroupContext caches (group_messages / group_members in
+ * SQLite): those hold per-channel chat history + roster; this holds operator-
+ * authored instruction text. Keeping them decoupled means a GROUP.md refresh
+ * never touches the message DB and vice versa.
  *
- * Freshness: this class only stores and serves; it does not expire entries on a
- * timer. A populated entry is returned until `invalidate()` is called — the
- * event-driven refresh that decides WHEN to invalidate is a separate work item.
- * Holding a stable value between invalidations is also what keeps the agent's
- * cached system prompt byte-identical turn-to-turn (see CLAUDE.md "Frozen system
- * prompt").
+ * SECURITY — why memory-only (review #172, 🔴 durable-cache poisoning):
+ *   The resolved GROUP.md is injected into the agent's system prompt as a TRUSTED
+ *   instruction block (same channel as the operator's local `groupConfigDir`
+ *   file). A local file earns that trust from OS permissions (operator-owned,
+ *   non-writable by others; `group-config.ts` additionally refuses a group/world-
+ *   writable file). A DISK cache cannot earn the same trust here: the gateway
+ *   runs the agent under `bypassPermissions` with `Bash`/`Write`, so the agent
+ *   process — drivable by untrusted chat input — can write any file the gateway
+ *   user owns, including a cache file. A persisted cache entry would then be read
+ *   back and injected as trusted across restarts (a chat-injection → trusted-
+ *   prompt poisoning that survives reboot), and the `0o022` perm check is useless
+ *   because agent == gateway user. So GROUP.md from the server is cached ONLY in
+ *   memory: the sole path content can enter the trusted channel is a live,
+ *   authenticated `getGroupMd` over the bot token against the SSRF-validated
+ *   `apiUrl` (server-side bot_admin-gated) — never a forgeable on-disk artifact.
+ *   The tradeoff (no cross-restart durability) is acceptable: a cold start simply
+ *   re-fetches, and the local file remains the offline fallback.
  *
- * Never throws — disk I/O failures degrade to "memory only" (or "no cache"),
- * never failing the turn.
+ * Freshness: an entry expires `ttlMs` after it was stored; an expired read is a
+ * miss (the resolver re-fetches). This is a staleness BACKSTOP so a server-side
+ * GROUP.md edit eventually takes effect (review #172, 🟡) — Stage 2 (item B) adds
+ * event-driven invalidation on top; the two do not conflict.
+ *
+ * Never throws.
  */
-
-import {
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  rmSync,
-  writeFileSync,
-} from 'node:fs';
-import { join } from 'node:path';
 
 /** A cached GROUP.md plus the server metadata that came with it. */
 export interface GroupMdEntry {
@@ -41,119 +43,66 @@ export interface GroupMdEntry {
   updated_by?: string;
 }
 
+/** Default staleness backstop: re-fetch a cached GROUP.md at most this old. */
+export const DEFAULT_GROUP_MD_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
 /**
- * Only allow groupNos that are safe as a single path segment, so a crafted id
- * can never escape the cache dir. Same policy as group-config.ts isSafeId.
+ * Only allow groupNos that are safe as a single Map key / log token. Mirrors
+ * group-config.ts isSafeId — cheap defense-in-depth against a crafted id even
+ * though nothing here touches the filesystem anymore.
  */
 function isSafeGroupNo(groupNo: string): boolean {
   return /^[a-zA-Z0-9._-]+$/.test(groupNo) && groupNo !== '.' && groupNo !== '..';
 }
 
+interface StoredEntry {
+  entry: GroupMdEntry;
+  storedAt: number;
+}
+
 export class GroupMdCache {
-  private readonly mem = new Map<string, GroupMdEntry>();
-  private readonly cacheDir?: string;
-  /** Set once we've successfully created cacheDir (lazy: only when first written). */
-  private dirReady = false;
+  private readonly mem = new Map<string, StoredEntry>();
+  private readonly ttlMs: number;
+  private readonly now: () => number;
 
   /**
-   * @param cacheDir directory for the durable copy. When undefined the cache is
-   *   memory-only (still correct, just not restart-durable).
+   * @param ttlMs staleness backstop in ms (entry expires this long after it was
+   *   stored). Defaults to {@link DEFAULT_GROUP_MD_TTL_MS}. A non-positive value
+   *   disables expiry (entries live until invalidate()).
+   * @param now injectable clock (testing); defaults to Date.now.
    */
-  constructor(cacheDir?: string) {
-    this.cacheDir = cacheDir;
+  constructor(ttlMs: number = DEFAULT_GROUP_MD_TTL_MS, now: () => number = () => Date.now()) {
+    this.ttlMs = ttlMs;
+    this.now = now;
   }
 
   /**
-   * Read a cached entry. Checks memory first, then the on-disk copy (hydrating
-   * memory on a disk hit so the next read is hot). Returns undefined on a miss
-   * or for an unsafe groupNo.
+   * Read a cached entry from memory. Returns undefined on a miss, an expired
+   * entry (which is also evicted), or an unsafe groupNo.
    */
   get(groupNo: string): GroupMdEntry | undefined {
     if (!isSafeGroupNo(groupNo)) return undefined;
-    const hot = this.mem.get(groupNo);
-    if (hot) return hot;
-    const fromDisk = this.readDisk(groupNo);
-    if (fromDisk) this.mem.set(groupNo, fromDisk);
-    return fromDisk;
+    const stored = this.mem.get(groupNo);
+    if (!stored) return undefined;
+    if (this.ttlMs > 0 && this.now() - stored.storedAt >= this.ttlMs) {
+      this.mem.delete(groupNo);
+      return undefined;
+    }
+    return stored.entry;
   }
 
-  /** Store an entry in memory and (best-effort) on disk. */
+  /** Store an entry in memory, stamping it for TTL expiry. */
   set(groupNo: string, entry: GroupMdEntry): void {
     if (!isSafeGroupNo(groupNo)) return;
-    this.mem.set(groupNo, entry);
-    this.writeDisk(groupNo, entry);
+    this.mem.set(groupNo, { entry, storedAt: this.now() });
   }
 
   /**
-   * Drop a cached entry from memory and disk. The hook the event-driven refresh
-   * (separate work item) calls when the server reports a GROUP.md changed, so
-   * the next turn re-fetches.
+   * Drop a cached entry. The hook the event-driven refresh (item B) calls when
+   * the server reports a GROUP.md changed, so the next turn re-fetches.
    */
   invalidate(groupNo: string): void {
     if (!isSafeGroupNo(groupNo)) return;
     this.mem.delete(groupNo);
-    if (!this.cacheDir) return;
-    for (const name of [`${groupNo}.md`, `${groupNo}.meta.json`]) {
-      try {
-        rmSync(join(this.cacheDir, name), { force: true });
-      } catch (err) {
-        console.error(`[cc-channel-octo] group-md-cache: invalidate ${name} failed: ${String(err)}`);
-      }
-    }
-  }
-
-  private ensureDir(): boolean {
-    if (!this.cacheDir) return false;
-    if (this.dirReady) return true;
-    try {
-      mkdirSync(this.cacheDir, { recursive: true });
-      this.dirReady = true;
-      return true;
-    } catch (err) {
-      console.error(`[cc-channel-octo] group-md-cache: mkdir ${this.cacheDir} failed: ${String(err)}`);
-      return false;
-    }
-  }
-
-  private readDisk(groupNo: string): GroupMdEntry | undefined {
-    if (!this.cacheDir) return undefined;
-    const contentPath = join(this.cacheDir, `${groupNo}.md`);
-    const metaPath = join(this.cacheDir, `${groupNo}.meta.json`);
-    try {
-      if (!existsSync(contentPath)) return undefined;
-      const content = readFileSync(contentPath, 'utf-8');
-      let version = 0;
-      let updatedAt: string | null = null;
-      let updatedBy: string | undefined;
-      if (existsSync(metaPath)) {
-        try {
-          const meta = JSON.parse(readFileSync(metaPath, 'utf-8')) as Partial<GroupMdEntry>;
-          if (typeof meta.version === 'number') version = meta.version;
-          if (typeof meta.updated_at === 'string' || meta.updated_at === null) updatedAt = meta.updated_at ?? null;
-          if (typeof meta.updated_by === 'string') updatedBy = meta.updated_by;
-        } catch {
-          // Corrupt meta — keep the content, default the metadata.
-        }
-      }
-      return { content, version, updated_at: updatedAt, updated_by: updatedBy };
-    } catch (err) {
-      console.error(`[cc-channel-octo] group-md-cache: read ${groupNo} failed: ${String(err)}`);
-      return undefined;
-    }
-  }
-
-  private writeDisk(groupNo: string, entry: GroupMdEntry): void {
-    if (!this.ensureDir() || !this.cacheDir) return;
-    try {
-      writeFileSync(join(this.cacheDir, `${groupNo}.md`), entry.content, 'utf-8');
-      const meta = {
-        version: entry.version,
-        updated_at: entry.updated_at,
-        updated_by: entry.updated_by,
-      };
-      writeFileSync(join(this.cacheDir, `${groupNo}.meta.json`), JSON.stringify(meta), 'utf-8');
-    } catch (err) {
-      console.error(`[cc-channel-octo] group-md-cache: write ${groupNo} failed: ${String(err)}`);
-    }
   }
 }

--- a/src/group-md.ts
+++ b/src/group-md.ts
@@ -1,0 +1,110 @@
+/**
+ * GROUP.md resolution (P2-A): server-first fetch with a never-lose local-file
+ * fallback, behind a feature flag.
+ *
+ * `resolveGroupInstructions` is the single entry point the message pipeline
+ * calls to obtain the trusted per-group instruction block injected into the
+ * agent's system prompt. Resolution order:
+ *
+ *   1. Feature flag OFF (default) or no cache wired → pure local file
+ *      (`loadGroupConfig`). Byte-identical to the pre-P2 behavior, so existing
+ *      local-file deployments are unaffected.
+ *   2. Feature flag ON:
+ *        a. serve a cached server GROUP.md if present (keyed by the PARENT group
+ *           number — a thread shares its parent group's GROUP.md);
+ *        b. otherwise fetch from the server (server-first). On success with
+ *           non-empty content, cache it and use it;
+ *        c. on ANY failure (404 "no GROUP.md", network, timeout, empty content)
+ *           fall back to the local file. The local-file path is never lost.
+ *
+ * Thread routing (P1): a thread channelId is the composite `<groupNo>____<shortId>`.
+ * The server GROUP.md endpoint is keyed by the parent group number, so we resolve
+ * it with `extractParentGroupNo` for the API call + cache key (identity for a
+ * plain group). The local-file fallback still receives the FULL channelId so its
+ * own thread/short-id routing in `loadGroupConfig` is preserved unchanged.
+ *
+ * Never throws — a server error degrades to local, a local miss degrades to
+ * "no custom instructions".
+ */
+
+import { getGroupMd } from './octo/api.js';
+import { extractParentGroupNo } from './octo/channel-id.js';
+import { loadGroupConfig, MAX_GROUP_CONFIG_BYTES } from './group-config.js';
+import type { GroupMdCache, GroupMdEntry } from './group-md-cache.js';
+
+/**
+ * Trim and byte-bound server-provided GROUP.md the same way loadGroupConfig
+ * bounds a local file, so an oversized server payload can't blow the prompt
+ * budget. Returns undefined for empty/whitespace-only content.
+ */
+function boundInstructions(content: string): string | undefined {
+  let text = content;
+  if (Buffer.byteLength(text, 'utf-8') > MAX_GROUP_CONFIG_BYTES) {
+    const buf = Buffer.from(text, 'utf-8').subarray(0, MAX_GROUP_CONFIG_BYTES);
+    // The slice may end mid-codepoint; trim a trailing replacement char.
+    text = buf.toString('utf-8').replace(/�+$/, '') + '\n[… group config truncated]';
+  }
+  const trimmed = text.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+export interface ResolveGroupInstructionsParams {
+  /** Operator local-instruction directory (the existing fallback source). */
+  groupConfigDir?: string;
+  /** Feature flag: when false/undefined, server fetch is skipped entirely. */
+  serverMd?: boolean;
+  apiUrl: string;
+  botToken: string;
+  /** Full channelId (may be a `<groupNo>____<shortId>` thread composite). */
+  channelId: string;
+  /** Server GROUP.md cache. Omitted (or flag off) → pure local file. */
+  cache?: GroupMdCache;
+  signal?: AbortSignal;
+}
+
+export async function resolveGroupInstructions(
+  params: ResolveGroupInstructionsParams,
+): Promise<string | undefined> {
+  const { groupConfigDir, serverMd, apiUrl, botToken, channelId, cache, signal } = params;
+
+  const local = (): string | undefined => loadGroupConfig(groupConfigDir, channelId);
+
+  // Flag off (or no cache to dedupe fetches) → pure local file, unchanged behavior.
+  if (!serverMd || !cache) return local();
+
+  const groupNo = extractParentGroupNo(channelId);
+
+  // a) cached server GROUP.md wins (kept stable until invalidated by the
+  //    event-driven refresh — a separate work item).
+  const cached = cache.get(groupNo);
+  if (cached) {
+    const bounded = boundInstructions(cached.content);
+    if (bounded) return bounded;
+    // Cached-but-empty (shouldn't normally happen) → fall through to local.
+    return local();
+  }
+
+  // b) server-first fetch.
+  try {
+    const md = await getGroupMd({ apiUrl, botToken, groupNo, signal });
+    const bounded = boundInstructions(md?.content ?? '');
+    if (bounded) {
+      const entry: GroupMdEntry = {
+        content: md.content,
+        version: typeof md.version === 'number' ? md.version : 0,
+        updated_at: md.updated_at ?? null,
+        updated_by: md.updated_by,
+      };
+      cache.set(groupNo, entry);
+      return bounded;
+    }
+    // Server reachable but no/empty GROUP.md → local fallback.
+    return local();
+  } catch (err) {
+    // c) 404 / network / timeout — never-lose local fallback.
+    console.error(
+      `[cc-channel-octo] group-md: server fetch for ${groupNo} failed, falling back to local: ${String(err)}`,
+    );
+    return local();
+  }
+}

--- a/src/group-md.ts
+++ b/src/group-md.ts
@@ -10,12 +10,22 @@
  *      (`loadGroupConfig`). Byte-identical to the pre-P2 behavior, so existing
  *      local-file deployments are unaffected.
  *   2. Feature flag ON:
- *        a. serve a cached server GROUP.md if present (keyed by the PARENT group
- *           number — a thread shares its parent group's GROUP.md);
+ *        a. serve a cached server GROUP.md if present and not past its TTL (keyed
+ *           by the PARENT group number — a thread shares its parent group's
+ *           GROUP.md). The cache is IN-MEMORY ONLY (no disk), so the only way
+ *           content reaches this trusted system-prompt channel is a live,
+ *           authenticated fetch — never a forgeable on-disk artifact a chat-
+ *           driven Bash/Write could plant (review #172 🔴; see group-md-cache.ts);
  *        b. otherwise fetch from the server (server-first). On success with
  *           non-empty content, cache it and use it;
  *        c. on ANY failure (404 "no GROUP.md", network, timeout, empty content)
  *           fall back to the local file. The local-file path is never lost.
+ *
+ * Trust: server content stands on its own trust root — an authenticated
+ * `getGroupMd` over the bot token against the SSRF-validated `apiUrl`, server-
+ * side bot_admin-gated — NOT on the OS-permission trust the local `groupConfigDir`
+ * file relies on. By caching only in memory we never let server content
+ * masquerade as (or be confused with) a trusted local file on disk.
  *
  * Thread routing (P1): a thread channelId is the composite `<groupNo>____<shortId>`.
  * The server GROUP.md endpoint is keyed by the parent group number, so we resolve
@@ -74,8 +84,9 @@ export async function resolveGroupInstructions(
 
   const groupNo = extractParentGroupNo(channelId);
 
-  // a) cached server GROUP.md wins (kept stable until invalidated by the
-  //    event-driven refresh — a separate work item).
+  // a) fresh cached server GROUP.md wins. The cache is in-memory only and TTL-
+  //    bounded, so an expired entry reads as a miss and falls through to a
+  //    re-fetch below (staleness backstop; item B adds event-driven refresh).
   const cached = cache.get(groupNo);
   if (cached) {
     const bounded = boundInstructions(cached.content);

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,8 @@ import type { BotMessage } from './octo/types.js';
 import { resolveContent, tryResolveFile, resolveHistoricalMessagePlaceholder } from './inbound.js';
 import { downloadInboundImage, MAX_IMAGES_PER_MESSAGE } from './media-inbound.js';
 import { handleCommand } from './commands.js';
-import { loadGroupConfig } from './group-config.js';
+import { resolveGroupInstructions } from './group-md.js';
+import { GroupMdCache } from './group-md-cache.js';
 import { CronStore } from './cron-store.js';
 import { CronScheduler } from './cron-scheduler.js';
 import { createCronToolServer, CRON_TOOL_SERVER_NAME, type CronSessionCoords } from './cron-tool.js';
@@ -211,6 +212,12 @@ async function startBot(config: ReturnType<typeof loadConfig>, multi: boolean): 
     const groupContext = new GroupContext(adapter, config.context.maxContextChars);
     groupContext.loadAllFromDb();
 
+    // --- P2-A: server GROUP.md cache (durable copy under dataDir, decoupled from
+    // the P1 GroupContext caches). Created unconditionally — cheap, and the disk
+    // dir is only materialized on first write (i.e. when serverMd is enabled and
+    // a fetch succeeds). ---
+    const groupMdCache = new GroupMdCache(join(config.dataDir, 'group-md-cache'));
+
     // --- #115: cron (opt-in). ---
     if (config.sdk.cron && config.botId) {
       cronStore = new CronStore(join(config.baseDir, config.botId, 'cron.json'));
@@ -278,7 +285,7 @@ async function startBot(config: ReturnType<typeof loadConfig>, multi: boolean): 
       // these on the WS path; guard here too for safety (otherwise a bot's own
       // group message could be cached into group context as un-processed chatter).
       if (msg.from_uid === gateway.botId) return;
-      const p = handleMessage(msg, config, store, router, groupContext, streamRelay, gateway.botId, cronStore)
+      const p = handleMessage(msg, config, store, router, groupContext, streamRelay, gateway.botId, cronStore, groupMdCache)
         .catch((err) => {
           console.error(`[cc-channel-octo] ${label}Unhandled message handler error:`, err instanceof Error ? err.message : err);
         })
@@ -299,7 +306,7 @@ async function startBot(config: ReturnType<typeof loadConfig>, multi: boolean): 
         cronStore,
         onFire: (msg: BotMessage): Promise<void> => {
           if (gateway.draining) return Promise.resolve();
-          const p = handleMessage(msg, config, store, router, groupContext, streamRelay, gateway.botId, cronStore)
+          const p = handleMessage(msg, config, store, router, groupContext, streamRelay, gateway.botId, cronStore, groupMdCache)
             .finally(() => { activeHandlers.delete(p); });
           activeHandlers.add(p);
           return p;
@@ -359,6 +366,7 @@ export async function handleMessage(
   streamRelay: StreamRelay,
   botId: string,
   cronStore?: CronStore,
+  groupMdCache?: GroupMdCache,
 ): Promise<void> {
   const channelId = msg.channel_id ?? '';
   const channelType = msg.channel_type ?? ChannelType.DM;
@@ -793,11 +801,20 @@ export async function handleMessage(
         sessionOpts = { ...(sessionOpts ?? {}), memoryDir };
       }
 
-      // v1.0 GROUP.md: inject operator-provided per-group instructions (from
-      // config.groupConfigDir/<channelId>.md) into the system prompt. Only for
-      // groups — DMs key on the peer uid, not a shared channel.
+      // GROUP.md: inject operator-provided per-group instructions into the
+      // system prompt. Only for groups — DMs key on the peer uid, not a shared
+      // channel. P2-A: server-first (GET /v1/bot/groups/{groupNo}/md, cached)
+      // with a never-lose fallback to the local `groupConfigDir/<channelId>.md`
+      // file; gated behind `config.serverMd` (off → pure local file).
       if (isGroup) {
-        const groupInstructions = loadGroupConfig(config.groupConfigDir, channelId);
+        const groupInstructions = await resolveGroupInstructions({
+          groupConfigDir: config.groupConfigDir,
+          serverMd: config.serverMd,
+          apiUrl: config.apiUrl,
+          botToken: config.botToken,
+          channelId,
+          cache: groupMdCache,
+        });
         if (groupInstructions) {
           sessionOpts = { ...(sessionOpts ?? {}), groupInstructions };
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ import { resolveContent, tryResolveFile, resolveHistoricalMessagePlaceholder } f
 import { downloadInboundImage, MAX_IMAGES_PER_MESSAGE } from './media-inbound.js';
 import { handleCommand } from './commands.js';
 import { resolveGroupInstructions } from './group-md.js';
-import { GroupMdCache } from './group-md-cache.js';
+import { GroupMdCache, DEFAULT_GROUP_MD_TTL_MS } from './group-md-cache.js';
 import { CronStore } from './cron-store.js';
 import { CronScheduler } from './cron-scheduler.js';
 import { createCronToolServer, CRON_TOOL_SERVER_NAME, type CronSessionCoords } from './cron-tool.js';
@@ -212,11 +212,13 @@ async function startBot(config: ReturnType<typeof loadConfig>, multi: boolean): 
     const groupContext = new GroupContext(adapter, config.context.maxContextChars);
     groupContext.loadAllFromDb();
 
-    // --- P2-A: server GROUP.md cache (durable copy under dataDir, decoupled from
-    // the P1 GroupContext caches). Created unconditionally — cheap, and the disk
-    // dir is only materialized on first write (i.e. when serverMd is enabled and
-    // a fetch succeeds). ---
-    const groupMdCache = new GroupMdCache(join(config.dataDir, 'group-md-cache'));
+    // --- P2-A: server GROUP.md cache. IN-MEMORY ONLY (no disk) — the resolved
+    // GROUP.md is injected as a TRUSTED system-prompt block, and a disk cache the
+    // gateway user can write would be a chat-injection → trusted-prompt poisoning
+    // vector that survives restart (review #172 🔴; see group-md-cache.ts). TTL
+    // bounds staleness (review #172 🟡). Decoupled from the P1 GroupContext
+    // caches; created unconditionally (cheap, only populated when serverMd is on). ---
+    const groupMdCache = new GroupMdCache(config.serverMdTtlMs ?? DEFAULT_GROUP_MD_TTL_MS);
 
     // --- #115: cron (opt-in). ---
     if (config.sdk.cron && config.botId) {

--- a/src/octo/api.ts
+++ b/src/octo/api.ts
@@ -1,9 +1,10 @@
 // Forked from openclaw-channel-octo v1.0.13 (2026-06-04)
 // Source: https://github.com/Mininglamp-OSS/openclaw-channel-octo
-// Removed: COS upload, GROUP.md API, OBO, rich text, media, group management,
+// Removed: COS upload, OBO, rich text, media, group management,
 //          read receipts, bot groups list, group info, mention prefs, space members.
 // Restored: thread lifecycle (create/list/get/delete/members/join/leave) — see
-//          "Thread Lifecycle" section below; group/server-md APIs stay removed.
+//          "Thread Lifecycle" section below; GROUP.md server API (get/update) —
+//          see "Group Markdown (GROUP.md)" section below.
 
 import {
   ChannelType,
@@ -665,4 +666,81 @@ export async function leaveThread(params: {
     `/v1/bot/groups/${encodeURIComponent(params.groupNo)}/threads/${encodeURIComponent(params.shortId)}/leave`,
     params.signal,
   );
+}
+
+// ─── Group Markdown (GROUP.md) ───────────────────────────────────────────────
+//
+// Restores the GROUP.md server API removed at fork time (see file header). A
+// group's GROUP.md is operator-authored persona / rules stored server-side; the
+// gateway fetches it (server-first) and injects it as a trusted instruction
+// block into the agent's system prompt. Path / method / auth / response shape
+// are a verbatim restore of openclaw-channel-octo api-fetch.ts
+// (getGroupMd / updateGroupMd), routed through this client's getJson helper so
+// GET shares the same timeout, Bearer auth, int64-safe JSON parse and
+// error-message format as the rest of the API surface.
+
+/** Server GROUP.md payload returned by GET /v1/bot/groups/{groupNo}/md. */
+export interface GroupMd {
+  content: string;
+  version: number;
+  updated_at: string | null;
+  updated_by: string;
+}
+
+/**
+ * Fetch a group's server-side GROUP.md. GET /v1/bot/groups/{groupNo}/md.
+ *
+ * Throws on any non-2xx (including 404 "no GROUP.md set") — the caller decides
+ * how to degrade. The server-first fetch orchestrator (group-md.ts) catches and
+ * falls back to the local instruction file, so a 404 cleanly downgrades to local.
+ */
+export async function getGroupMd(params: {
+  apiUrl: string;
+  botToken: string;
+  groupNo: string;
+  signal?: AbortSignal;
+}): Promise<GroupMd> {
+  return await getJson<GroupMd>(
+    params.apiUrl,
+    params.botToken,
+    `/v1/bot/groups/${encodeURIComponent(params.groupNo)}/md`,
+    params.signal,
+  );
+}
+
+/**
+ * Update a group's server-side GROUP.md (requires bot_admin permission).
+ * PUT /v1/bot/groups/{groupNo}/md, body `{ content }` → `{ version }`.
+ *
+ * NOTE (P2-A scope): this client function is restored alongside getGroupMd, but
+ * is intentionally NOT wired into any write-back path here — the PUT trigger
+ * chain is owned by a separate work item. Mirrors postJson's timeout, Bearer
+ * auth and error-message format.
+ */
+export async function updateGroupMd(params: {
+  apiUrl: string;
+  botToken: string;
+  groupNo: string;
+  content: string;
+  signal?: AbortSignal;
+}): Promise<{ version: number }> {
+  const path = `/v1/bot/groups/${encodeURIComponent(params.groupNo)}/md`;
+  const url = `${params.apiUrl.replace(/\/+$/, "")}${path}`;
+  const effectiveSignal = params.signal ?? AbortSignal.timeout(DEFAULT_TIMEOUT_MS);
+  const resp = await fetch(url, {
+    method: "PUT",
+    headers: {
+      ...DEFAULT_HEADERS,
+      Authorization: `Bearer ${params.botToken}`,
+    },
+    body: JSON.stringify({ content: params.content }),
+    signal: effectiveSignal,
+  });
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => "");
+    throw new Error(`Octo API ${path} failed (${resp.status}): ${text || resp.statusText}`);
+  }
+  const text = await resp.text();
+  if (!text) return { version: 0 };
+  return parseOctoJson<{ version: number }>(text);
 }


### PR DESCRIPTION
Part of #88

## P2-A: server GROUP.md fetch + cache + feature flag

Restores the server GROUP.md API removed at fork time and wires it into the per-group instruction injection, server-first with a never-lose local-file fallback, behind a feature flag. PUT write-back triggering and event-driven refresh are out of scope here (separate work items).

### Changes
- **`src/octo/api.ts`** — restore `getGroupMd` (`GET /v1/bot/groups/{groupNo}/md` → `{content, version, updated_at, updated_by}`) routed through the shared `getJson` client so it reuses the same timeout, `Bearer` auth, int64-safe JSON parse and error format as the rest of the surface. `updateGroupMd` (`PUT`, body `{content}` → `{version}`) is restored as a client function **only** — it is not connected to any write-back path.
- **`src/group-md-cache.ts`** (new) — two-tier cache keyed by `groupNo`: in-memory `Map` + durable on-disk copy (`<groupNo>.md` for content, `<groupNo>.meta.json` for version/updated_at/updated_by). Independent of the group-context caches. Path-safe `groupNo` guard; `invalidate()` hook for the future event-driven refresh.
- **`src/group-md.ts`** (new) — `resolveGroupInstructions`: server-first with a never-lose fallback to the local `groupConfigDir` file on any failure (404 / network / timeout / empty content). Threads resolve their **parent** `groupNo` (`extractParentGroupNo`) for the server call + cache key, while the local fallback keeps the full `channelId` routing intact.
- **`src/config.ts`** — `serverMd` feature flag (default **off** → pure local-file behavior; flip off to roll back).
- **`src/index.ts`** — `await resolveGroupInstructions(...)` in the group path; one cache instance per bot under `<dataDir>/group-md-cache`.
- **`config.example.json`** — document the `serverMd` flag.

### Testing
- Baseline before: 58 files / 1132 tests green. After: **60 files / 1153 tests green** (+21 new), no regressions.
- New tests: `group-md-api` (GET/PUT path, method, Bearer auth, body, parse, non-2xx errors) and `group-md` (cache memory+disk persistence/invalidate/path-safety; resolver flag gating, server-first preference, 404/empty/network/no-cache fallback, cache reuse, thread parent-group routing).
- Verified the existing local-file injection, thread routing, and group-instruction e2e paths stay green (no degradation).
- `type-check`, `lint` (`--max-warnings 0`) and `build` all clean.
