### PR TITLE
feat(group-md): event-driven GROUP.md cache refresh (P2-B)

### DIFF
--- a/src/__tests__/session-router.test.ts
+++ b/src/__tests__/session-router.test.ts
@@ -10,6 +10,8 @@ import type { BotMessage } from '../octo/types.js';
 import { ChannelType, MessageType } from '../octo/types.js';
 import type { Config } from '../config.js';
 import { sendMessage } from '../octo/api.js';
+import { GroupMdCache } from '../group-md-cache.js';
+import type { GroupMdEntry } from '../group-md-cache.js';
 
 const ROBOT_ID = 'bot-001';
 
@@ -970,5 +972,156 @@ describe('SessionRouter — thread (CommunityTopic) session isolation [#88]', ()
     const a = makeMsg({ channel_type: ChannelType.CommunityTopic, channel_id: `${GROUP}____aaa`, from_uid: 'u1' });
     const b = makeMsg({ channel_type: ChannelType.CommunityTopic, channel_id: `${GROUP}____bbb`, from_uid: 'u1' });
     expect(router.sessionKey(a)).not.toBe(router.sessionKey(b));
+  });
+});
+
+// --- P2-B: server GROUP.md change events drive a cache refresh ---
+//
+// GROUP.md change events are delivered on a system/DM channel (a group event on
+// the group's own channel dies at the mention gate before reaching the event
+// branch — XIN-173), so the group identity travels in `event.group_no`, not the
+// arriving channel_id. The event.type literal is PROVISIONAL (group-md-events.ts)
+// — these tests use the default literal and an explicit override to lock in BOTH
+// the routing (md event → invalidate; everything else → dropped, never
+// invalidated) and the config-override seam, so calibrating the literal later
+// needs no test rewrite.
+describe('SessionRouter — GROUP.md event-driven cache refresh (P2-B)', () => {
+  const GROUP = 'group-abc';
+
+  function makeEntry(): GroupMdEntry {
+    return { content: '# cached', version: 1, updated_at: null };
+  }
+
+  function makeRouter(cache?: GroupMdCache, overrides?: Partial<Config>): SessionRouter {
+    // serverMd on by default here — the refresh path is gated on it.
+    return new SessionRouter(makeConfig({ serverMd: true, ...overrides }), ROBOT_ID, '', cache);
+  }
+
+  // A GROUP.md change event as it really arrives: on a DM channel, with the
+  // affected group carried in event.group_no.
+  function mdEvent(overrides?: Partial<BotMessage>): BotMessage {
+    return makeMsg({
+      channel_type: ChannelType.DM,
+      channel_id: 'dm-peer',
+      from_uid: 'user-1',
+      payload: { type: MessageType.Text, content: '', event: { type: 'group_md_updated', group_no: GROUP } },
+      ...overrides,
+    });
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('a GROUP.md update event invalidates that group\'s cache (next turn re-fetches) and still returns null', async () => {
+    const cache = new GroupMdCache();
+    cache.set(GROUP, makeEntry());
+    const router = makeRouter(cache);
+
+    const result = await router.route(mdEvent());
+
+    // The event itself never produces a reply.
+    expect(result).toBeNull();
+    expect(sendMessage).not.toHaveBeenCalled();
+    // The cached entry is dropped (keyed by event.group_no, not the DM channel),
+    // so the resolver re-fetches the authoritative copy on the next turn.
+    expect(cache.get(GROUP)).toBeUndefined();
+  });
+
+  it('a join/leave (non-md) system event is dropped WITHOUT invalidating the cache', async () => {
+    const cache = new GroupMdCache();
+    cache.set(GROUP, makeEntry());
+    const router = makeRouter(cache);
+
+    const join = mdEvent({
+      payload: { type: MessageType.Text, content: '', event: { type: 'group_member_join', group_no: GROUP } },
+    });
+    const result = await router.route(join);
+
+    expect(result).toBeNull();
+    expect(sendMessage).not.toHaveBeenCalled();
+    // Non-md events must NOT be mistaken for an md event — cache is untouched.
+    expect(cache.get(GROUP)).toEqual(makeEntry());
+  });
+
+  it('an event with no type is dropped and never invalidates', async () => {
+    const cache = new GroupMdCache();
+    cache.set(GROUP, makeEntry());
+    const router = makeRouter(cache);
+
+    const result = await router.route(
+      mdEvent({ payload: { type: MessageType.Text, content: '', event: { group_no: GROUP } } }),
+    );
+
+    expect(result).toBeNull();
+    expect(cache.get(GROUP)).toEqual(makeEntry());
+  });
+
+  it('an md event with no group_no on a DM channel is a no-op (no group to target)', async () => {
+    const cache = new GroupMdCache();
+    cache.set(GROUP, makeEntry());
+    const router = makeRouter(cache);
+
+    const result = await router.route(
+      mdEvent({ payload: { type: MessageType.Text, content: '', event: { type: 'group_md_updated' } } }),
+    );
+
+    expect(result).toBeNull();
+    expect(cache.get(GROUP)).toEqual(makeEntry());
+  });
+
+  it('with serverMd off the cache is never touched (rollback flag)', async () => {
+    const cache = new GroupMdCache();
+    cache.set(GROUP, makeEntry());
+    const router = makeRouter(cache, { serverMd: false });
+
+    const result = await router.route(mdEvent());
+
+    expect(result).toBeNull();
+    expect(cache.get(GROUP)).toEqual(makeEntry());
+  });
+
+  it('no cache wired → md event is a harmless no-op (still returns null)', async () => {
+    const router = makeRouter(undefined);
+    const result = await router.route(mdEvent());
+    expect(result).toBeNull();
+  });
+
+  it('falls back to the channel group when an md event arrives on a mention-free group with no group_no', async () => {
+    const cache = new GroupMdCache();
+    cache.set(GROUP, makeEntry());
+    // Mention-free is the one group path that reaches the event branch (the
+    // mention gate otherwise drops un-mentioned group messages). A composite
+    // thread channel_id normalizes to its parent group.
+    const router = makeRouter(cache, { mentionFreeGroups: [`${GROUP}____thread-1`] });
+
+    const result = await router.route(
+      mdEvent({
+        channel_type: ChannelType.CommunityTopic,
+        channel_id: `${GROUP}____thread-1`,
+        payload: { type: MessageType.Text, content: '', event: { type: 'group_md_updated' } },
+      }),
+    );
+
+    expect(result).toBeNull();
+    expect(cache.get(GROUP)).toBeUndefined();
+  });
+
+  it('the md event literal is overridable via serverMdEventTypes (calibration seam)', async () => {
+    const cache = new GroupMdCache();
+    cache.set(GROUP, makeEntry());
+    // The provisional default literal no longer matches; a real captured literal does.
+    const router = makeRouter(cache, { serverMdEventTypes: ['group.md.changed'] });
+
+    // Default literal is now ignored.
+    await router.route(mdEvent());
+    expect(cache.get(GROUP)).toEqual(makeEntry());
+
+    // The configured literal triggers invalidation.
+    const real = mdEvent({
+      payload: { type: MessageType.Text, content: '', event: { type: 'group.md.changed', group_no: GROUP } },
+    });
+    await router.route(real);
+    expect(cache.get(GROUP)).toBeUndefined();
   });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -107,6 +107,16 @@ export interface Config {
    * `DEFAULT_GROUP_MD_TTL_MS` (5 min). Only meaningful when `serverMd` is true.
    */
   serverMdTtlMs?: number;
+  /**
+   * P2-B: `event.type` literal(s) the server emits when a group's GROUP.md
+   * changes. On such an event the in-memory GROUP.md cache for that group is
+   * invalidated so the next turn re-fetches the authoritative copy (never
+   * trusting the event payload — see group-md-events.ts). PROVISIONAL: the
+   * exact literal is not yet confirmed from a real captured event, so this is
+   * overridable here to calibrate without a code change. Defaults to
+   * `DEFAULT_GROUP_MD_EVENT_TYPES`. Only meaningful when `serverMd` is true.
+   */
+  serverMdEventTypes?: string[];
   sdk: {
     model?: string;
     /**
@@ -279,6 +289,7 @@ type PartialConfig = {
   groupConfigDir?: string;
   serverMd?: boolean;
   serverMdTtlMs?: number;
+  serverMdEventTypes?: string[];
   sdk?: Partial<Config['sdk']>;
   rateLimit?: Partial<Config['rateLimit']>;
   context?: Partial<Config['context']>;
@@ -372,6 +383,7 @@ function mergeConfig(base: Config, override: PartialConfig): Config {
     groupConfigDir: override.groupConfigDir ?? base.groupConfigDir,
     serverMd: override.serverMd ?? base.serverMd,
     serverMdTtlMs: override.serverMdTtlMs ?? base.serverMdTtlMs,
+    serverMdEventTypes: override.serverMdEventTypes ?? base.serverMdEventTypes,
     sdk: {
       ...base.sdk,
       ...(override.sdk ?? {}),
@@ -606,6 +618,7 @@ export function resolveBotConfigs(config: Config): Config[] {
       groupConfigDir: perBotFile.groupConfigDir ?? config.groupConfigDir,
       serverMd: perBotFile.serverMd ?? config.serverMd,
       serverMdTtlMs: perBotFile.serverMdTtlMs ?? config.serverMdTtlMs,
+      serverMdEventTypes: perBotFile.serverMdEventTypes ?? config.serverMdEventTypes,
       sdk: {
         ...config.sdk,
         ...(perBotFile.sdk ?? {}),

--- a/src/group-md-events.ts
+++ b/src/group-md-events.ts
@@ -1,0 +1,52 @@
+/**
+ * GROUP.md server-event classification (P2-B) — event-driven cache refresh.
+ *
+ * The server emits system events on the inbound socket as `payload.event`
+ * (shape `{ type, version, updated_by, group_no, short_id }`, see
+ * octo/types.ts MessagePayload.event). When the operator edits a group's
+ * server GROUP.md, the server reports it as one of these events; on receipt we
+ * INVALIDATE the in-memory GROUP.md cache for that group so the next turn
+ * re-fetches the authoritative copy (see group-md-cache.ts `invalidate`).
+ *
+ * SECURITY — why invalidate-then-refetch, never trust the event payload:
+ *   The event arrives over the same untrusted channel as chat, so a forged
+ *   `group_md_updated` event must NOT be able to inject content. We never read
+ *   the new GROUP.md from the event body; we only use it as a signal to drop
+ *   the cached entry, after which the resolver re-fetches over the
+ *   authenticated bot token against the SSRF-validated apiUrl (the sole trusted
+ *   path, identical to P2-A). The worst a forged event can do is force a
+ *   redundant authenticated re-fetch of the real value — never poisoning.
+ *
+ * ⚠️ PROVISIONAL EVENT TYPE — the exact `event.type` literal the server emits
+ * for a GROUP.md change is NOT yet confirmed from a real captured event
+ * (XIN-173 confirmed the event SHAPE, not the type literal). The default below
+ * is named after the design (`group_md_updated`) and is overridable via
+ * `config.serverMdEventTypes`, so the literal can be calibrated against a real
+ * event WITHOUT a code change once captured. Keep this note until calibrated.
+ */
+
+/**
+ * Provisional `event.type` literals treated as a GROUP.md change. PROVISIONAL —
+ * see the calibration note above. Overridable via `config.serverMdEventTypes`.
+ */
+export const DEFAULT_GROUP_MD_EVENT_TYPES: readonly string[] = ['group_md_updated'];
+
+/** The `payload.event` shape (mirrors MessagePayload.event in octo/types.ts). */
+export interface GroupMdEventLike {
+  type?: string;
+  group_no?: string;
+}
+
+/**
+ * True iff this event signals a GROUP.md change and should drive a cache
+ * refresh. All other system events (group join/leave, etc.) return false and
+ * are dropped unchanged by the router. `eventTypes` lets the operator override
+ * the provisional literal(s) without a code change.
+ */
+export function isGroupMdUpdateEvent(
+  event: GroupMdEventLike | undefined,
+  eventTypes: readonly string[] = DEFAULT_GROUP_MD_EVENT_TYPES,
+): boolean {
+  if (!event || typeof event.type !== 'string' || event.type === '') return false;
+  return eventTypes.includes(event.type);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -272,7 +272,10 @@ async function startBot(config: ReturnType<typeof loadConfig>, multi: boolean): 
     }
 
     // --- Session router ---
-    const router = new SessionRouter(config, gateway.botId, gateway.ownerUid);
+    // P2-B: the router holds the GROUP.md cache so a server GROUP.md change
+    // event invalidates the affected group's entry (re-fetched authoritatively
+    // next turn — never trusting the event payload). No-op when serverMd is off.
+    const router = new SessionRouter(config, gateway.botId, gateway.ownerUid, groupMdCache);
 
     // --- Active handler tracking (Q6: in-flight drain on shutdown) ---
     const activeHandlers = new Set<Promise<void>>();

--- a/src/session-router.ts
+++ b/src/session-router.ts
@@ -7,6 +7,9 @@ import type { BotMessage, MentionEntity } from './octo/types.js';
 import { ChannelType, MessageType } from './octo/types.js';
 import { sendMessage } from './octo/api.js';
 import { isAuthenticCronFire } from './cron-fire-marker.js';
+import { extractParentGroupNo } from './octo/channel-id.js';
+import type { GroupMdCache } from './group-md-cache.js';
+import { isGroupMdUpdateEvent } from './group-md-events.js';
 
 export interface RouteResult {
   sessionKey: string;
@@ -64,11 +67,20 @@ export class SessionRouter {
    */
   private readonly knownBotUids = new Set<string>();
 
-  constructor(config: Config, robotId: string, ownerUid = '') {
+  /**
+   * P2-B: in-memory server GROUP.md cache (A's P2-A cache). Held so a GROUP.md
+   * change event can invalidate the affected group's entry, forcing the next
+   * turn to re-fetch the authoritative copy. Optional — omitted (or with
+   * `serverMd` off) the event path is a harmless no-op.
+   */
+  private readonly groupMdCache?: GroupMdCache;
+
+  constructor(config: Config, robotId: string, ownerUid = '', groupMdCache?: GroupMdCache) {
     this.config = config;
     this.robotId = robotId;
     this.ownerUid = ownerUid;
     this.knownBotUids.add(robotId);
+    this.groupMdCache = groupMdCache;
   }
 
   /** G14: register another known bot uid (future multi-bot support). */
@@ -335,6 +347,51 @@ export class SessionRouter {
     return isAuthenticCronFire(msg.payload);
   }
 
+  /**
+   * P2-B: react to a server system event that signals a GROUP.md change by
+   * invalidating that group's cached server GROUP.md, so the next turn re-fetches
+   * the authoritative copy over the authenticated bot token (never trusting the
+   * event payload as the new content — see group-md-events.ts for the
+   * forged-event poisoning rationale). Non-md system events (join/leave, etc.)
+   * match nothing here and fall through to the caller's `return null`, so they
+   * are dropped exactly as before.
+   *
+   * Gated on `serverMd`: with the flag off the cache is never populated, so there
+   * is nothing to invalidate. Best-effort and never throws — a malformed event
+   * must not wedge the router (the caller drops the event regardless).
+   *
+   * The group is identified from the event's `group_no`: these events are
+   * delivered on a system/DM channel (a group event on the group's own channel
+   * dies at the mention gate above, never reaching here — XIN-173), so the
+   * arriving `channel_id` is the sender, not the group. The channel is only a
+   * fallback when `group_no` is absent AND the event happens to have arrived on a
+   * group-like channel (e.g. a mention-free group, the one group path that
+   * reaches this point). Using the event-supplied `group_no` is safe despite the
+   * event being untrusted: invalidation is non-destructive — the worst a forged
+   * event can do is force a redundant authenticated re-fetch of the real value,
+   * never inject content (the new GROUP.md is always re-fetched, never read from
+   * the event body — see group-md-events.ts).
+   */
+  private handleGroupMdEvent(msg: BotMessage): void {
+    if (!this.config.serverMd || !this.groupMdCache) return;
+    const event = msg.payload.event;
+    if (!isGroupMdUpdateEvent(event, this.config.serverMdEventTypes)) return;
+
+    let groupNo = event?.group_no ?? '';
+    if (groupNo === '' && this.isGroupLike(msg.channel_type)) {
+      groupNo = extractParentGroupNo(msg.channel_id ?? '');
+    }
+    if (groupNo === '') return;
+
+    // invalidate() is itself total (validates the id, never throws); the guard
+    // here keeps a future non-total cache from breaking the drop path.
+    try {
+      this.groupMdCache.invalidate(groupNo);
+    } catch {
+      /* best-effort: a refresh hiccup must never block dropping the event */
+    }
+  }
+
   private async processMessage(msg: BotMessage, key: string): Promise<RouteResult | null> {
     // Skip messages from self.
     if (msg.from_uid === this.robotId) return null;
@@ -394,8 +451,16 @@ export class SessionRouter {
       }
     }
 
-    // Skip system events (group join/leave, etc.) — no user-facing reply needed.
-    if (msg.payload.event) return null;
+    // System events (group join/leave, GROUP.md change, etc.) never produce a
+    // user-facing reply, so they always route to `null`. P2-B: before dropping,
+    // a GROUP.md change event is dispatched to invalidate that group's cached
+    // server GROUP.md (forcing the next turn to re-fetch the authoritative copy);
+    // every other system event (join/leave/...) is dropped unchanged, exactly as
+    // before — non-md events must NOT be mistaken for an md event.
+    if (msg.payload.event) {
+      this.handleGroupMdEvent(msg);
+      return null;
+    }
 
     // Rate limit check BEFORE non-text check — prevents DM spam of non-text
     // messages from bypassing rate limiting entirely.


### PR DESCRIPTION
## Summary

Part of #88 (P2). Stage 2 item **B — server GROUP.md change events drive a cache refresh**.

`session-router` currently drops every system event with a single `if (msg.payload.event) return null;`. This change splits that guard by `event.type`:

- A **GROUP.md change** event invalidates that group's entry in the in-memory server GROUP.md cache, so the next turn re-fetches the authoritative copy.
- Every **other** system event (group join/leave, etc.) is dropped unchanged — non-md events must never be mistaken for an md event.

The event payload is **never** trusted as the new content. The event is only a signal to drop the cached entry; the existing resolver then re-fetches over the authenticated bot token against the SSRF-validated `apiUrl` (the sole trusted path, identical to the P2-A design). The worst a forged event can do is force a redundant authenticated re-fetch of the real value — never inject content. This keeps the same memory-only / no-poisoning guarantees as the cache layer.

The affected group is taken from the event's `group_no` (these events arrive on a system/DM channel, so the arriving `channel_id` is the sender, not the group), falling back to the channel only on the mention-free-group path where a group event can reach this point.

## Dependency on A (stacked PR)

This branches off **#172** (`feat/server-group-md-fetch-cache`, A's P2-A cache + `invalidate()` hook) — **not** `main` — and must merge **after** #172. The cache-layer commits (`302497b`, `d31d570`) shown in this PR's range belong to #172; the only new commit here is the event-refresh change. Review base should be A's branch.

## Provisional event type (⚠️ needs calibration against a real event)

XIN-173 confirmed the event **shape** (`{ type, version, updated_by, group_no, short_id }`) but **not** the exact `event.type` literal the server emits for a GROUP.md change. The default literal (`group_md_updated`) is named after the design and is **overridable via `serverMdEventTypes`**, so it can be calibrated once a real event is captured — without a code change. The `⚠️ PROVISIONAL` note in `group-md-events.ts` tracks this until confirmed.

## Rollback

Gated behind the existing `serverMd` feature flag (flag off → cache never populated → the event path is a harmless no-op).

## Tests

New `session-router` cases cover both branches of the split:

- md event → cache for that group is invalidated (re-fetch next turn), still returns `null`, no reply sent;
- join/leave (and typeless) event → dropped, cache untouched;
- `serverMd` off / no cache wired → no-op;
- mention-free-group fallback to the channel group when `group_no` is absent;
- `serverMdEventTypes` override (calibration seam).

Full suite green (`npm test`: 1164 passing), lint clean (`--max-warnings 0`), build clean.
