### PR TITLE
feat(group-md): owner-gated GROUP.md write-back

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -11,6 +11,9 @@
 
   "_comment_server_md": "P2-A: set serverMd=true to fetch each group's instructions from the server GROUP.md API (GET /v1/bot/groups/{groupNo}/md) first, falling back to the local groupConfigDir file on any failure (404 / network / no content). The fetched copy is cached IN MEMORY ONLY (never on disk — it is injected as a trusted system prompt, and a disk cache the gateway user could write would be a poisoning vector). serverMdTtlMs (default 300000 = 5 min) bounds how stale a cached entry may get before re-fetch. Default serverMd=false = pure local-file behavior (flip off to roll back).",
 
+  "_comment_md_writeback": "P2-C: set mdWriteback=true to give the agent an in-process MCP tool (mcp__group_md__update_group_md) that writes GROUP.md back to the server (PUT /v1/bot/groups/{groupNo}/md). Invocation is owner-gated (only the bot owner uid may call it); content is capped at 10240 bytes UTF-8 locally; write-backs to the same group are serialized in-process (the server has no compare-and-swap, so this prevents this gateway from racing itself — cross-source last-write-wins still applies). Default false = no write-back tool (GROUP.md is read-only from the gateway). Independent of serverMd.",
+
+
   "sdk": {
     "_comment_anthropic_base_url": "Q1: Optional self-hosted Claude API gateway base URL. Forwarded to the SDK subprocess (scoped). Must be https:// (or http://localhost for dev) — SSRF-validated at boot. Omit to use Anthropic's public endpoint.",
     "_comment_allowed_tools": "Q2: either '*' (allow every tool the SDK exposes) or an explicit string[] whitelist.",

--- a/src/__tests__/group-md-tool.test.ts
+++ b/src/__tests__/group-md-tool.test.ts
@@ -1,0 +1,157 @@
+/**
+ * P2-C: GROUP.md write-back tool tests (group-md-tool.ts).
+ *
+ * Drives the tool handler directly via buildGroupMdTools (the MCP server keeps
+ * tools private). The SDK's `tool`/`createSdkMcpServer` are mocked to plain
+ * passthroughs so the module loads without the real SDK.
+ *
+ * Covers the acceptance gates at the policy layer:
+ *   - owner-gate: only the bot owner may write (non-owner / empty-owner rejected,
+ *     no server call);
+ *   - ≤10240-byte UTF-8 rejection surfaces a clean error (no server call);
+ *   - a successful write hits A's updateGroupMd client and refreshes the cache;
+ *   - a thread channelId resolves to its PARENT group number;
+ *   - concurrent tool calls for the same group serialize through the shared
+ *     coordinator (no overlap, no lost write).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@anthropic-ai/claude-agent-sdk', () => ({
+  createSdkMcpServer: (opts: { name: string }) => ({ type: 'sdk', name: opts.name, instance: {} }),
+  tool: (name: string, description: string, inputSchema: unknown, handler: unknown) => ({ name, description, inputSchema, handler }),
+}));
+
+import {
+  buildGroupMdTools,
+  createGroupMdToolServer,
+  GROUP_MD_TOOL_SERVER_NAME,
+  type GroupMdSessionCoords,
+  type GroupMdToolDeps,
+} from '../group-md-tool.js';
+import { GroupMdWriteback, MAX_GROUP_MD_CONTENT_BYTES, type UpdateGroupMdFn } from '../group-md-writeback.js';
+import { GroupMdCache } from '../group-md-cache.js';
+
+const OWNER = 'owner-uid';
+const API = 'https://api.example.com';
+const TOKEN = 'bot-token';
+
+const delay = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+function coords(over: Partial<GroupMdSessionCoords> = {}): GroupMdSessionCoords {
+  return { channelId: 'grp-1', fromUid: OWNER, fromName: 'Owner', ...over };
+}
+
+function getTool(deps: GroupMdToolDeps, c: GroupMdSessionCoords, owner = OWNER) {
+  const t = buildGroupMdTools(deps, c, owner).find((x) => x.name === 'update_group_md');
+  if (!t) throw new Error('tool update_group_md not found');
+  return t as { name: string; handler: (args: { content: string }, extra: unknown) => Promise<{ content: Array<{ text?: string }>; isError?: boolean }> };
+}
+function text(r: { content: Array<{ text?: string }> }): string {
+  return r.content.map((c) => c.text ?? '').join('');
+}
+
+describe('group-md-tool', () => {
+  let cache: GroupMdCache;
+  let putFn: ReturnType<typeof vi.fn<UpdateGroupMdFn>>;
+  let deps: GroupMdToolDeps;
+
+  beforeEach(() => {
+    cache = new GroupMdCache();
+    let version = 0;
+    putFn = vi.fn<UpdateGroupMdFn>(async () => ({ version: ++version }));
+    deps = { writeback: new GroupMdWriteback(cache, putFn), apiUrl: API, botToken: TOKEN };
+  });
+
+  it('createGroupMdToolServer builds an MCP server named "group_md"', () => {
+    const s = createGroupMdToolServer(deps, coords(), OWNER);
+    expect(GROUP_MD_TOOL_SERVER_NAME).toBe('group_md');
+    expect((s as { name: string }).name).toBe('group_md');
+  });
+
+  it('owner write: PUTs the content and refreshes the cache', async () => {
+    const r = await getTool(deps, coords()).handler({ content: 'new persona' }, {});
+    expect(r.isError).toBeFalsy();
+    expect(putFn).toHaveBeenCalledWith(
+      expect.objectContaining({ apiUrl: API, botToken: TOKEN, groupNo: 'grp-1', content: 'new persona' }),
+    );
+    expect(text(r)).toContain('"version": 1');
+    expect(cache.get('grp-1')).toEqual({ content: 'new persona', version: 1, updated_at: null });
+  });
+
+  it('non-owner write is rejected and never calls the server', async () => {
+    const r = await getTool(deps, coords({ fromUid: 'rando' })).handler({ content: 'x' }, {});
+    expect(r.isError).toBe(true);
+    expect(text(r)).toMatch(/only the bot owner/i);
+    expect(putFn).not.toHaveBeenCalled();
+    expect(cache.get('grp-1')).toBeUndefined();
+  });
+
+  it('empty owner uid gates everyone out (no owner → unusable)', async () => {
+    const r = await getTool(deps, coords(), '').handler({ content: 'x' }, {});
+    expect(r.isError).toBe(true);
+    expect(putFn).not.toHaveBeenCalled();
+  });
+
+  it('over-limit content is rejected with a clear error and no server call', async () => {
+    const tooBig = 'a'.repeat(MAX_GROUP_MD_CONTENT_BYTES + 1);
+    const r = await getTool(deps, coords()).handler({ content: tooBig }, {});
+    expect(r.isError).toBe(true);
+    expect(text(r)).toMatch(/over the 10240-byte/i);
+    expect(putFn).not.toHaveBeenCalled();
+    expect(cache.get('grp-1')).toBeUndefined();
+  });
+
+  it('content exactly at the limit is accepted', async () => {
+    const atLimit = 'a'.repeat(MAX_GROUP_MD_CONTENT_BYTES);
+    const r = await getTool(deps, coords()).handler({ content: atLimit }, {});
+    expect(r.isError).toBeFalsy();
+    expect(putFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('a thread channelId writes to its PARENT group number', async () => {
+    const r = await getTool(deps, coords({ channelId: 'grp-7____thread9' })).handler({ content: 'doc' }, {});
+    expect(r.isError).toBeFalsy();
+    expect(putFn).toHaveBeenCalledWith(expect.objectContaining({ groupNo: 'grp-7' }));
+    expect(cache.get('grp-7')).toMatchObject({ content: 'doc' });
+  });
+
+  it('surfaces the client error when the PUT fails (cache untouched)', async () => {
+    putFn.mockRejectedValueOnce(new Error('Octo API PUT failed (400): err.server.bot_api.content_too_large'));
+    const r = await getTool(deps, coords()).handler({ content: 'doc' }, {});
+    expect(r.isError).toBe(true);
+    expect(text(r)).toMatch(/PUT failed/);
+    expect(cache.get('grp-1')).toBeUndefined();
+  });
+
+  it('serializes concurrent tool calls for the same group through the shared coordinator', async () => {
+    let active = 0;
+    let maxActive = 0;
+    let version = 0;
+    const order: string[] = [];
+    const slow: UpdateGroupMdFn = async (p) => {
+      active++;
+      maxActive = Math.max(maxActive, active);
+      await delay(10);
+      order.push(p.content);
+      active--;
+      return { version: ++version };
+    };
+    const shared = new GroupMdWriteback(cache, slow);
+    const d: GroupMdToolDeps = { writeback: shared, apiUrl: API, botToken: TOKEN };
+
+    // Two separate per-turn tool instances (as in production) borrowing the same
+    // shared coordinator — concurrency must still be contained.
+    const tA = getTool(d, coords());
+    const tB = getTool(d, coords());
+    const results = await Promise.all([
+      tA.handler({ content: 'A' }, {}),
+      tB.handler({ content: 'B' }, {}),
+    ]);
+
+    expect(results.every((r) => !r.isError)).toBe(true);
+    expect(maxActive).toBe(1);
+    expect(order).toHaveLength(2); // both writes executed; none lost
+    expect(cache.get('grp-1')?.version).toBe(2);
+  });
+});

--- a/src/__tests__/group-md-writeback.test.ts
+++ b/src/__tests__/group-md-writeback.test.ts
@@ -1,0 +1,184 @@
+/**
+ * P2-C: GROUP.md write-back coordinator tests (group-md-writeback.ts).
+ *
+ * Covers the four XIN-201 contract obligations at the mechanism layer:
+ *   - ≤10240-byte UTF-8 cap rejected LOCALLY (no server PUT) — byte, not char,
+ *     counting on the boundary;
+ *   - successful PUT writes the new content/version back into A's in-memory
+ *     cache (so the next resolve serves what we wrote, not a stale/refetched copy);
+ *   - per-groupNo serialization: concurrent write-backs to the SAME group never
+ *     overlap and never lose a write (no-CAS / last-write-wins is contained
+ *     within this gateway), while different groups still run concurrently;
+ *   - a failed PUT leaves the cache untouched and does not wedge the lock.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  GroupMdWriteback,
+  GroupMdContentTooLargeError,
+  MAX_GROUP_MD_CONTENT_BYTES,
+  type UpdateGroupMdFn,
+} from '../group-md-writeback.js';
+import { GroupMdCache } from '../group-md-cache.js';
+
+const API = 'https://api.example.com';
+const TOKEN = 'bot-token';
+
+const delay = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+/** A version-incrementing fake PUT client (server-style monotonic counter). */
+function versioningUpdateFn(): { fn: UpdateGroupMdFn; calls: () => number } {
+  let version = 0;
+  let calls = 0;
+  const fn: UpdateGroupMdFn = async () => {
+    calls++;
+    version++;
+    return { version };
+  };
+  return { fn, calls: () => calls };
+}
+
+describe('GroupMdWriteback', () => {
+  it('writes content back to the cache with the server-assigned version', async () => {
+    const cache = new GroupMdCache();
+    const { fn } = versioningUpdateFn();
+    const wb = new GroupMdWriteback(cache, fn);
+
+    const res = await wb.writeBack({ apiUrl: API, botToken: TOKEN, groupNo: 'g1', content: 'hello' });
+
+    expect(res).toEqual({ groupNo: 'g1', version: 1, bytes: 5 });
+    expect(cache.get('g1')).toEqual({ content: 'hello', version: 1, updated_at: null });
+  });
+
+  it('passes apiUrl/botToken/groupNo/content through to the PUT client', async () => {
+    const cache = new GroupMdCache();
+    const fn = vi.fn<UpdateGroupMdFn>(async () => ({ version: 7 }));
+    const wb = new GroupMdWriteback(cache, fn);
+
+    await wb.writeBack({ apiUrl: API, botToken: TOKEN, groupNo: 'g9', content: 'doc' });
+
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith(
+      expect.objectContaining({ apiUrl: API, botToken: TOKEN, groupNo: 'g9', content: 'doc' }),
+    );
+  });
+
+  it('allows content exactly at the byte limit', async () => {
+    const cache = new GroupMdCache();
+    const { fn, calls } = versioningUpdateFn();
+    const wb = new GroupMdWriteback(cache, fn);
+    const atLimit = 'a'.repeat(MAX_GROUP_MD_CONTENT_BYTES); // ASCII → 1 byte each
+
+    const res = await wb.writeBack({ apiUrl: API, botToken: TOKEN, groupNo: 'g1', content: atLimit });
+
+    expect(res.bytes).toBe(MAX_GROUP_MD_CONTENT_BYTES);
+    expect(calls()).toBe(1);
+  });
+
+  it('rejects content over the byte limit LOCALLY without calling the PUT client', async () => {
+    const cache = new GroupMdCache();
+    const { fn, calls } = versioningUpdateFn();
+    const wb = new GroupMdWriteback(cache, fn);
+    const tooBig = 'a'.repeat(MAX_GROUP_MD_CONTENT_BYTES + 1);
+
+    await expect(
+      wb.writeBack({ apiUrl: API, botToken: TOKEN, groupNo: 'g1', content: tooBig }),
+    ).rejects.toBeInstanceOf(GroupMdContentTooLargeError);
+
+    expect(calls()).toBe(0); // never hit the server
+    expect(cache.get('g1')).toBeUndefined(); // cache untouched
+  });
+
+  it('counts BYTES not characters on the limit (multi-byte UTF-8)', async () => {
+    const cache = new GroupMdCache();
+    const { fn, calls } = versioningUpdateFn();
+    const wb = new GroupMdWriteback(cache, fn);
+    // '✓' is 3 UTF-8 bytes; 3414 chars = 10242 bytes > limit, though only 3414 chars.
+    const content = '✓'.repeat(3414);
+    expect(content.length).toBeLessThan(MAX_GROUP_MD_CONTENT_BYTES);
+    expect(Buffer.byteLength(content, 'utf-8')).toBeGreaterThan(MAX_GROUP_MD_CONTENT_BYTES);
+
+    await expect(
+      wb.writeBack({ apiUrl: API, botToken: TOKEN, groupNo: 'g1', content }),
+    ).rejects.toBeInstanceOf(GroupMdContentTooLargeError);
+    expect(calls()).toBe(0);
+  });
+
+  it('serializes concurrent write-backs to the SAME group (no overlap, no lost write)', async () => {
+    const cache = new GroupMdCache();
+    let active = 0;
+    let maxActive = 0;
+    let version = 0;
+    const order: string[] = [];
+    const fn: UpdateGroupMdFn = async (p) => {
+      active++;
+      maxActive = Math.max(maxActive, active);
+      await delay(10);
+      order.push(p.content);
+      version++;
+      active--;
+      return { version };
+    };
+    const wb = new GroupMdWriteback(cache, fn);
+
+    await Promise.all(
+      ['v1', 'v2', 'v3', 'v4', 'v5'].map((c) =>
+        wb.writeBack({ apiUrl: API, botToken: TOKEN, groupNo: 'g1', content: c }),
+      ),
+    );
+
+    expect(maxActive).toBe(1); // never two in-flight for the same group
+    expect(order).toEqual(['v1', 'v2', 'v3', 'v4', 'v5']); // submission order preserved
+    // Last write wins in the cache, with the final monotonic version — and every
+    // write actually executed (none collapsed/lost).
+    expect(cache.get('g1')).toEqual({ content: 'v5', version: 5, updated_at: null });
+  });
+
+  it('runs write-backs for DIFFERENT groups concurrently', async () => {
+    const cache = new GroupMdCache();
+    let active = 0;
+    let maxActive = 0;
+    let version = 0;
+    const fn: UpdateGroupMdFn = async () => {
+      active++;
+      maxActive = Math.max(maxActive, active);
+      await delay(10);
+      active--;
+      version++;
+      return { version };
+    };
+    const wb = new GroupMdWriteback(cache, fn);
+
+    await Promise.all([
+      wb.writeBack({ apiUrl: API, botToken: TOKEN, groupNo: 'g1', content: 'a' }),
+      wb.writeBack({ apiUrl: API, botToken: TOKEN, groupNo: 'g2', content: 'b' }),
+    ]);
+
+    expect(maxActive).toBe(2); // distinct groups are not serialized against each other
+  });
+
+  it('leaves the cache untouched and does not wedge the lock when a PUT fails', async () => {
+    const cache = new GroupMdCache();
+    let shouldFail = true;
+    let version = 0;
+    const fn: UpdateGroupMdFn = async () => {
+      if (shouldFail) {
+        shouldFail = false;
+        throw new Error('Octo API PUT failed (500): boom');
+      }
+      version++;
+      return { version };
+    };
+    const wb = new GroupMdWriteback(cache, fn);
+
+    await expect(
+      wb.writeBack({ apiUrl: API, botToken: TOKEN, groupNo: 'g1', content: 'first' }),
+    ).rejects.toThrow(/PUT failed/);
+    expect(cache.get('g1')).toBeUndefined();
+
+    // The lock chain must keep working after a rejected op.
+    const res = await wb.writeBack({ apiUrl: API, botToken: TOKEN, groupNo: 'g1', content: 'second' });
+    expect(res.version).toBe(1);
+    expect(cache.get('g1')).toEqual({ content: 'second', version: 1, updated_at: null });
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -117,6 +117,16 @@ export interface Config {
    * `DEFAULT_GROUP_MD_EVENT_TYPES`. Only meaningful when `serverMd` is true.
    */
   serverMdEventTypes?: string[];
+  /**
+   * P2-C feature flag: when true, the agent gets an in-process MCP tool
+   * (`mcp__group_md__update_group_md`) that writes GROUP.md back to the server
+   * (PUT /v1/bot/groups/{groupNo}/md). Off (default) → no write-back tool is
+   * registered, so GROUP.md is read-only from the gateway's side — flip it off
+   * to roll back. Invocation is owner-gated regardless; this flag is the
+   * coarse on/off switch. Independent of `serverMd` (which only governs the
+   * server-first READ path), so an operator can enable reads without writes.
+   */
+  mdWriteback?: boolean;
   sdk: {
     model?: string;
     /**
@@ -290,6 +300,7 @@ type PartialConfig = {
   serverMd?: boolean;
   serverMdTtlMs?: number;
   serverMdEventTypes?: string[];
+  mdWriteback?: boolean;
   sdk?: Partial<Config['sdk']>;
   rateLimit?: Partial<Config['rateLimit']>;
   context?: Partial<Config['context']>;
@@ -384,6 +395,7 @@ function mergeConfig(base: Config, override: PartialConfig): Config {
     serverMd: override.serverMd ?? base.serverMd,
     serverMdTtlMs: override.serverMdTtlMs ?? base.serverMdTtlMs,
     serverMdEventTypes: override.serverMdEventTypes ?? base.serverMdEventTypes,
+    mdWriteback: override.mdWriteback ?? base.mdWriteback,
     sdk: {
       ...base.sdk,
       ...(override.sdk ?? {}),
@@ -619,6 +631,7 @@ export function resolveBotConfigs(config: Config): Config[] {
       serverMd: perBotFile.serverMd ?? config.serverMd,
       serverMdTtlMs: perBotFile.serverMdTtlMs ?? config.serverMdTtlMs,
       serverMdEventTypes: perBotFile.serverMdEventTypes ?? config.serverMdEventTypes,
+      mdWriteback: perBotFile.mdWriteback ?? config.mdWriteback,
       sdk: {
         ...config.sdk,
         ...(perBotFile.sdk ?? {}),

--- a/src/group-md-tool.ts
+++ b/src/group-md-tool.ts
@@ -1,0 +1,135 @@
+/**
+ * P2-C: GROUP.md write-back tool — an in-process MCP server letting the agent
+ * persist an updated GROUP.md back to the server. The tool surfaces to the model
+ * as `mcp__group_md__update_group_md`.
+ *
+ * The server is built PER TURN (`createGroupMdToolServer`) with the current
+ * message's channel coords + the bot owner uid, so:
+ *  - the write targets the PARENT group of the channel the agent is in
+ *    (`extractParentGroupNo` — a thread shares its parent group's GROUP.md);
+ *  - invocation is GATED to the bot owner (registerBot.owner_uid). The group's
+ *    octo_tag token has server-side write permission, but the agent is driven by
+ *    untrusted IM users, so this owner gate — not LLM judgment, and independent
+ *    of the token's group-role permission — is what stops a prompt-injected
+ *    agent from rewriting the operator's trusted GROUP.md from any chat.
+ *
+ * Concurrency, the byte ceiling, and the cache refresh are owned by the shared
+ * {@link GroupMdWriteback} coordinator (group-md-writeback.ts); this layer is
+ * only the owner-gate policy + the MCP surface.
+ */
+
+import { z } from 'zod';
+import { createSdkMcpServer, tool } from '@anthropic-ai/claude-agent-sdk';
+import { extractParentGroupNo } from './octo/channel-id.js';
+import {
+  GroupMdContentTooLargeError,
+  MAX_GROUP_MD_CONTENT_BYTES,
+  type GroupMdWriteback,
+} from './group-md-writeback.js';
+
+/** MCP server name; the tool surfaces as `mcp__group_md__update_group_md`. */
+export const GROUP_MD_TOOL_SERVER_NAME = 'group_md';
+
+/** Raw coords of the session invoking the tool — gates the call + targets the group. */
+export interface GroupMdSessionCoords {
+  /** Full channelId (may be a `<groupNo>____<shortId>` thread composite). */
+  channelId: string;
+  fromUid: string;
+  fromName?: string;
+}
+
+/** Shared deps the tool needs to perform a write-back. */
+export interface GroupMdToolDeps {
+  writeback: GroupMdWriteback;
+  apiUrl: string;
+  botToken: string;
+}
+
+function jsonResult(value: unknown): { content: Array<{ type: 'text'; text: string }> } {
+  return { content: [{ type: 'text', text: JSON.stringify(value, null, 2) }] };
+}
+function errResult(msg: string): { content: Array<{ type: 'text'; text: string }>; isError: true } {
+  return { content: [{ type: 'text', text: `Error: ${msg}` }], isError: true };
+}
+
+/**
+ * Build the GROUP.md tool DEFINITIONS for one agent turn. Exported separately
+ * from the server so tests can invoke the handler directly. `coords` targets the
+ * group + supplies the caller uid; `ownerUid` is the owner gate.
+ */
+export function buildGroupMdTools(
+  deps: GroupMdToolDeps,
+  coords: GroupMdSessionCoords,
+  ownerUid: string,
+) {
+  const isOwner = coords.fromUid === ownerUid && ownerUid !== '';
+
+  return [
+    tool(
+      'update_group_md',
+      'Persist new GROUP.md content for THIS group on the server (it becomes the ' +
+        "group's trusted operator instructions on the next turn). `content` is the " +
+        'FULL replacement document, not a diff. Hard limit: 10240 bytes UTF-8. Only ' +
+        'the bot owner may call this; a non-owner request is rejected. Last write ' +
+        'wins server-side — compose the complete updated document, do not assume a ' +
+        'concurrent edit merged.',
+      {
+        content: z
+          .string()
+          .describe('Full replacement GROUP.md document (≤10240 bytes UTF-8).'),
+      },
+      async (args) => {
+        try {
+          if (!isOwner) {
+            return errResult('Only the bot owner can update GROUP.md.');
+          }
+          const groupNo = extractParentGroupNo(coords.channelId);
+          if (!groupNo) {
+            return errResult('Could not resolve a group number from this channel.');
+          }
+          // Surface a friendly over-limit message before the coordinator throws
+          // (it re-checks as the authoritative boundary; this is just for UX).
+          const bytes = Buffer.byteLength(args.content, 'utf-8');
+          if (bytes > MAX_GROUP_MD_CONTENT_BYTES) {
+            return errResult(
+              `content is ${bytes} bytes, over the ${MAX_GROUP_MD_CONTENT_BYTES}-byte ` +
+                `UTF-8 limit — trim it before writing (the server would reject it).`,
+            );
+          }
+          const res = await deps.writeback.writeBack({
+            apiUrl: deps.apiUrl,
+            botToken: deps.botToken,
+            groupNo,
+            content: args.content,
+          });
+          return jsonResult({
+            updated: { groupNo: res.groupNo, version: res.version, bytes: res.bytes },
+          });
+        } catch (err) {
+          if (err instanceof GroupMdContentTooLargeError) {
+            return errResult(
+              `content is ${err.bytes} bytes, over the ${MAX_GROUP_MD_CONTENT_BYTES}-byte UTF-8 limit.`,
+            );
+          }
+          return errResult(err instanceof Error ? err.message : String(err));
+        }
+      },
+    ),
+  ];
+}
+
+/**
+ * Build the GROUP.md write-back MCP server for one agent turn. `coords` targets
+ * the group + supplies the caller uid; `ownerUid` is the owner gate.
+ */
+export function createGroupMdToolServer(
+  deps: GroupMdToolDeps,
+  coords: GroupMdSessionCoords,
+  ownerUid: string,
+) {
+  return createSdkMcpServer({
+    name: GROUP_MD_TOOL_SERVER_NAME,
+    version: '1.0.0',
+    tools: buildGroupMdTools(deps, coords, ownerUid),
+  });
+}

--- a/src/group-md-writeback.ts
+++ b/src/group-md-writeback.ts
@@ -1,0 +1,144 @@
+/**
+ * GROUP.md write-back (P2-C): the app-layer coordinator that persists an
+ * agent-authored GROUP.md back to the server (PUT /v1/bot/groups/{groupNo}/md)
+ * via A's `updateGroupMd` client, then refreshes A's in-memory cache so the next
+ * resolve does not TTL-refetch a stale copy.
+ *
+ * Two server-contract facts (XIN-201, measured — NOT inferred) shape this:
+ *
+ *   1. content has a HARD ≤10240-byte (UTF-8) limit; the server answers an
+ *      oversized body with 400 err.server.bot_api.content_too_large. We reject
+ *      locally BEFORE the PUT so a too-large write never reaches the server.
+ *
+ *   2. `version` is a server-side monotonic counter and the PUT does NOT do
+ *      compare-and-swap (last-write-wins, no CAS). Concurrent writers therefore
+ *      silently clobber each other server-side. We cannot fix a foreign writer
+ *      (operator console, another gateway), but we CAN guarantee that this
+ *      gateway never races itself: all write-backs for the same groupNo are
+ *      serialized through a per-groupNo promise-chain lock, so the read-modify-
+ *      write (PUT + cache update) for one call completes before the next starts.
+ *      Cross-source last-write-wins remains possible by design — see the caveat
+ *      on {@link GroupMdWriteback}.
+ *
+ * Owner-gating lives in the MCP tool layer (group-md-tool.ts), not here: this
+ * module is the mechanism, the tool is the policy boundary.
+ *
+ * Never persists anything to disk — the cache it updates is the same in-memory-
+ * only cache A's resolver reads (group-md-cache.ts), so this introduces no new
+ * durable-trust surface.
+ */
+
+import { updateGroupMd } from './octo/api.js';
+import type { GroupMdCache } from './group-md-cache.js';
+
+/**
+ * Hard UTF-8 byte ceiling for GROUP.md content, per the XIN-201 measured
+ * server contract. A body above this is rejected locally (a server PUT would
+ * answer 400 err.server.bot_api.content_too_large).
+ */
+export const MAX_GROUP_MD_CONTENT_BYTES = 10240;
+
+/** Thrown when content exceeds {@link MAX_GROUP_MD_CONTENT_BYTES}. */
+export class GroupMdContentTooLargeError extends Error {
+  constructor(public readonly bytes: number) {
+    super(
+      `GROUP.md content is ${bytes} bytes, over the ${MAX_GROUP_MD_CONTENT_BYTES}-byte UTF-8 limit`,
+    );
+    this.name = 'GroupMdContentTooLargeError';
+  }
+}
+
+/** The `updateGroupMd` client signature, injectable for testing. */
+export type UpdateGroupMdFn = typeof updateGroupMd;
+
+/** Outcome of a successful write-back. */
+export interface GroupMdWriteResult {
+  groupNo: string;
+  /** Server-assigned version after the PUT. */
+  version: number;
+  /** UTF-8 byte length of the content that was written. */
+  bytes: number;
+}
+
+export interface GroupMdWriteParams {
+  apiUrl: string;
+  botToken: string;
+  groupNo: string;
+  content: string;
+  signal?: AbortSignal;
+}
+
+/**
+ * Serializes GROUP.md write-backs per groupNo and keeps A's cache in sync.
+ *
+ * Constructed ONCE per bot (alongside the GroupMdCache it updates) and shared
+ * across turns, so the per-groupNo lock actually spans concurrent agent turns —
+ * a per-turn instance would defeat the lock. The MCP tool server (built per
+ * turn) borrows this shared instance.
+ *
+ * CAVEAT (documented per XIN-201 item 4): the lock only covers THIS gateway. A
+ * write from another source (operator console, a second gateway process) is not
+ * coordinated and, because the server has no CAS, last-write-wins across sources
+ * — that is an accepted limitation, not a bug.
+ */
+export class GroupMdWriteback {
+  /** Tail of the in-flight write chain per groupNo (serializes same-key writes). */
+  private readonly tails = new Map<string, Promise<unknown>>();
+
+  constructor(
+    private readonly cache: GroupMdCache,
+    /** Injectable PUT client (defaults to the real octo client). */
+    private readonly updateFn: UpdateGroupMdFn = updateGroupMd,
+  ) {}
+
+  /**
+   * Run `fn` after every previously-queued op for `key` has settled, so bodies
+   * for the same key never overlap. Different keys run independently. `fn`'s
+   * rejection is surfaced to its own caller; the chain tail swallows it so a
+   * failed write does not wedge later writes.
+   */
+  private withLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
+    const prev = this.tails.get(key) ?? Promise.resolve();
+    const result = prev.then(fn, fn); // run regardless of prior success/failure
+    const tail = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    this.tails.set(key, tail);
+    // Best-effort cleanup: drop the key once the queue drains to this tail, so
+    // the Map does not grow without bound across many groups.
+    tail.then(() => {
+      if (this.tails.get(key) === tail) this.tails.delete(key);
+    });
+    return result;
+  }
+
+  /**
+   * Persist `content` as the group's GROUP.md and refresh the cache.
+   *
+   * Rejects with {@link GroupMdContentTooLargeError} (before any server call)
+   * when content exceeds the UTF-8 byte limit; propagates the client error when
+   * the PUT itself fails (cache is left untouched in that case).
+   */
+  async writeBack(params: GroupMdWriteParams): Promise<GroupMdWriteResult> {
+    const { apiUrl, botToken, groupNo, content, signal } = params;
+    const bytes = Buffer.byteLength(content, 'utf-8');
+    if (bytes > MAX_GROUP_MD_CONTENT_BYTES) {
+      // Reject locally — do NOT hit the server (it would answer 400).
+      throw new GroupMdContentTooLargeError(bytes);
+    }
+    return this.withLock(groupNo, async () => {
+      const { version } = await this.updateFn({ apiUrl, botToken, groupNo, content, signal });
+      // Write the just-persisted content/version back into A's in-memory cache
+      // so the next resolveGroupInstructions serves what we wrote instead of
+      // either re-fetching (TTL) or, worse, returning a now-stale cached copy.
+      // updated_at is null because the PUT response carries only { version }.
+      this.cache.set(groupNo, {
+        content,
+        version: typeof version === 'number' ? version : 0,
+        updated_at: null,
+      });
+      return { groupNo, version, bytes };
+    });
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,9 +29,11 @@ import { downloadInboundImage, MAX_IMAGES_PER_MESSAGE } from './media-inbound.js
 import { handleCommand } from './commands.js';
 import { resolveGroupInstructions } from './group-md.js';
 import { GroupMdCache, DEFAULT_GROUP_MD_TTL_MS } from './group-md-cache.js';
+import { GroupMdWriteback } from './group-md-writeback.js';
 import { CronStore } from './cron-store.js';
 import { CronScheduler } from './cron-scheduler.js';
 import { createCronToolServer, CRON_TOOL_SERVER_NAME, type CronSessionCoords } from './cron-tool.js';
+import { createGroupMdToolServer, GROUP_MD_TOOL_SERVER_NAME, type GroupMdSessionCoords } from './group-md-tool.js';
 import { buildInlinedFileBody, truncateUtf8ByBytes, assembleUserMessage, MAX_USER_LLM_BYTES } from './file-inline-wrap.js';
 import { join } from 'node:path';
 import { mkdirSync, realpathSync } from 'node:fs';
@@ -220,6 +222,14 @@ async function startBot(config: ReturnType<typeof loadConfig>, multi: boolean): 
     // caches; created unconditionally (cheap, only populated when serverMd is on). ---
     const groupMdCache = new GroupMdCache(config.serverMdTtlMs ?? DEFAULT_GROUP_MD_TTL_MS);
 
+    // --- P2-C: GROUP.md write-back coordinator. Shared across turns so its
+    // per-groupNo write lock actually serializes concurrent agent turns writing
+    // the same group (a per-turn instance would defeat the lock). Updates the
+    // SAME in-memory groupMdCache above on a successful PUT — no new disk surface.
+    // Cheap to construct unconditionally; only exercised when the write-back tool
+    // is registered (config.mdWriteback). ---
+    const groupMdWriteback = new GroupMdWriteback(groupMdCache);
+
     // --- #115: cron (opt-in). ---
     if (config.sdk.cron && config.botId) {
       cronStore = new CronStore(join(config.baseDir, config.botId, 'cron.json'));
@@ -290,7 +300,7 @@ async function startBot(config: ReturnType<typeof loadConfig>, multi: boolean): 
       // these on the WS path; guard here too for safety (otherwise a bot's own
       // group message could be cached into group context as un-processed chatter).
       if (msg.from_uid === gateway.botId) return;
-      const p = handleMessage(msg, config, store, router, groupContext, streamRelay, gateway.botId, cronStore, groupMdCache)
+      const p = handleMessage(msg, config, store, router, groupContext, streamRelay, gateway.botId, cronStore, groupMdCache, groupMdWriteback)
         .catch((err) => {
           console.error(`[cc-channel-octo] ${label}Unhandled message handler error:`, err instanceof Error ? err.message : err);
         })
@@ -311,7 +321,7 @@ async function startBot(config: ReturnType<typeof loadConfig>, multi: boolean): 
         cronStore,
         onFire: (msg: BotMessage): Promise<void> => {
           if (gateway.draining) return Promise.resolve();
-          const p = handleMessage(msg, config, store, router, groupContext, streamRelay, gateway.botId, cronStore, groupMdCache)
+          const p = handleMessage(msg, config, store, router, groupContext, streamRelay, gateway.botId, cronStore, groupMdCache, groupMdWriteback)
             .finally(() => { activeHandlers.delete(p); });
           activeHandlers.add(p);
           return p;
@@ -372,6 +382,7 @@ export async function handleMessage(
   botId: string,
   cronStore?: CronStore,
   groupMdCache?: GroupMdCache,
+  groupMdWriteback?: GroupMdWriteback,
 ): Promise<void> {
   const channelId = msg.channel_id ?? '';
   const channelType = msg.channel_type ?? ChannelType.DM;
@@ -839,6 +850,29 @@ export async function handleMessage(
         sessionOpts = {
           ...(sessionOpts ?? {}),
           mcpServers: { [CRON_TOOL_SERVER_NAME]: cronServer },
+        };
+      }
+
+      // P2-C: when GROUP.md write-back is on, inject the write-back MCP tool
+      // bound to THIS message's channel coords (so the write targets the channel's
+      // parent group) and gated to the bot owner uid. Only for group channels —
+      // a DM has no shared GROUP.md. Per-turn server (coords differ per message);
+      // it borrows the shared groupMdWriteback so the per-groupNo write lock and
+      // the cache it refreshes are process-wide, not per-turn.
+      if (config.mdWriteback && groupMdWriteback && isGroup) {
+        const coords: GroupMdSessionCoords = {
+          channelId,
+          fromUid: msg.from_uid,
+          fromName: msg.from_name,
+        };
+        const groupMdServer = createGroupMdToolServer(
+          { writeback: groupMdWriteback, apiUrl: config.apiUrl, botToken: config.botToken },
+          coords,
+          router.getOwnerUid(),
+        );
+        sessionOpts = {
+          ...(sessionOpts ?? {}),
+          mcpServers: { ...(sessionOpts?.mcpServers ?? {}), [GROUP_MD_TOOL_SERVER_NAME]: groupMdServer },
         };
       }
 


### PR DESCRIPTION
## Summary

Adds an owner-gated GROUP.md write-back tool so a bot can persist group instruction changes back to the server, completing the read+write GROUP.md chain (server-first fetch/cache on top, write-back on top of that).

## Changes

- `feat(group-md): owner-gated GROUP.md write-back MCP tool` — exposes `update_group_md`, registered per group session at message time, gated on `mdWriteback && isGroup`. Only the bot owner uid may invoke it. Content is capped at 10240 bytes (full-replace semantics).
- Builds on the server-first GROUP.md fetch + memory-only cache with TTL (read path) so read and write share one source of truth.

## Behavior verified (real environment)

- Owner-origin write-back on a real group: owner @-triggers the bot, the tool calls the server PUT, server GROUP.md is updated with `updated_by = <bot id>` and the version bumps. Confirmed by reading the server GROUP.md after the write.
- Owner gate: non-owner triggers are rejected (no PUT).
- Byte cap enforced at 10240.

Part of #88
