### PR TITLE
feat(thread-md): inject a thread's own THREAD.md, not the parent GROUP.md (#88 P3-1)

### DIFF
--- a/src/__tests__/group-md-api.test.ts
+++ b/src/__tests__/group-md-api.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest';
-import { getGroupMd, updateGroupMd, type GroupMd } from '../octo/api.js';
+import { getGroupMd, getThreadMd, updateGroupMd, type GroupMd, type ThreadMd } from '../octo/api.js';
 
 const fetchMock = vi.fn();
 const originalFetch = globalThis.fetch;
@@ -75,6 +75,39 @@ describe('getGroupMd', () => {
   it('throws on a 500', async () => {
     fetchMock.mockResolvedValueOnce(new Response('boom', { status: 500, statusText: 'Internal Server Error' }));
     await expect(getGroupMd({ ...BASE, groupNo: GROUP })).rejects.toThrow(/failed \(500\)/);
+  });
+});
+
+const SHORT = '2071488441815666688';
+
+describe('getThreadMd', () => {
+  it('GETs /v1/bot/groups/{groupNo}/threads/{shortId}/md with Bearer auth and parses the payload', async () => {
+    const payload: ThreadMd = {
+      content: 'Thread-only rules.',
+      version: 49,
+      updated_at: '2026-07-01T00:00:00Z',
+      updated_by: 'op-uid',
+    };
+    fetchMock.mockResolvedValueOnce(mockJsonResponse(payload));
+
+    const md = await getThreadMd({ ...BASE, groupNo: GROUP, shortId: SHORT });
+
+    const { url, init } = call();
+    expect(url).toBe(`${BASE.apiUrl}/v1/bot/groups/${GROUP}/threads/${SHORT}/md`);
+    expect(init.method).toBe('GET');
+    expect(authHeader(init)).toBe(`Bearer ${BASE.botToken}`);
+    expect(md).toEqual(payload);
+  });
+
+  it('url-encodes both the groupNo and shortId path segments', async () => {
+    fetchMock.mockResolvedValueOnce(mockJsonResponse({ content: '', version: 0, updated_at: null, updated_by: '' }));
+    await getThreadMd({ ...BASE, groupNo: 'a/b', shortId: 'c/d' });
+    expect(call().url).toBe(`${BASE.apiUrl}/v1/bot/groups/a%2Fb/threads/c%2Fd/md`);
+  });
+
+  it('throws on a 404 (no THREAD.md set) so the caller can degrade to local', async () => {
+    fetchMock.mockResolvedValueOnce(new Response('not found', { status: 404, statusText: 'Not Found' }));
+    await expect(getThreadMd({ ...BASE, groupNo: GROUP, shortId: SHORT })).rejects.toThrow(/failed \(404\)/);
   });
 });
 

--- a/src/__tests__/group-md.test.ts
+++ b/src/__tests__/group-md.test.ts
@@ -249,39 +249,47 @@ describe('resolveGroupInstructions', () => {
     expect(out).toBeUndefined();
   });
 
-  it('thread channelId → server fetch uses the PARENT groupNo (P1 routing preserved)', async () => {
+  it('🔴 thread channelId + serverMd on + parent has server GROUP.md → does NOT inject the parent GROUP.md (core P3 fix)', async () => {
+    // The bug (XIN-224): the old resolver collapsed a thread to its parent
+    // groupNo and, with serverMd on, injected the parent's server GROUP.md.
+    // After the fix a thread is mutually exclusive from its parent group.
     const channelId = `${GROUP}____tid123`;
-    fetchMock.mockResolvedValueOnce(mockMd('server rules'));
+    // Any fetch that DID happen would return parent GROUP.md — its presence in
+    // the output is exactly the regression we guard against.
+    fetchMock.mockResolvedValue(mockMd('parent GROUP rules'));
     const cache = new GroupMdCache();
 
     const out = await resolveGroupInstructions({
       groupConfigDir: cfgDir,
-      serverMd: true,
+      serverMd: true, // group flag on…
+      // …but threadMd off → thread stays local; parent GROUP.md must never leak.
       ...BASE,
       channelId,
       cache,
     });
 
-    expect(out).toBe('server rules');
-    // URL is keyed by the parent group number, NOT the composite channelId.
-    expect(call0Url()).toBe(`${BASE.apiUrl}/v1/bot/groups/${GROUP}/md`);
+    expect(out).toBeUndefined(); // no thread-local file, and NO parent GROUP.md
+    // The thread branch must not touch the group GROUP.md endpoint at all.
+    expect(fetchMock).not.toHaveBeenCalled();
+    // …and it must never read or write the parent-group cache.
+    expect(cache.get(GROUP)).toBeUndefined();
   });
 
-  it('thread channelId → local fallback still routes by the thread short-id file', async () => {
+  it('thread channelId → local fallback routes by the thread short-id file, no server call', async () => {
     // Thread's own short-id instruction file (loadGroupConfig new semantics).
     writeFileSync(join(cfgDir, 'tid123.md'), 'thread-local rules');
-    fetchMock.mockResolvedValueOnce(new Response('nope', { status: 404, statusText: 'Not Found' }));
     const cache = new GroupMdCache();
 
     const out = await resolveGroupInstructions({
       groupConfigDir: cfgDir,
-      serverMd: true,
+      serverMd: true, // group flag on, but a thread ignores it
       ...BASE,
       channelId: `${GROUP}____tid123`,
       cache,
     });
 
     expect(out).toBe('thread-local rules');
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });
 

--- a/src/__tests__/thread-md.test.ts
+++ b/src/__tests__/thread-md.test.ts
@@ -1,0 +1,301 @@
+/**
+ * Tests for the THREAD.md server cache + thread-branch resolver (P3-1).
+ *
+ * Covers:
+ *   - ThreadMdCache: in-memory store/read keyed by the COMPOSITE `groupNo::shortId`,
+ *     TTL expiry, invalidate, path-safe components, cross-group isolation (same
+ *     shortId under different parents never collide), and no durable backing.
+ *   - resolveGroupInstructions thread branch: mutual exclusion from the group
+ *     GROUP.md (the core XIN-224 fix), threadMd flag gating, server-first
+ *     preference, never-lose local `<shortId>.md` fallback, cache reuse, TTL
+ *     re-fetch, and the invariant that the thread branch NEVER reads or writes
+ *     the group GROUP.md cache / endpoint.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach, afterAll } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { GroupMdCache, ThreadMdCache } from '../group-md-cache.js';
+import { resolveGroupInstructions } from '../group-md.js';
+
+const fetchMock = vi.fn();
+const originalFetch = globalThis.fetch;
+
+let cfgDir: string;
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+  cfgDir = mkdtempSync(join(tmpdir(), 'thread-md-cfg-'));
+});
+
+afterEach(() => {
+  rmSync(cfgDir, { recursive: true, force: true });
+});
+
+afterAll(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function mockMd(content: string, version = 1): Response {
+  return new Response(
+    JSON.stringify({ content, version, updated_at: '2026-07-01T00:00:00Z', updated_by: 'op' }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } },
+  );
+}
+
+const BASE = { apiUrl: 'https://test.example.com', botToken: 'bf_test' };
+const GROUP = 'grp001';
+const SHORT = '2071488441815666688'; // a real-shaped snowflake shortId
+const CHANNEL = `${GROUP}____${SHORT}`;
+
+/** A controllable clock for deterministic TTL tests. */
+function fakeClock(start = 1_000_000) {
+  let t = start;
+  return { now: () => t, advance: (ms: number) => { t += ms; } };
+}
+
+function call0Url(): string {
+  return (fetchMock.mock.calls[0] as [string, RequestInit])[0];
+}
+
+// ─── ThreadMdCache ─────────────────────────────────────────────────────────
+
+describe('ThreadMdCache', () => {
+  it('stores and reads an entry keyed by the composite groupNo::shortId', () => {
+    const cache = new ThreadMdCache();
+    cache.set(GROUP, SHORT, { content: 'hi', version: 3, updated_at: null });
+    expect(cache.get(GROUP, SHORT)).toEqual({ content: 'hi', version: 3, updated_at: null, updated_by: undefined });
+  });
+
+  it('isolates the same shortId under different parent groups (composite key double-insurance)', () => {
+    const cache = new ThreadMdCache();
+    cache.set('groupA', SHORT, { content: 'A rules', version: 1, updated_at: null });
+    cache.set('groupB', SHORT, { content: 'B rules', version: 1, updated_at: null });
+    expect(cache.get('groupA', SHORT)?.content).toBe('A rules');
+    expect(cache.get('groupB', SHORT)?.content).toBe('B rules');
+  });
+
+  it('expires an entry once it is older than the TTL (staleness backstop)', () => {
+    const clock = fakeClock();
+    const cache = new ThreadMdCache(1000, clock.now);
+    cache.set(GROUP, SHORT, { content: 'x', version: 1, updated_at: null });
+
+    clock.advance(999);
+    expect(cache.get(GROUP, SHORT)?.content).toBe('x'); // still fresh
+
+    clock.advance(1); // now exactly at TTL → expired
+    expect(cache.get(GROUP, SHORT)).toBeUndefined();
+  });
+
+  it('a non-positive TTL disables expiry', () => {
+    const clock = fakeClock();
+    const cache = new ThreadMdCache(0, clock.now);
+    cache.set(GROUP, SHORT, { content: 'x', version: 1, updated_at: null });
+    clock.advance(10 * 365 * 24 * 3600 * 1000);
+    expect(cache.get(GROUP, SHORT)?.content).toBe('x');
+  });
+
+  it('invalidate clears the entry', () => {
+    const cache = new ThreadMdCache();
+    cache.set(GROUP, SHORT, { content: 'x', version: 1, updated_at: null });
+    cache.invalidate(GROUP, SHORT);
+    expect(cache.get(GROUP, SHORT)).toBeUndefined();
+  });
+
+  it('rejects an unsafe groupNo or shortId (never stored)', () => {
+    const cache = new ThreadMdCache();
+    cache.set('../escape', SHORT, { content: 'evil', version: 1, updated_at: null });
+    cache.set(GROUP, '../escape', { content: 'evil', version: 1, updated_at: null });
+    expect(cache.get('../escape', SHORT)).toBeUndefined();
+    expect(cache.get(GROUP, '../escape')).toBeUndefined();
+  });
+
+  it('persists nothing across instances — a fresh cache shares no state (no durable backing)', () => {
+    const a = new ThreadMdCache();
+    a.set(GROUP, SHORT, { content: 'durable?', version: 9, updated_at: '2026-07-01T00:00:00Z', updated_by: 'op' });
+    expect(a.get(GROUP, SHORT)?.content).toBe('durable?');
+
+    const b = new ThreadMdCache();
+    expect(b.get(GROUP, SHORT)).toBeUndefined();
+  });
+});
+
+// ─── resolveGroupInstructions — thread branch ────────────────────────────────
+
+describe('resolveGroupInstructions (thread branch)', () => {
+  it('threadMd OFF → reads the local <shortId>.md only, never hits the server', async () => {
+    writeFileSync(join(cfgDir, `${SHORT}.md`), 'thread-local rules');
+    const threadCache = new ThreadMdCache();
+
+    const out = await resolveGroupInstructions({
+      groupConfigDir: cfgDir,
+      threadMd: false,
+      ...BASE,
+      channelId: CHANNEL,
+      threadCache,
+    });
+
+    expect(out).toBe('thread-local rules');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('threadMd ON but no thread cache wired → local <shortId>.md only, no server call', async () => {
+    writeFileSync(join(cfgDir, `${SHORT}.md`), 'thread-local rules');
+    const out = await resolveGroupInstructions({
+      groupConfigDir: cfgDir,
+      threadMd: true,
+      ...BASE,
+      channelId: CHANNEL,
+    });
+    expect(out).toBe('thread-local rules');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('threadMd ON → server THREAD.md wins over the local file (server-first) and uses the thread md endpoint', async () => {
+    writeFileSync(join(cfgDir, `${SHORT}.md`), 'thread-local rules');
+    fetchMock.mockResolvedValueOnce(mockMd('server THREAD rules'));
+    const threadCache = new ThreadMdCache();
+
+    const out = await resolveGroupInstructions({
+      groupConfigDir: cfgDir,
+      threadMd: true,
+      ...BASE,
+      channelId: CHANNEL,
+      threadCache,
+    });
+
+    expect(out).toBe('server THREAD rules');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(call0Url()).toBe(`${BASE.apiUrl}/v1/bot/groups/${GROUP}/threads/${SHORT}/md`);
+  });
+
+  it('caches the server fetch — a second call serves from cache (no second fetch)', async () => {
+    fetchMock.mockResolvedValueOnce(mockMd('server THREAD rules'));
+    const threadCache = new ThreadMdCache();
+    const args = { groupConfigDir: cfgDir, threadMd: true, ...BASE, channelId: CHANNEL, threadCache };
+
+    expect(await resolveGroupInstructions(args)).toBe('server THREAD rules');
+    expect(await resolveGroupInstructions(args)).toBe('server THREAD rules');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-fetches after the cache entry expires (TTL backstop picks up edits)', async () => {
+    const clock = fakeClock();
+    const threadCache = new ThreadMdCache(1000, clock.now);
+    const args = { groupConfigDir: cfgDir, threadMd: true, ...BASE, channelId: CHANNEL, threadCache };
+
+    fetchMock.mockResolvedValueOnce(mockMd('old rules'));
+    expect(await resolveGroupInstructions(args)).toBe('old rules');
+
+    clock.advance(1000); // expire the cached entry
+    fetchMock.mockResolvedValueOnce(mockMd('new rules'));
+    expect(await resolveGroupInstructions(args)).toBe('new rules');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('server 404 → falls back to the local <shortId>.md (fallback never lost)', async () => {
+    writeFileSync(join(cfgDir, `${SHORT}.md`), 'thread-local rules');
+    fetchMock.mockResolvedValueOnce(new Response('nope', { status: 404, statusText: 'Not Found' }));
+    const threadCache = new ThreadMdCache();
+
+    const out = await resolveGroupInstructions({
+      groupConfigDir: cfgDir,
+      threadMd: true,
+      ...BASE,
+      channelId: CHANNEL,
+      threadCache,
+    });
+
+    expect(out).toBe('thread-local rules');
+  });
+
+  it('server reachable but empty content → local fallback', async () => {
+    writeFileSync(join(cfgDir, `${SHORT}.md`), 'thread-local rules');
+    fetchMock.mockResolvedValueOnce(mockMd('   '));
+    const threadCache = new ThreadMdCache();
+
+    const out = await resolveGroupInstructions({
+      groupConfigDir: cfgDir,
+      threadMd: true,
+      ...BASE,
+      channelId: CHANNEL,
+      threadCache,
+    });
+
+    expect(out).toBe('thread-local rules');
+  });
+
+  it('server network error → local fallback, never throws', async () => {
+    writeFileSync(join(cfgDir, `${SHORT}.md`), 'thread-local rules');
+    fetchMock.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+    const threadCache = new ThreadMdCache();
+
+    const out = await resolveGroupInstructions({
+      groupConfigDir: cfgDir,
+      threadMd: true,
+      ...BASE,
+      channelId: CHANNEL,
+      threadCache,
+    });
+
+    expect(out).toBe('thread-local rules');
+  });
+
+  it('no server THREAD.md and no local file → undefined', async () => {
+    fetchMock.mockResolvedValueOnce(new Response('nope', { status: 404, statusText: 'Not Found' }));
+    const threadCache = new ThreadMdCache();
+
+    const out = await resolveGroupInstructions({
+      groupConfigDir: cfgDir,
+      threadMd: true,
+      ...BASE,
+      channelId: CHANNEL,
+      threadCache,
+    });
+
+    expect(out).toBeUndefined();
+  });
+
+  it('🔴 thread branch NEVER reads or writes the group GROUP.md cache (mutual exclusion)', async () => {
+    // Spy on the group cache. The thread branch must not touch it — a thread's
+    // instructions are its own THREAD.md, never the parent group's GROUP.md.
+    const groupCache = new GroupMdCache();
+    const getSpy = vi.spyOn(groupCache, 'get');
+    const setSpy = vi.spyOn(groupCache, 'set');
+    const threadCache = new ThreadMdCache();
+    fetchMock.mockResolvedValueOnce(mockMd('server THREAD rules'));
+
+    await resolveGroupInstructions({
+      groupConfigDir: cfgDir,
+      serverMd: true, // group flag on…
+      threadMd: true, // …thread flag on
+      ...BASE,
+      channelId: CHANNEL,
+      cache: groupCache,
+      threadCache,
+    });
+
+    expect(getSpy).not.toHaveBeenCalled();
+    expect(setSpy).not.toHaveBeenCalled();
+    // The only fetch was the thread md endpoint, not the group md endpoint.
+    expect(call0Url()).toBe(`${BASE.apiUrl}/v1/bot/groups/${GROUP}/threads/${SHORT}/md`);
+  });
+
+  it('malformed thread channelId (no shortId) → local fallback, never fetches a group-scoped path', async () => {
+    fetchMock.mockResolvedValue(mockMd('should not be used'));
+    const threadCache = new ThreadMdCache();
+
+    const out = await resolveGroupInstructions({
+      groupConfigDir: cfgDir,
+      threadMd: true,
+      ...BASE,
+      channelId: `${GROUP}____`, // trailing separator, empty shortId
+      threadCache,
+    });
+
+    expect(out).toBeUndefined();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -127,6 +127,17 @@ export interface Config {
    * server-first READ path), so an operator can enable reads without writes.
    */
   mdWriteback?: boolean;
+  /**
+   * P3-1 feature flag: when true, a THREAD (CommunityTopic) channel resolves its
+   * THREAD.md server-first (GET /v1/bot/groups/{groupNo}/threads/{shortId}/md,
+   * cached in-memory keyed by `groupNo::shortId`) before its local `<shortId>.md`
+   * file. Off (default) → a thread resolves ONLY its local file, which is already
+   * the correct behavior (a thread injects its own THREAD.md and never stacks the
+   * parent group's GROUP.md). So this flag gates the NEW server-read capability,
+   * NOT the thread/group split — that split is unconditional. Independent of
+   * `serverMd` (which governs the group server-read path).
+   */
+  threadMd?: boolean;
   sdk: {
     model?: string;
     /**
@@ -301,6 +312,7 @@ type PartialConfig = {
   serverMdTtlMs?: number;
   serverMdEventTypes?: string[];
   mdWriteback?: boolean;
+  threadMd?: boolean;
   sdk?: Partial<Config['sdk']>;
   rateLimit?: Partial<Config['rateLimit']>;
   context?: Partial<Config['context']>;
@@ -396,6 +408,7 @@ function mergeConfig(base: Config, override: PartialConfig): Config {
     serverMdTtlMs: override.serverMdTtlMs ?? base.serverMdTtlMs,
     serverMdEventTypes: override.serverMdEventTypes ?? base.serverMdEventTypes,
     mdWriteback: override.mdWriteback ?? base.mdWriteback,
+    threadMd: override.threadMd ?? base.threadMd,
     sdk: {
       ...base.sdk,
       ...(override.sdk ?? {}),
@@ -632,6 +645,7 @@ export function resolveBotConfigs(config: Config): Config[] {
       serverMdTtlMs: perBotFile.serverMdTtlMs ?? config.serverMdTtlMs,
       serverMdEventTypes: perBotFile.serverMdEventTypes ?? config.serverMdEventTypes,
       mdWriteback: perBotFile.mdWriteback ?? config.mdWriteback,
+      threadMd: perBotFile.threadMd ?? config.threadMd,
       sdk: {
         ...config.sdk,
         ...(perBotFile.sdk ?? {}),

--- a/src/group-md-cache.ts
+++ b/src/group-md-cache.ts
@@ -106,3 +106,83 @@ export class GroupMdCache {
     this.mem.delete(groupNo);
   }
 }
+
+/**
+ * THREAD.md server cache (P3-1) — IN-MEMORY ONLY, with a TTL.
+ *
+ * The thread analogue of {@link GroupMdCache}. Holds server-fetched THREAD.md
+ * for a CommunityTopic thread. Same memory-only security model as the group
+ * cache (see the module SECURITY note): the resolved THREAD.md is injected as a
+ * trusted system-prompt block, so it must never touch disk — the only path
+ * content can enter the trusted channel is a live, authenticated `getThreadMd`
+ * over the bot token against the SSRF-validated `apiUrl`.
+ *
+ * Keying — COMPOSITE `<groupNo>::<shortId>`, NOT the bare shortId. Octo's
+ * current shortId is a globally unique 19-digit snowflake, so a bare shortId
+ * would not collide across groups today; the composite key is defensive
+ * double-insurance so that even if a future shortId scheme becomes a
+ * per-parent-group sequence, one group's THREAD.md can never be served for a
+ * same-shortId thread under a different parent group. `::` is intentionally
+ * outside the safe-id charset, so it can never appear inside a validated
+ * component and cannot be forged to cross a key boundary.
+ *
+ * Never throws.
+ */
+export class ThreadMdCache {
+  private readonly mem = new Map<string, StoredEntry>();
+  private readonly ttlMs: number;
+  private readonly now: () => number;
+
+  /**
+   * @param ttlMs staleness backstop in ms (entry expires this long after it was
+   *   stored). Defaults to {@link DEFAULT_GROUP_MD_TTL_MS} — the thread cache
+   *   shares the group cache's staleness policy. A non-positive value disables
+   *   expiry (entries live until invalidate()).
+   * @param now injectable clock (testing); defaults to Date.now.
+   */
+  constructor(ttlMs: number = DEFAULT_GROUP_MD_TTL_MS, now: () => number = () => Date.now()) {
+    this.ttlMs = ttlMs;
+    this.now = now;
+  }
+
+  /**
+   * Build the composite Map key, or null if either component is unsafe. Both
+   * halves are validated with the same isSafeGroupNo rule the group cache uses,
+   * and neither can contain `::` (colon is outside the charset), so the
+   * separator is unambiguous.
+   */
+  private key(groupNo: string, shortId: string): string | null {
+    if (!isSafeGroupNo(groupNo) || !isSafeGroupNo(shortId)) return null;
+    return `${groupNo}::${shortId}`;
+  }
+
+  /**
+   * Read a cached entry from memory. Returns undefined on a miss, an expired
+   * entry (which is also evicted), or an unsafe groupNo/shortId.
+   */
+  get(groupNo: string, shortId: string): GroupMdEntry | undefined {
+    const k = this.key(groupNo, shortId);
+    if (k === null) return undefined;
+    const stored = this.mem.get(k);
+    if (!stored) return undefined;
+    if (this.ttlMs > 0 && this.now() - stored.storedAt >= this.ttlMs) {
+      this.mem.delete(k);
+      return undefined;
+    }
+    return stored.entry;
+  }
+
+  /** Store an entry in memory, stamping it for TTL expiry. */
+  set(groupNo: string, shortId: string, entry: GroupMdEntry): void {
+    const k = this.key(groupNo, shortId);
+    if (k === null) return;
+    this.mem.set(k, { entry, storedAt: this.now() });
+  }
+
+  /** Drop a cached entry (event-driven refresh hook, symmetric to GroupMdCache). */
+  invalidate(groupNo: string, shortId: string): void {
+    const k = this.key(groupNo, shortId);
+    if (k === null) return;
+    this.mem.delete(k);
+  }
+}

--- a/src/group-md.ts
+++ b/src/group-md.ts
@@ -1,46 +1,58 @@
 /**
- * GROUP.md resolution (P2-A): server-first fetch with a never-lose local-file
- * fallback, behind a feature flag.
+ * GROUP.md / THREAD.md resolution: server-first fetch with a never-lose
+ * local-file fallback, behind a feature flag.
  *
  * `resolveGroupInstructions` is the single entry point the message pipeline
- * calls to obtain the trusted per-group instruction block injected into the
- * agent's system prompt. Resolution order:
+ * calls to obtain the trusted per-conversation instruction block injected into
+ * the agent's system prompt.
  *
+ * 🔴 Thread vs group are MUTUALLY EXCLUSIVE (老板拍板口径, #88 P3). The entry
+ * point routes on channelId shape:
+ *   - A thread (`<groupNo>____<shortId>`, CommunityTopic) resolves its OWN
+ *     THREAD.md only. It NEVER falls back to — nor stacks — the parent group's
+ *     GROUP.md, and it NEVER reads or writes the group's `groupMdCache` (which
+ *     is keyed by the parent groupNo). See `resolveThreadInstructions`.
+ *   - A plain group (`<groupNo>`, no separator) resolves its GROUP.md exactly as
+ *     before — the group branch below is byte-for-byte the pre-P3 behavior.
+ *
+ * The bug this fixes (XIN-224): the old resolver collapsed EVERY channelId to
+ * its parent groupNo via `extractParentGroupNo`, so with `serverMd` on a thread
+ * message was injected the parent group's GROUP.md — violating the redline that
+ * a thread injects only its own THREAD.md.
+ *
+ * Group-branch resolution order (unchanged):
  *   1. Feature flag OFF (default) or no cache wired → pure local file
- *      (`loadGroupConfig`). Byte-identical to the pre-P2 behavior, so existing
- *      local-file deployments are unaffected.
+ *      (`loadGroupConfig`). Byte-identical to the pre-P2 behavior.
  *   2. Feature flag ON:
  *        a. serve a cached server GROUP.md if present and not past its TTL (keyed
- *           by the PARENT group number — a thread shares its parent group's
- *           GROUP.md). The cache is IN-MEMORY ONLY (no disk), so the only way
- *           content reaches this trusted system-prompt channel is a live,
- *           authenticated fetch — never a forgeable on-disk artifact a chat-
- *           driven Bash/Write could plant (review #172 🔴; see group-md-cache.ts);
+ *           by the group number). The cache is IN-MEMORY ONLY (no disk), so the
+ *           only way content reaches this trusted system-prompt channel is a
+ *           live, authenticated fetch — never a forgeable on-disk artifact
+ *           (review #172 🔴; see group-md-cache.ts);
  *        b. otherwise fetch from the server (server-first). On success with
  *           non-empty content, cache it and use it;
  *        c. on ANY failure (404 "no GROUP.md", network, timeout, empty content)
  *           fall back to the local file. The local-file path is never lost.
  *
- * Trust: server content stands on its own trust root — an authenticated
- * `getGroupMd` over the bot token against the SSRF-validated `apiUrl`, server-
- * side bot_admin-gated — NOT on the OS-permission trust the local `groupConfigDir`
- * file relies on. By caching only in memory we never let server content
- * masquerade as (or be confused with) a trusted local file on disk.
+ * Thread-branch resolution order (P3-1) mirrors the group branch, keyed by the
+ * COMPOSITE `<groupNo>::<shortId>` (see `resolveThreadInstructions`), gated on
+ * the independent `threadMd` flag; when the flag is off a thread still resolves
+ * its local `<shortId>.md` (already the correct non-stacking behavior).
  *
- * Thread routing (P1): a thread channelId is the composite `<groupNo>____<shortId>`.
- * The server GROUP.md endpoint is keyed by the parent group number, so we resolve
- * it with `extractParentGroupNo` for the API call + cache key (identity for a
- * plain group). The local-file fallback still receives the FULL channelId so its
- * own thread/short-id routing in `loadGroupConfig` is preserved unchanged.
+ * Trust: server content stands on its own trust root — an authenticated
+ * `getGroupMd` / `getThreadMd` over the bot token against the SSRF-validated
+ * `apiUrl` — NOT on the OS-permission trust the local `groupConfigDir` file
+ * relies on. By caching only in memory we never let server content masquerade
+ * as (or be confused with) a trusted local file on disk.
  *
  * Never throws — a server error degrades to local, a local miss degrades to
  * "no custom instructions".
  */
 
-import { getGroupMd } from './octo/api.js';
-import { extractParentGroupNo } from './octo/channel-id.js';
+import { getGroupMd, getThreadMd } from './octo/api.js';
+import { extractParentGroupNo, extractThreadShortId, isThreadChannelId } from './octo/channel-id.js';
 import { loadGroupConfig, MAX_GROUP_CONFIG_BYTES } from './group-config.js';
-import type { GroupMdCache, GroupMdEntry } from './group-md-cache.js';
+import type { GroupMdCache, GroupMdEntry, ThreadMdCache } from './group-md-cache.js';
 
 /**
  * Trim and byte-bound server-provided GROUP.md the same way loadGroupConfig
@@ -61,18 +73,45 @@ function boundInstructions(content: string): string | undefined {
 export interface ResolveGroupInstructionsParams {
   /** Operator local-instruction directory (the existing fallback source). */
   groupConfigDir?: string;
-  /** Feature flag: when false/undefined, server fetch is skipped entirely. */
+  /** Feature flag: when false/undefined, server GROUP.md fetch is skipped. */
   serverMd?: boolean;
+  /**
+   * P3-1 feature flag: when true, a THREAD channel resolves its THREAD.md
+   * server-first (GET /v1/bot/groups/{groupNo}/threads/{shortId}/md) before its
+   * local `<shortId>.md`. When false/undefined (default) a thread resolves ONLY
+   * its local file — which is already the correct non-stacking behavior, so the
+   * flag gates the NEW server-read capability, not the bug fix. Independent of
+   * `serverMd` (which governs the group server-read path).
+   */
+  threadMd?: boolean;
   apiUrl: string;
   botToken: string;
   /** Full channelId (may be a `<groupNo>____<shortId>` thread composite). */
   channelId: string;
-  /** Server GROUP.md cache. Omitted (or flag off) → pure local file. */
+  /** Server GROUP.md cache (group branch). Omitted (or flag off) → pure local. */
   cache?: GroupMdCache;
+  /** Server THREAD.md cache (thread branch). Omitted (or flag off) → pure local. */
+  threadCache?: ThreadMdCache;
   signal?: AbortSignal;
 }
 
 export async function resolveGroupInstructions(
+  params: ResolveGroupInstructionsParams,
+): Promise<string | undefined> {
+  // 🔴 Thread and group are mutually exclusive. A thread resolves ONLY its own
+  // THREAD.md and must never touch the parent group's GROUP.md nor its cache.
+  if (isThreadChannelId(params.channelId)) {
+    return resolveThreadInstructions(params);
+  }
+  return resolveGroupBranch(params);
+}
+
+/**
+ * Plain-group branch — byte-for-byte the pre-P3 `resolveGroupInstructions`
+ * behavior (server-first GROUP.md + in-memory cache keyed by groupNo + never-
+ * lose local `<groupNo>.md` fallback). Reached only for non-thread channelIds.
+ */
+async function resolveGroupBranch(
   params: ResolveGroupInstructionsParams,
 ): Promise<string | undefined> {
   const { groupConfigDir, serverMd, apiUrl, botToken, channelId, cache, signal } = params;
@@ -115,6 +154,76 @@ export async function resolveGroupInstructions(
     // c) 404 / network / timeout — never-lose local fallback.
     console.error(
       `[cc-channel-octo] group-md: server fetch for ${groupNo} failed, falling back to local: ${String(err)}`,
+    );
+    return local();
+  }
+}
+
+/**
+ * Thread branch (P3-1) — resolves a CommunityTopic thread's OWN THREAD.md.
+ *
+ * 🔴 By construction this branch NEVER reads or writes the group `cache`
+ * (keyed by parent groupNo) and NEVER calls `getGroupMd`, so a thread can never
+ * be injected — or have cached — its parent group's GROUP.md.
+ *
+ * Resolution mirrors the group branch, keyed by the COMPOSITE `groupNo::shortId`:
+ *   - `threadMd` off (or no thread cache) → local `<shortId>.md` only
+ *     (`loadGroupConfig` is already thread-aware). This is the correct
+ *     non-stacking behavior even with the new server capability disabled.
+ *   - `threadMd` on:
+ *       a. serve a fresh cached THREAD.md (in-memory only, TTL-bounded);
+ *       b. else server-first `getThreadMd`, cache non-empty content and use it;
+ *       c. on ANY failure / empty → never-lose local `<shortId>.md` fallback.
+ */
+async function resolveThreadInstructions(
+  params: ResolveGroupInstructionsParams,
+): Promise<string | undefined> {
+  const { groupConfigDir, threadMd, apiUrl, botToken, channelId, threadCache, signal } = params;
+
+  // Local fallback keeps the FULL channelId — loadGroupConfig routes a thread to
+  // its own `<shortId>.md`, never the parent group's `<groupNo>.md`.
+  const local = (): string | undefined => loadGroupConfig(groupConfigDir, channelId);
+
+  // Flag off (or no thread cache) → pure local `<shortId>.md`. Already correct
+  // non-stacking behavior — the flag only gates the server-read capability.
+  if (!threadMd || !threadCache) return local();
+
+  const groupNo = extractParentGroupNo(channelId);
+  const shortId = extractThreadShortId(channelId);
+  // A malformed thread channelId (`<groupNo>____` with no shortId) can't be
+  // server-keyed — degrade to local rather than fetch a group-scoped path.
+  if (!shortId) return local();
+
+  // a) fresh cached server THREAD.md wins. Composite-keyed, in-memory only,
+  //    TTL-bounded (expired → miss → re-fetch below).
+  const cached = threadCache.get(groupNo, shortId);
+  if (cached) {
+    const bounded = boundInstructions(cached.content);
+    if (bounded) return bounded;
+    // Cached-but-empty (shouldn't normally happen) → fall through to local.
+    return local();
+  }
+
+  // b) server-first fetch of this thread's own THREAD.md.
+  try {
+    const md = await getThreadMd({ apiUrl, botToken, groupNo, shortId, signal });
+    const bounded = boundInstructions(md?.content ?? '');
+    if (bounded) {
+      const entry: GroupMdEntry = {
+        content: md.content,
+        version: typeof md.version === 'number' ? md.version : 0,
+        updated_at: md.updated_at ?? null,
+        updated_by: md.updated_by,
+      };
+      threadCache.set(groupNo, shortId, entry);
+      return bounded;
+    }
+    // Server reachable but no/empty THREAD.md → local fallback.
+    return local();
+  } catch (err) {
+    // c) 404 / network / timeout — never-lose local fallback.
+    console.error(
+      `[cc-channel-octo] thread-md: server fetch for ${groupNo}::${shortId} failed, falling back to local: ${String(err)}`,
     );
     return local();
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ import { resolveContent, tryResolveFile, resolveHistoricalMessagePlaceholder } f
 import { downloadInboundImage, MAX_IMAGES_PER_MESSAGE } from './media-inbound.js';
 import { handleCommand } from './commands.js';
 import { resolveGroupInstructions } from './group-md.js';
-import { GroupMdCache, DEFAULT_GROUP_MD_TTL_MS } from './group-md-cache.js';
+import { GroupMdCache, ThreadMdCache, DEFAULT_GROUP_MD_TTL_MS } from './group-md-cache.js';
 import { GroupMdWriteback } from './group-md-writeback.js';
 import { CronStore } from './cron-store.js';
 import { CronScheduler } from './cron-scheduler.js';
@@ -222,6 +222,14 @@ async function startBot(config: ReturnType<typeof loadConfig>, multi: boolean): 
     // caches; created unconditionally (cheap, only populated when serverMd is on). ---
     const groupMdCache = new GroupMdCache(config.serverMdTtlMs ?? DEFAULT_GROUP_MD_TTL_MS);
 
+    // --- P3-1: server THREAD.md cache. Same IN-MEMORY-ONLY security model as the
+    // group cache above, but keyed by the COMPOSITE `groupNo::shortId` so one
+    // group's threads never collide (defensive even though shortId is a globally
+    // unique snowflake today). Created unconditionally (cheap; only populated when
+    // config.threadMd is on). Kept SEPARATE from groupMdCache so the thread branch
+    // can never read or write a parent-group GROUP.md entry (老板拍板互斥口径). ---
+    const threadMdCache = new ThreadMdCache(config.serverMdTtlMs ?? DEFAULT_GROUP_MD_TTL_MS);
+
     // --- P2-C: GROUP.md write-back coordinator. Shared across turns so its
     // per-groupNo write lock actually serializes concurrent agent turns writing
     // the same group (a per-turn instance would defeat the lock). Updates the
@@ -300,7 +308,7 @@ async function startBot(config: ReturnType<typeof loadConfig>, multi: boolean): 
       // these on the WS path; guard here too for safety (otherwise a bot's own
       // group message could be cached into group context as un-processed chatter).
       if (msg.from_uid === gateway.botId) return;
-      const p = handleMessage(msg, config, store, router, groupContext, streamRelay, gateway.botId, cronStore, groupMdCache, groupMdWriteback)
+      const p = handleMessage(msg, config, store, router, groupContext, streamRelay, gateway.botId, cronStore, groupMdCache, groupMdWriteback, threadMdCache)
         .catch((err) => {
           console.error(`[cc-channel-octo] ${label}Unhandled message handler error:`, err instanceof Error ? err.message : err);
         })
@@ -321,7 +329,7 @@ async function startBot(config: ReturnType<typeof loadConfig>, multi: boolean): 
         cronStore,
         onFire: (msg: BotMessage): Promise<void> => {
           if (gateway.draining) return Promise.resolve();
-          const p = handleMessage(msg, config, store, router, groupContext, streamRelay, gateway.botId, cronStore, groupMdCache, groupMdWriteback)
+          const p = handleMessage(msg, config, store, router, groupContext, streamRelay, gateway.botId, cronStore, groupMdCache, groupMdWriteback, threadMdCache)
             .finally(() => { activeHandlers.delete(p); });
           activeHandlers.add(p);
           return p;
@@ -383,6 +391,7 @@ export async function handleMessage(
   cronStore?: CronStore,
   groupMdCache?: GroupMdCache,
   groupMdWriteback?: GroupMdWriteback,
+  threadMdCache?: ThreadMdCache,
 ): Promise<void> {
   const channelId = msg.channel_id ?? '';
   const channelType = msg.channel_type ?? ChannelType.DM;
@@ -839,17 +848,22 @@ export async function handleMessage(
 
       // GROUP.md: inject operator-provided per-group instructions into the
       // system prompt. Only for groups — DMs key on the peer uid, not a shared
-      // channel. P2-A: server-first (GET /v1/bot/groups/{groupNo}/md, cached)
-      // with a never-lose fallback to the local `groupConfigDir/<channelId>.md`
-      // file; gated behind `config.serverMd` (off → pure local file).
+      // channel. P2-A: a plain group resolves GROUP.md server-first (GET
+      // /v1/bot/groups/{groupNo}/md, cached) with a never-lose fallback to the
+      // local `groupConfigDir/<channelId>.md` file (gated behind `config.serverMd`).
+      // P3-1: a thread (CommunityTopic) resolves its OWN THREAD.md ONLY — the
+      // resolver routes on channelId shape and NEVER stacks the parent group's
+      // GROUP.md for a thread (server thread read gated behind `config.threadMd`).
       if (isGroup) {
         const groupInstructions = await resolveGroupInstructions({
           groupConfigDir: config.groupConfigDir,
           serverMd: config.serverMd,
+          threadMd: config.threadMd,
           apiUrl: config.apiUrl,
           botToken: config.botToken,
           channelId,
           cache: groupMdCache,
+          threadCache: threadMdCache,
         });
         if (groupInstructions) {
           sessionOpts = { ...(sessionOpts ?? {}), groupInstructions };

--- a/src/octo/api.ts
+++ b/src/octo/api.ts
@@ -732,6 +732,48 @@ export async function getGroupMd(params: {
 }
 
 /**
+ * Server THREAD.md payload returned by GET /v1/bot/groups/{groupNo}/threads/{shortId}/md.
+ *
+ * Same shape as {@link GroupMd} — the thread markdown endpoint is symmetric to
+ * the group one (verified against the live backend: 200 with
+ * `{content, version, updated_at, updated_by}`). A thread carries its OWN
+ * operator-authored instructions; it does NOT inherit the parent group's GROUP.md.
+ */
+export interface ThreadMd {
+  content: string;
+  version: number;
+  updated_at: string | null;
+  updated_by: string;
+}
+
+/**
+ * Fetch a thread's server-side THREAD.md.
+ * GET /v1/bot/groups/{groupNo}/threads/{shortId}/md.
+ *
+ * The endpoint is symmetric to {@link getGroupMd} (group md = `.../groups/{groupNo}/md`;
+ * thread md = `.../groups/{groupNo}/threads/{shortId}/md`), sharing the same
+ * getJson timeout / Bearer auth / int64-safe JSON parse / error-message format.
+ *
+ * Throws on any non-2xx (including 404 "no THREAD.md set") — the caller
+ * (group-md.ts thread branch) catches and falls back to the local
+ * `<shortId>.md` file, mirroring the group server-first degrade path.
+ */
+export async function getThreadMd(params: {
+  apiUrl: string;
+  botToken: string;
+  groupNo: string;
+  shortId: string;
+  signal?: AbortSignal;
+}): Promise<ThreadMd> {
+  return await getJson<ThreadMd>(
+    params.apiUrl,
+    params.botToken,
+    `/v1/bot/groups/${encodeURIComponent(params.groupNo)}/threads/${encodeURIComponent(params.shortId)}/md`,
+    params.signal,
+  );
+}
+
+/**
  * Update a group's server-side GROUP.md (requires bot_admin permission).
  * PUT /v1/bot/groups/{groupNo}/md, body `{ content }` → `{ version }`.
  *


### PR DESCRIPTION
## Summary

`#88` **P3-1** — a CommunityTopic thread now injects **only its own THREAD.md** and never the parent group's GROUP.md. Previously `resolveGroupInstructions` collapsed every channelId to its parent `groupNo` via `extractParentGroupNo`, so with server-md reads enabled a thread message was injected the parent group's server GROUP.md — violating the redline that a thread and its parent group are mutually exclusive instruction sources.

## Changes

- **`resolveGroupInstructions` split on channelId shape into two mutually-exclusive branches**:
  - **Plain group** — unchanged: server-first GROUP.md, in-memory cache keyed by `groupNo`, never-lose local `<groupNo>.md` fallback (byte-for-byte pre-P3 behavior).
  - **Thread** — resolves its own THREAD.md via a new `getThreadMd` (`GET /v1/bot/groups/{groupNo}/threads/{shortId}/md`), a **separate** in-memory `ThreadMdCache` keyed by the composite `<groupNo>::<shortId>`, and a never-lose local `<shortId>.md` fallback. The thread branch **never reads or writes the group GROUP.md cache and never calls `getGroupMd`.**
- **The thread/group split is unconditional** (it is the bug fix, shipped as the default). A new `threadMd` flag (default off) gates only the new server-read capability; with it off a thread still resolves its local `<shortId>.md`, which is already the correct non-stacking behavior. `threadMd` is independent of `serverMd`.
- **Composite cache key** `groupNo::shortId` is defensive double-insurance: `shortId` is a globally unique 19-digit snowflake today (a bare key would not collide), but the composite key ensures one group's THREAD.md can never be served for a same-`shortId` thread under a different parent group if the id scheme ever changes. A code comment declares the "shortId is globally unique" assumption. `::` is outside the safe-id charset, so it can never appear inside a validated key component.

## Thread server-md endpoint verification

The proposal noted the thread server-md endpoint might not exist upstream. **Verified against the live backend that it does** and is symmetric to the group md endpoint:

```
GET /v1/bot/groups/{groupNo}/threads/{shortId}/md
→ 200 { "content": "...", "version": 49, "updated_at": "...", "updated_by": "..." }
```

Same payload shape as `GET /v1/bot/groups/{groupNo}/md`. The thread branch therefore does a **server-first read of THREAD.md** (behind `threadMd`), reusing the existing `getJson` timeout / SSRF-validated `apiUrl` / Bearer auth / int64-safe parse chain. No follow-up work item is needed for the read path.

## Security

Same trust model as P2-A GROUP.md: the resolved THREAD.md is injected as a trusted system-prompt block, so the `ThreadMdCache` is **in-memory only** (no disk) — the only path content can enter the trusted channel is a live, authenticated `getThreadMd`, never a forgeable on-disk artifact. TTL-bounded staleness backstop shared with the group cache. The thread cache is kept decoupled from group md-change events (P2-B), so a thread never swallows a group event and vice versa.

## Testing

- New `src/__tests__/thread-md.test.ts` (18 tests): `ThreadMdCache` composite-key store/read, cross-group isolation, TTL, invalidate, unsafe-id rejection, no durable backing; thread-branch flag gating, server-first, cache reuse, TTL re-fetch, 404 / empty / network local fallback, malformed channelId, and a **spy assertion that the thread branch never touches the group GROUP.md cache**.
- Core regression added in `group-md.test.ts`: a thread with `serverMd` on + a parent GROUP.md present asserts the parent GROUP.md is **not** injected and the group cache is never read/written.
- `getThreadMd` endpoint/auth/shape tests in `group-md-api.test.ts`.
- Regression baseline (group-md, group-md-api, group-md-tool, group-md-writeback, thread-api, channel-id, group-config) unchanged; **full suite 1210 → 1231 passing, zero group-path regressions.** Lint (0 warnings), type-check, and build all clean.

Part of #88
