### PR TITLE
feat(sdk): 支持通过 config 声明外部 MCP 服务

### DIFF
--- a/config.bot.example.json
+++ b/config.bot.example.json
@@ -10,6 +10,7 @@
     "_comment_systemPrompt": "Inline personality string. A ./SOUL.md file next to this config overrides it.",
     "_comment_skills": "Per-bot skill selection: 'all' or a string[] of skill names from the shared library (~/.cc-channel-octo/skills + this bot's ./skills).",
     "_comment_env": "Extra env injected into the agent's tool subprocess, e.g. {\"OCTO_BOT_ID\":\"<robotId>\"} so a shared CLI acts as this bot.",
-    "_comment_cron": "Set cron=true to let the agent schedule tasks (cron_create/list/delete → ./cron.json, owner-gated)."
+    "_comment_cron": "Set cron=true to let the agent schedule tasks (cron_create/list/delete → ./cron.json, owner-gated).",
+    "_comment_mcp_servers": "Per-bot external MCP servers (mcp__<name>__<tool>), same shape as the global sdk.mcpServers. A per-bot map fully REPLACES the global one (sdk blocks merge shallowly), so list every server this bot needs. http header values are secrets — keep this file non-world-readable (chmod 600). Omit to inherit the global map."
   }
 }

--- a/config.example.json
+++ b/config.example.json
@@ -21,7 +21,12 @@
     "permissionMode": "bypassPermissions",
     "_comment_tool_progress": "v0.3: set toolProgress=true to post '🔧 Running <tool>(<params>)…' notices (params truncated). Off by default.",
     "_comment_setting_sources": "#100: which host filesystem settings the SDK loads (user=~/.claude, project=.claude, local=.claude/*.local). Default [\"project\"] so the SDK discovers skills symlinked into each session sandbox's .claude/skills/. Memory stays isolated regardless (the auto-memory dir is pinned via inline settings, ranked above projectSettings). Add \"user\" only to deliberately load the operator's real ~/.claude.",
-    "settingSources": ["project"]
+    "settingSources": ["project"],
+    "_comment_mcp_servers": "External MCP servers exposed to the agent, keyed by name (tools surface as mcp__<name>__<tool>). Because settingSources is ['project'], servers in the operator's ~/.claude.json are NOT inherited — declare them here to opt a bot in. Merged with cc's in-process servers (cron, GROUP.md write-back); those win a name clash. Forwarded VERBATIM to the SDK subprocess (same trust model as env — config.json is operator-controlled). A per-bot sdk.mcpServers fully REPLACES this global map (sdk blocks merge shallowly). Omit to expose none. Example below shows one stdio (local command) and one http (remote) server.",
+    "mcpServers": {
+      "chrome-devtools": { "type": "stdio", "command": "npx", "args": ["-y", "chrome-devtools-mcp@latest", "--isolated"] },
+      "exa": { "type": "http", "url": "https://mcp.exa.ai/mcp", "headers": { "x-api-key": "<your-exa-api-key>" } }
+    }
   },
 
   "rateLimit": {

--- a/config.example.json
+++ b/config.example.json
@@ -22,11 +22,8 @@
     "_comment_tool_progress": "v0.3: set toolProgress=true to post '🔧 Running <tool>(<params>)…' notices (params truncated). Off by default.",
     "_comment_setting_sources": "#100: which host filesystem settings the SDK loads (user=~/.claude, project=.claude, local=.claude/*.local). Default [\"project\"] so the SDK discovers skills symlinked into each session sandbox's .claude/skills/. Memory stays isolated regardless (the auto-memory dir is pinned via inline settings, ranked above projectSettings). Add \"user\" only to deliberately load the operator's real ~/.claude.",
     "settingSources": ["project"],
-    "_comment_mcp_servers": "External MCP servers exposed to the agent, keyed by name (tools surface as mcp__<name>__<tool>). Because settingSources is ['project'], servers in the operator's ~/.claude.json are NOT inherited — declare them here to opt a bot in. Merged with cc's in-process servers (cron, GROUP.md write-back); those win a name clash. Forwarded VERBATIM to the SDK subprocess (same trust model as env — config.json is operator-controlled). A per-bot sdk.mcpServers fully REPLACES this global map (sdk blocks merge shallowly). Omit to expose none. Example below shows one stdio (local command) and one http (remote) server.",
-    "mcpServers": {
-      "chrome-devtools": { "type": "stdio", "command": "npx", "args": ["-y", "chrome-devtools-mcp@latest", "--isolated"] },
-      "exa": { "type": "http", "url": "https://mcp.exa.ai/mcp", "headers": { "x-api-key": "<your-exa-api-key>" } }
-    }
+    "_comment_mcp_servers": "External MCP servers exposed to the agent, keyed by name (tools surface as mcp__<name>__<tool>). Because settingSources is ['project'], servers in the operator's ~/.claude.json are NOT inherited — declare them here to opt a bot in. Merged with cc's in-process servers (cron, GROUP.md write-back); those win a name clash. Forwarded VERBATIM to the SDK subprocess (same trust model as env — config.json is operator-controlled). A per-bot sdk.mcpServers fully REPLACES this global map (sdk blocks merge shallowly). SECURITY: http header values (e.g. x-api-key / Authorization) are secrets stored in this file — keep config.json non-world-readable (chmod 600); the startup file-permission warning applies here too. Left EMPTY by default so copying this template enables NO external processes; add entries to opt in. Example shapes — stdio (local command): {\"chrome-devtools\": {\"type\": \"stdio\", \"command\": \"npx\", \"args\": [\"-y\", \"chrome-devtools-mcp@latest\", \"--isolated\"]}} — http (remote): {\"exa\": {\"type\": \"http\", \"url\": \"https://mcp.exa.ai/mcp\", \"headers\": {\"x-api-key\": \"<secret>\"}}}.",
+    "mcpServers": {}
   },
 
   "rateLimit": {

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -124,6 +124,44 @@ describe('config-file over defaults', () => {
   });
 });
 
+// ─── 2b. sdk.mcpServers ─────────────────────────────────────────────────────
+
+describe('sdk.mcpServers', () => {
+  beforeEach(setup);
+  afterEach(teardown);
+
+  it('loads a global sdk.mcpServers map and forwards it to every bot', () => {
+    const mcpServers = {
+      exa: { type: 'http', url: 'https://mcp.exa.ai/mcp', headers: { 'x-api-key': 'k' } },
+      'chrome-devtools': { type: 'stdio', command: 'npx', args: ['-y', 'chrome-devtools-mcp@latest'] },
+    };
+    const path = writeConfig({ botToken: 'bf', apiUrl: 'https://api.test', sdk: { mcpServers } });
+    const [bot] = resolveBotConfigs(loadConfig(path));
+    expect(bot.sdk.mcpServers).toEqual(mcpServers);
+  });
+
+  it('is undefined by default (no servers inherited from host ~/.claude.json)', () => {
+    const path = writeConfig({ botToken: 'bf', apiUrl: 'https://api.test' });
+    const [bot] = resolveBotConfigs(loadConfig(path));
+    expect(bot.sdk.mcpServers).toBeUndefined();
+  });
+
+  it('per-bot sdk.mcpServers REPLACES the global map (shallow sdk merge)', () => {
+    const path = writeConfig({
+      apiUrl: 'https://api.test',
+      bots: [{ id: 'a' }],
+      sdk: { mcpServers: { exa: { type: 'http', url: 'https://mcp.exa.ai/mcp' } } },
+    });
+    writeBotConfig('a', {
+      botToken: 'bf_a',
+      sdk: { mcpServers: { local: { type: 'stdio', command: 'my-tool' } } },
+    });
+    const [bot] = resolveBotConfigs(loadConfig(path));
+    // The bot's own sdk block wins wholesale — the global `exa` is not merged in.
+    expect(bot.sdk.mcpServers).toEqual({ local: { type: 'stdio', command: 'my-tool' } });
+  });
+});
+
 // ─── 3. Required Fields ────────────────────────────────────────────────────
 
 describe('required field validation', () => {

--- a/src/__tests__/cron-integration.test.ts
+++ b/src/__tests__/cron-integration.test.ts
@@ -125,6 +125,32 @@ describe('cron integration (#115)', () => {
     expect(captured!.cron).toBeDefined();
   });
 
+  it('external sdk.mcpServers reach the agent and coexist with the cron tool', async () => {
+    // A declared external server (e.g. a browser/search backend) must be offered
+    // to the agent ALONGSIDE the per-turn in-process cron tool — the cron
+    // injection must not clobber the external map (regression guard: cron used to
+    // REPLACE mcpServers rather than merge). A same-named external server is
+    // overridden by the in-process cron server (documented "built-ins win").
+    config.sdk.mcpServers = {
+      exa: { type: 'http', url: 'https://mcp.exa.ai/mcp' },
+      cron: { type: 'http', url: 'http://override-me.invalid' }, // clashes with the built-in
+    };
+    let captured: Record<string, unknown> | undefined;
+    (queryAgent as ReturnType<typeof vi.fn>).mockImplementation(
+      async function* (_u: string, _cfg: unknown, _ctx: unknown, _t: unknown, opts: { mcpServers?: Record<string, unknown> }) {
+        captured = opts?.mcpServers;
+        yield 'ok';
+      },
+    );
+    const msg = synthesizeCronMessage(task());
+    await handleMessage(msg, config, store, router, groupContext, streamRelay, BOT_ID, cronStore);
+    expect(captured).toBeDefined();
+    expect(captured!.exa).toBeDefined(); // non-clashing external survived
+    expect(captured!.cron).toBeDefined(); // cron present
+    // the in-process cron server won the name clash, not the http external
+    expect((captured!.cron as { url?: string }).url).toBeUndefined();
+  });
+
   it('a FAILED cron fire is attributed to its task at the real catch site (#A)', async () => {
     // The production failure path: queryAgent throws → handleMessage's own
     // try/catch swallows it (sends a user-facing error reply, never rethrows).

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,6 +17,7 @@
 import { readFileSync, existsSync, statSync, realpathSync } from 'node:fs';
 import { resolve as resolvePath, sep, dirname, join as pathJoin } from 'node:path';
 import { homedir } from 'node:os';
+import type { McpServerConfig } from '@anthropic-ai/claude-agent-sdk';
 import { isAllowedApiUrl } from './url-policy.js';
 
 /**
@@ -209,6 +210,24 @@ export interface Config {
      * is gated to the bot owner uid (registerBot.owner_uid). Default off. Per-bot.
      */
     cron?: boolean;
+    /**
+     * External MCP servers exposed to the agent, keyed by server name (tools
+     * surface as `mcp__<name>__<tool>`). Merged with any in-process servers cc
+     * injects per turn (cron, GROUP.md write-back) — a name clash lets those
+     * built-ins win, since they are bound to per-turn session coords. This is
+     * how bots reach browser / search / other MCP backends: the gateway loads
+     * only `settingSources: ['project']`, so servers declared in the operator's
+     * `~/.claude.json` are deliberately NOT inherited — declare them here to opt
+     * a bot in explicitly.
+     *
+     * Trust model mirrors `env` (#107): the value is forwarded VERBATIM to the
+     * SDK subprocess with no validation — config.json is operator-controlled and
+     * outside the agent-writable sandbox, so declaring a server is an explicit
+     * operator grant. Can be set at the global layer (all bots) or per-bot in
+     * `<baseDir>/<id>/config.json` (a per-bot `sdk.mcpServers` fully REPLACES the
+     * global map — sdk blocks merge shallowly, so list every server the bot needs).
+     */
+    mcpServers?: Record<string, McpServerConfig>;
   };
   rateLimit: {
     maxPerMinute: number;

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import { OctoGateway } from './gateway.js';
 import { SessionRouter } from './session-router.js';
 import { GroupContext } from './group-context.js';
 import { queryAgent } from './agent-bridge.js';
+import type { McpServerConfig } from '@anthropic-ai/claude-agent-sdk';
 import { sanitizeDisplayName, escapeSectionMarkers, sanitizePromptBody, formatSenderLabel } from './prompt-safety.js';
 import type { SessionCtx } from './cwd-resolver.js';
 import { cleanupExpiredCwds, resolveMemoryDir, resolveSessionCwd } from './cwd-resolver.js';
@@ -815,7 +816,7 @@ export async function handleMessage(
       // queryAgent recovers by calling onResumeFailed (clear the bad id) and
       // retrying once with the pre-assembled fallbackRetryPrompt so the
       // conversation isn't lost (and assembly happens exactly once — see above).
-      let sessionOpts: { resume?: string; onSessionId?: (id: string) => void; groupInstructions?: string; memoryDir?: string; mcpServers?: Record<string, ReturnType<typeof createCronToolServer>>; onResumeFailed?: () => void; fallbackRetryPrompt?: string } | undefined = {
+      let sessionOpts: { resume?: string; onSessionId?: (id: string) => void; groupInstructions?: string; memoryDir?: string; mcpServers?: Record<string, McpServerConfig>; onResumeFailed?: () => void; fallbackRetryPrompt?: string } | undefined = {
         ...(resume ? { resume } : {}),
         onSessionId: (id: string) => store.setSdkSessionId(sessionKey, id),
         ...(resume
@@ -835,6 +836,17 @@ export async function handleMessage(
         const memBase = config.memoryBase ?? join(config.dataDir, 'memory');
         const memoryDir = resolveMemoryDir(memBase, sessionCtx);
         sessionOpts = { ...(sessionOpts ?? {}), memoryDir };
+      }
+
+      // External MCP servers declared in config (sdk.mcpServers): seed the map
+      // FIRST so the per-turn in-process servers below (cron, GROUP.md write-back)
+      // merge on top and win any name clash — those are bound to this turn's
+      // session coords and must not be shadowed by a same-named external server.
+      if (config.sdk.mcpServers && Object.keys(config.sdk.mcpServers).length > 0) {
+        sessionOpts = {
+          ...(sessionOpts ?? {}),
+          mcpServers: { ...(sessionOpts?.mcpServers ?? {}), ...config.sdk.mcpServers },
+        };
       }
 
       // GROUP.md: inject operator-provided per-group instructions into the
@@ -869,7 +881,7 @@ export async function handleMessage(
         const cronServer = createCronToolServer(cronStore, coords, router.getOwnerUid());
         sessionOpts = {
           ...(sessionOpts ?? {}),
-          mcpServers: { [CRON_TOOL_SERVER_NAME]: cronServer },
+          mcpServers: { ...(sessionOpts?.mcpServers ?? {}), [CRON_TOOL_SERVER_NAME]: cronServer },
         };
       }
 


### PR DESCRIPTION
## 背景 / 问题
gateway 以 `settingSources: ['project']` 加载 SDK 设置,因此 operator `~/.claude.json` 里声明的 MCP 服务**不会**被 bot 会话继承。此前 bot 只能用到进程内注入的 MCP(cron、GROUP.md 写回),没有任何配置途径把**外部 MCP 服务**(浏览器 / 搜索等 stdio/http 后端)暴露给 agent —— 即便写进 `~/.cc-channel-octo/config.json` 也不会被读取、不会传给模型。

## 改动
新增 `sdk.mcpServers` 配置项,按服务名声明外部 MCP(stdio / http),工具以 `mcp__<name>__<tool>` 暴露给 agent。

- **config.ts**:`sdk` 块内新增 `mcpServers?: Record<string, McpServerConfig>`(type-only 引入 SDK 类型)。随 `sdk` 块浅合并透传:全局层作用于所有 bot,per-bot `sdk.mcpServers` 整体替换全局 map(与既有 sdk 合并语义一致,注释已说明)。
- **index.ts**:组装 `sessionOpts.mcpServers` 时先铺入 `config.sdk.mcpServers`,再叠加 per-turn 的进程内服务。cron 注入由「整体替换」改为「合并」,避免冲掉外部声明;同名冲突时进程内内置服务(绑定到本轮 session coords)胜出。`agent-bridge.ts` 已负责把 `opts.mcpServers` 透传给 SDK,无需改动。
- **config.example.json**:补带注释的 `mcpServers` 示例(一个 stdio、一个 http)。

## 信任模型
外部 MCP 配置逐字透传给 SDK 子进程、不做校验 —— 对齐既有 `env`(#107)的模型:`config.json` 由 operator 控制、位于 agent 可写沙箱之外,声明一个服务即显式授权。agent 无法改写 `config.json`,故无法自行注入服务。

## 测试
- `config.test.ts`:全局 `sdk.mcpServers` 加载并下发到每个 bot;默认 `undefined`(不继承宿主 `~/.claude.json`);per-bot 整体替换语义。
- `cron-integration.test.ts`:外部 MCP 与 cron 共存(回归守卫:cron 曾整体替换而非合并);同名冲突时内置 cron 覆盖外部。
- 全量 1214 测试通过,type-check / lint / build 均干净。

## 兼容性
未配置 `sdk.mcpServers` 时行为完全不变。