### PR TITLE
feat(thread-md): THREAD.md write-back + thread/deleted md event invalidation (#88 P3-2)

### DIFF
--- a/src/__tests__/group-md-api.test.ts
+++ b/src/__tests__/group-md-api.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest';
-import { getGroupMd, getThreadMd, updateGroupMd, type GroupMd, type ThreadMd } from '../octo/api.js';
+import { getGroupMd, getThreadMd, updateGroupMd, updateThreadMd, type GroupMd, type ThreadMd } from '../octo/api.js';
 
 const fetchMock = vi.fn();
 const originalFetch = globalThis.fetch;
@@ -129,6 +129,37 @@ describe('updateGroupMd', () => {
     fetchMock.mockResolvedValueOnce(new Response('forbidden', { status: 403, statusText: 'Forbidden' }));
     await expect(
       updateGroupMd({ ...BASE, groupNo: GROUP, content: 'x' }),
+    ).rejects.toThrow(/failed \(403\)/);
+  });
+});
+
+describe('updateThreadMd', () => {
+  const SHORT = '2071488441815666688';
+
+  it('PUTs /v1/bot/groups/{groupNo}/threads/{shortId}/md with Bearer auth and a {content} body', async () => {
+    fetchMock.mockResolvedValueOnce(mockJsonResponse({ version: 4 }));
+
+    const res = await updateThreadMd({ ...BASE, groupNo: GROUP, shortId: SHORT, content: 'Thread rules.' });
+
+    const { url, init } = call();
+    expect(url).toBe(`${BASE.apiUrl}/v1/bot/groups/${GROUP}/threads/${SHORT}/md`);
+    expect(init.method).toBe('PUT');
+    expect(authHeader(init)).toBe(`Bearer ${BASE.botToken}`);
+    // No compare-and-swap: the body carries ONLY content, never a version.
+    expect(JSON.parse(init.body as string)).toEqual({ content: 'Thread rules.' });
+    expect(res).toEqual({ version: 4 });
+  });
+
+  it('url-encodes both the groupNo and shortId path segments', async () => {
+    fetchMock.mockResolvedValueOnce(mockJsonResponse({ version: 1 }));
+    await updateThreadMd({ ...BASE, groupNo: 'a/b', shortId: 'c/d', content: 'x' });
+    expect(call().url).toBe(`${BASE.apiUrl}/v1/bot/groups/a%2Fb/threads/c%2Fd/md`);
+  });
+
+  it('throws on a non-2xx', async () => {
+    fetchMock.mockResolvedValueOnce(new Response('forbidden', { status: 403, statusText: 'Forbidden' }));
+    await expect(
+      updateThreadMd({ ...BASE, groupNo: GROUP, shortId: SHORT, content: 'x' }),
     ).rejects.toThrow(/failed \(403\)/);
   });
 });

--- a/src/__tests__/group-md-events.test.ts
+++ b/src/__tests__/group-md-events.test.ts
@@ -1,0 +1,71 @@
+/**
+ * GROUP.md / THREAD.md event classifiers (group-md-events.ts).
+ *
+ * Unit-level coverage of the pure predicates + their default literal sets,
+ * complementing the router-level invalidation tests in session-router.test.ts:
+ *   - both update and delete literals classify as a change (P2-B + P3-2 tail);
+ *   - the group and thread literal sets are DISJOINT (mutual exclusion);
+ *   - overrides replace the defaults; empty/missing type never matches.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  isGroupMdUpdateEvent,
+  isThreadMdUpdateEvent,
+  DEFAULT_GROUP_MD_EVENT_TYPES,
+  DEFAULT_THREAD_MD_EVENT_TYPES,
+} from '../group-md-events.js';
+
+describe('isGroupMdUpdateEvent', () => {
+  it('matches both the update and delete default literals', () => {
+    expect(isGroupMdUpdateEvent({ type: 'group_md_updated' })).toBe(true);
+    expect(isGroupMdUpdateEvent({ type: 'group_md_deleted' })).toBe(true);
+  });
+
+  it('does not match thread literals or unrelated system events', () => {
+    expect(isGroupMdUpdateEvent({ type: 'thread_md_updated' })).toBe(false);
+    expect(isGroupMdUpdateEvent({ type: 'group_member_join' })).toBe(false);
+  });
+
+  it('never matches an undefined / empty / typeless event', () => {
+    expect(isGroupMdUpdateEvent(undefined)).toBe(false);
+    expect(isGroupMdUpdateEvent({})).toBe(false);
+    expect(isGroupMdUpdateEvent({ type: '' })).toBe(false);
+  });
+
+  it('honours an override literal set (calibration seam)', () => {
+    expect(isGroupMdUpdateEvent({ type: 'group_md_updated' }, ['group.md.changed'])).toBe(false);
+    expect(isGroupMdUpdateEvent({ type: 'group.md.changed' }, ['group.md.changed'])).toBe(true);
+  });
+});
+
+describe('isThreadMdUpdateEvent', () => {
+  it('matches both the update and delete default literals', () => {
+    expect(isThreadMdUpdateEvent({ type: 'thread_md_updated' })).toBe(true);
+    expect(isThreadMdUpdateEvent({ type: 'thread_md_deleted' })).toBe(true);
+  });
+
+  it('does not match group literals or unrelated system events', () => {
+    expect(isThreadMdUpdateEvent({ type: 'group_md_updated' })).toBe(false);
+    expect(isThreadMdUpdateEvent({ type: 'group_md_deleted' })).toBe(false);
+    expect(isThreadMdUpdateEvent({ type: 'group_member_join' })).toBe(false);
+  });
+
+  it('never matches an undefined / empty / typeless event', () => {
+    expect(isThreadMdUpdateEvent(undefined)).toBe(false);
+    expect(isThreadMdUpdateEvent({})).toBe(false);
+    expect(isThreadMdUpdateEvent({ type: '' })).toBe(false);
+  });
+
+  it('honours an override literal set (calibration seam)', () => {
+    expect(isThreadMdUpdateEvent({ type: 'thread_md_updated' }, ['thread.md.changed'])).toBe(false);
+    expect(isThreadMdUpdateEvent({ type: 'thread.md.changed' }, ['thread.md.changed'])).toBe(true);
+  });
+});
+
+describe('default literal sets are disjoint (mutual exclusion invariant)', () => {
+  it('no literal appears in both the group and thread default sets', () => {
+    const overlap = DEFAULT_GROUP_MD_EVENT_TYPES.filter((t) => DEFAULT_THREAD_MD_EVENT_TYPES.includes(t));
+    expect(overlap).toEqual([]);
+  });
+});

--- a/src/__tests__/session-router.test.ts
+++ b/src/__tests__/session-router.test.ts
@@ -10,7 +10,7 @@ import type { BotMessage } from '../octo/types.js';
 import { ChannelType, MessageType } from '../octo/types.js';
 import type { Config } from '../config.js';
 import { sendMessage } from '../octo/api.js';
-import { GroupMdCache } from '../group-md-cache.js';
+import { GroupMdCache, ThreadMdCache } from '../group-md-cache.js';
 import type { GroupMdEntry } from '../group-md-cache.js';
 
 const ROBOT_ID = 'bot-001';
@@ -1123,5 +1123,174 @@ describe('SessionRouter — GROUP.md event-driven cache refresh (P2-B)', () => {
     });
     await router.route(real);
     expect(cache.get(GROUP)).toBeUndefined();
+  });
+
+  it('a GROUP.md DELETE event also invalidates the cache (P3-2 deleted-event tail)', async () => {
+    const cache = new GroupMdCache();
+    cache.set(GROUP, makeEntry());
+    const router = makeRouter(cache);
+
+    const result = await router.route(
+      mdEvent({ payload: { type: MessageType.Text, content: '', event: { type: 'group_md_deleted', group_no: GROUP } } }),
+    );
+
+    expect(result).toBeNull();
+    // A server-side delete drops the cached copy → next read 404s → local fallback.
+    expect(cache.get(GROUP)).toBeUndefined();
+  });
+});
+
+// P3-2: THREAD.md event-driven cache refresh. Mirrors the P2-B group block, but
+// keyed by the COMPOSITE groupNo::shortId and gated on `threadMd`. Verifies the
+// routing (thread md event → invalidate the right subarea; group events and
+// missing short_id → never touch the thread cache) and the config-override seam.
+describe('SessionRouter — THREAD.md event-driven cache refresh (P3-2)', () => {
+  const GROUP = 'group-abc';
+  const SHORT = '2071488441815666688';
+
+  function makeEntry(): GroupMdEntry {
+    return { content: '# cached thread', version: 1, updated_at: null };
+  }
+
+  function makeRouter(cache?: ThreadMdCache, overrides?: Partial<Config>): SessionRouter {
+    // threadMd on by default here — the thread refresh path is gated on it. The
+    // group cache is passed undefined; this block exercises the thread path only.
+    return new SessionRouter(makeConfig({ threadMd: true, ...overrides }), ROBOT_ID, '', undefined, cache);
+  }
+
+  // A THREAD.md change event as it really arrives: on a DM channel, with the
+  // affected thread carried in event.group_no + event.short_id.
+  function threadEvent(overrides?: Partial<BotMessage>): BotMessage {
+    return makeMsg({
+      channel_type: ChannelType.DM,
+      channel_id: 'dm-peer',
+      from_uid: 'user-1',
+      payload: {
+        type: MessageType.Text,
+        content: '',
+        event: { type: 'thread_md_updated', group_no: GROUP, short_id: SHORT },
+      },
+      ...overrides,
+    });
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('a THREAD.md update event invalidates that subarea\'s composite-keyed cache and returns null', async () => {
+    const cache = new ThreadMdCache();
+    cache.set(GROUP, SHORT, makeEntry());
+    const router = makeRouter(cache);
+
+    const result = await router.route(threadEvent());
+
+    expect(result).toBeNull();
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(cache.get(GROUP, SHORT)).toBeUndefined();
+  });
+
+  it('a THREAD.md DELETE event also invalidates the subarea cache', async () => {
+    const cache = new ThreadMdCache();
+    cache.set(GROUP, SHORT, makeEntry());
+    const router = makeRouter(cache);
+
+    await router.route(
+      threadEvent({
+        payload: { type: MessageType.Text, content: '', event: { type: 'thread_md_deleted', group_no: GROUP, short_id: SHORT } },
+      }),
+    );
+
+    expect(cache.get(GROUP, SHORT)).toBeUndefined();
+  });
+
+  it('only the targeted subarea is dropped — a sibling thread under the same group survives', async () => {
+    const cache = new ThreadMdCache();
+    cache.set(GROUP, SHORT, makeEntry());
+    cache.set(GROUP, 'sibling', makeEntry());
+    const router = makeRouter(cache);
+
+    await router.route(threadEvent());
+
+    expect(cache.get(GROUP, SHORT)).toBeUndefined();
+    expect(cache.get(GROUP, 'sibling')).toEqual(makeEntry()); // untouched
+  });
+
+  it('a GROUP.md event never touches the thread cache (disjoint literals / mutual exclusion)', async () => {
+    const cache = new ThreadMdCache();
+    cache.set(GROUP, SHORT, makeEntry());
+    const router = makeRouter(cache);
+
+    await router.route(
+      threadEvent({
+        payload: { type: MessageType.Text, content: '', event: { type: 'group_md_updated', group_no: GROUP, short_id: SHORT } },
+      }),
+    );
+
+    // A group-md literal must not invalidate a thread entry.
+    expect(cache.get(GROUP, SHORT)).toEqual(makeEntry());
+  });
+
+  it('a thread event with no short_id is a no-op (no subarea to key)', async () => {
+    const cache = new ThreadMdCache();
+    cache.set(GROUP, SHORT, makeEntry());
+    const router = makeRouter(cache);
+
+    await router.route(
+      threadEvent({ payload: { type: MessageType.Text, content: '', event: { type: 'thread_md_updated', group_no: GROUP } } }),
+    );
+
+    expect(cache.get(GROUP, SHORT)).toEqual(makeEntry());
+  });
+
+  it('with threadMd off the thread cache is never touched (rollback flag)', async () => {
+    const cache = new ThreadMdCache();
+    cache.set(GROUP, SHORT, makeEntry());
+    const router = makeRouter(cache, { threadMd: false });
+
+    await router.route(threadEvent());
+
+    expect(cache.get(GROUP, SHORT)).toEqual(makeEntry());
+  });
+
+  it('no thread cache wired → thread md event is a harmless no-op (returns null)', async () => {
+    const router = makeRouter(undefined);
+    const result = await router.route(threadEvent());
+    expect(result).toBeNull();
+  });
+
+  it('derives groupNo + shortId from the channel on a mention-free thread with no ids in the event', async () => {
+    const cache = new ThreadMdCache();
+    cache.set(GROUP, SHORT, makeEntry());
+    // Mention-free is the one group-like path that reaches the event branch.
+    const router = makeRouter(cache, { mentionFreeGroups: [`${GROUP}____${SHORT}`] });
+
+    await router.route(
+      threadEvent({
+        channel_type: ChannelType.CommunityTopic,
+        channel_id: `${GROUP}____${SHORT}`,
+        payload: { type: MessageType.Text, content: '', event: { type: 'thread_md_updated' } },
+      }),
+    );
+
+    expect(cache.get(GROUP, SHORT)).toBeUndefined();
+  });
+
+  it('the thread md event literal is overridable via threadMdEventTypes (calibration seam)', async () => {
+    const cache = new ThreadMdCache();
+    cache.set(GROUP, SHORT, makeEntry());
+    const router = makeRouter(cache, { threadMdEventTypes: ['thread.md.changed'] });
+
+    // Default provisional literal is now ignored.
+    await router.route(threadEvent());
+    expect(cache.get(GROUP, SHORT)).toEqual(makeEntry());
+
+    // The configured literal triggers invalidation.
+    await router.route(
+      threadEvent({
+        payload: { type: MessageType.Text, content: '', event: { type: 'thread.md.changed', group_no: GROUP, short_id: SHORT } },
+      }),
+    );
+    expect(cache.get(GROUP, SHORT)).toBeUndefined();
   });
 });

--- a/src/__tests__/thread-md-tool.test.ts
+++ b/src/__tests__/thread-md-tool.test.ts
@@ -1,0 +1,160 @@
+/**
+ * P3-2: THREAD.md write-back tool tests (group-md-tool.ts, update_thread_md).
+ *
+ * Drives the tool handler directly via buildThreadMdTools (the MCP server keeps
+ * tools private). The SDK's `tool`/`createSdkMcpServer` are mocked to plain
+ * passthroughs so the module loads without the real SDK.
+ *
+ * Covers the acceptance gates at the policy layer:
+ *   - owner-gate: only the bot owner may write (non-owner / empty-owner rejected,
+ *     no server call);
+ *   - the write targets the thread's OWN md path (groupNo + shortId), NEVER the
+ *     parent group — this is the XIN-230 follow-up the ticket exists to fix;
+ *   - a non-thread channelId is refused (thread tool is thread-only);
+ *   - ≤10240-byte UTF-8 rejection surfaces a clean error (no server call);
+ *   - concurrent tool calls for the same thread serialize through the shared
+ *     coordinator (no overlap, no lost write).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@anthropic-ai/claude-agent-sdk', () => ({
+  createSdkMcpServer: (opts: { name: string }) => ({ type: 'sdk', name: opts.name, instance: {} }),
+  tool: (name: string, description: string, inputSchema: unknown, handler: unknown) => ({ name, description, inputSchema, handler }),
+}));
+
+import {
+  buildThreadMdTools,
+  createThreadMdToolServer,
+  THREAD_MD_TOOL_SERVER_NAME,
+  type GroupMdSessionCoords,
+  type ThreadMdToolDeps,
+} from '../group-md-tool.js';
+import { ThreadMdWriteback, MAX_THREAD_MD_CONTENT_BYTES, type UpdateThreadMdFn } from '../group-md-writeback.js';
+import { ThreadMdCache } from '../group-md-cache.js';
+
+const OWNER = 'owner-uid';
+const API = 'https://api.example.com';
+const TOKEN = 'bot-token';
+const GROUP = 'grp-7';
+const SHORT = 'thread9';
+const THREAD_CHAN = `${GROUP}____${SHORT}`;
+
+const delay = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+function coords(over: Partial<GroupMdSessionCoords> = {}): GroupMdSessionCoords {
+  return { channelId: THREAD_CHAN, fromUid: OWNER, fromName: 'Owner', ...over };
+}
+
+function getTool(deps: ThreadMdToolDeps, c: GroupMdSessionCoords, owner = OWNER) {
+  const t = buildThreadMdTools(deps, c, owner).find((x) => x.name === 'update_thread_md');
+  if (!t) throw new Error('tool update_thread_md not found');
+  return t as { name: string; handler: (args: { content: string }, extra: unknown) => Promise<{ content: Array<{ text?: string }>; isError?: boolean }> };
+}
+function text(r: { content: Array<{ text?: string }> }): string {
+  return r.content.map((c) => c.text ?? '').join('');
+}
+
+describe('thread-md-tool', () => {
+  let cache: ThreadMdCache;
+  let putFn: ReturnType<typeof vi.fn<UpdateThreadMdFn>>;
+  let deps: ThreadMdToolDeps;
+
+  beforeEach(() => {
+    cache = new ThreadMdCache();
+    let version = 0;
+    putFn = vi.fn<UpdateThreadMdFn>(async () => ({ version: ++version }));
+    deps = { writeback: new ThreadMdWriteback(cache, putFn), apiUrl: API, botToken: TOKEN };
+  });
+
+  it('createThreadMdToolServer builds an MCP server named "thread_md"', () => {
+    const s = createThreadMdToolServer(deps, coords(), OWNER);
+    expect(THREAD_MD_TOOL_SERVER_NAME).toBe('thread_md');
+    expect((s as { name: string }).name).toBe('thread_md');
+  });
+
+  it('owner write: PUTs to the thread (groupNo + shortId), NOT the parent group, and refreshes the cache', async () => {
+    const r = await getTool(deps, coords()).handler({ content: 'thread persona' }, {});
+    expect(r.isError).toBeFalsy();
+    expect(putFn).toHaveBeenCalledWith(
+      expect.objectContaining({ apiUrl: API, botToken: TOKEN, groupNo: GROUP, shortId: SHORT, content: 'thread persona' }),
+    );
+    expect(text(r)).toContain('"version": 1');
+    expect(text(r)).toContain(`"shortId": "${SHORT}"`);
+    expect(cache.get(GROUP, SHORT)).toEqual({ content: 'thread persona', version: 1, updated_at: null });
+  });
+
+  it('non-owner write is rejected and never calls the server', async () => {
+    const r = await getTool(deps, coords({ fromUid: 'rando' })).handler({ content: 'x' }, {});
+    expect(r.isError).toBe(true);
+    expect(text(r)).toMatch(/only the bot owner/i);
+    expect(putFn).not.toHaveBeenCalled();
+    expect(cache.get(GROUP, SHORT)).toBeUndefined();
+  });
+
+  it('empty owner uid gates everyone out (no owner → unusable)', async () => {
+    const r = await getTool(deps, coords(), '').handler({ content: 'x' }, {});
+    expect(r.isError).toBe(true);
+    expect(putFn).not.toHaveBeenCalled();
+  });
+
+  it('a plain (non-thread) channelId is refused — the thread tool is thread-only', async () => {
+    const r = await getTool(deps, coords({ channelId: 'plain-group' })).handler({ content: 'x' }, {});
+    expect(r.isError).toBe(true);
+    expect(text(r)).toMatch(/not a thread/i);
+    expect(putFn).not.toHaveBeenCalled();
+  });
+
+  it('over-limit content is rejected with a clear error and no server call', async () => {
+    const tooBig = 'a'.repeat(MAX_THREAD_MD_CONTENT_BYTES + 1);
+    const r = await getTool(deps, coords()).handler({ content: tooBig }, {});
+    expect(r.isError).toBe(true);
+    expect(text(r)).toMatch(/over the 10240-byte/i);
+    expect(putFn).not.toHaveBeenCalled();
+    expect(cache.get(GROUP, SHORT)).toBeUndefined();
+  });
+
+  it('content exactly at the limit is accepted', async () => {
+    const atLimit = 'a'.repeat(MAX_THREAD_MD_CONTENT_BYTES);
+    const r = await getTool(deps, coords()).handler({ content: atLimit }, {});
+    expect(r.isError).toBeFalsy();
+    expect(putFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces the client error when the PUT fails (cache untouched)', async () => {
+    putFn.mockRejectedValueOnce(new Error('Octo API PUT failed (403): forbidden'));
+    const r = await getTool(deps, coords()).handler({ content: 'doc' }, {});
+    expect(r.isError).toBe(true);
+    expect(text(r)).toMatch(/PUT failed/);
+    expect(cache.get(GROUP, SHORT)).toBeUndefined();
+  });
+
+  it('serializes concurrent tool calls for the same thread through the shared coordinator', async () => {
+    let active = 0;
+    let maxActive = 0;
+    let version = 0;
+    const order: string[] = [];
+    const slow: UpdateThreadMdFn = async (p) => {
+      active++;
+      maxActive = Math.max(maxActive, active);
+      await delay(10);
+      order.push(p.content);
+      active--;
+      return { version: ++version };
+    };
+    const shared = new ThreadMdWriteback(cache, slow);
+    const d: ThreadMdToolDeps = { writeback: shared, apiUrl: API, botToken: TOKEN };
+
+    const tA = getTool(d, coords());
+    const tB = getTool(d, coords());
+    const results = await Promise.all([
+      tA.handler({ content: 'A' }, {}),
+      tB.handler({ content: 'B' }, {}),
+    ]);
+
+    expect(results.every((r) => !r.isError)).toBe(true);
+    expect(maxActive).toBe(1);
+    expect(order).toHaveLength(2);
+    expect(cache.get(GROUP, SHORT)?.version).toBe(2);
+  });
+});

--- a/src/__tests__/thread-md-writeback.test.ts
+++ b/src/__tests__/thread-md-writeback.test.ts
@@ -1,0 +1,198 @@
+/**
+ * P3-2: THREAD.md write-back coordinator tests (group-md-writeback.ts,
+ * ThreadMdWriteback).
+ *
+ * The thread analogue of the P2-C GROUP.md write-back tests. Covers:
+ *   - ≤10240-byte UTF-8 cap rejected LOCALLY (no server PUT), byte not char;
+ *   - a successful PUT writes the new content/version into the composite-keyed
+ *     THREAD.md cache (so the next resolve serves what we wrote);
+ *   - the write targets the thread (groupNo + shortId), NEVER the parent group;
+ *   - per-`groupNo::shortId` serialization: concurrent write-backs to the SAME
+ *     thread never overlap and never lose a write, while different threads (and a
+ *     same-shortId thread under a different parent group) still run concurrently;
+ *   - a failed PUT leaves the cache untouched and does not wedge the lock.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  ThreadMdWriteback,
+  ThreadMdContentTooLargeError,
+  MAX_THREAD_MD_CONTENT_BYTES,
+  type UpdateThreadMdFn,
+} from '../group-md-writeback.js';
+import { ThreadMdCache } from '../group-md-cache.js';
+
+const API = 'https://api.example.com';
+const TOKEN = 'bot-token';
+const GROUP = 'grp001';
+const SHORT = '2071488441815666688';
+
+const delay = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+/** A version-incrementing fake PUT client (server-style monotonic counter). */
+function versioningUpdateFn(): { fn: UpdateThreadMdFn; calls: () => number } {
+  let version = 0;
+  let calls = 0;
+  const fn: UpdateThreadMdFn = async () => {
+    calls++;
+    version++;
+    return { version };
+  };
+  return { fn, calls: () => calls };
+}
+
+describe('ThreadMdWriteback', () => {
+  it('writes content back to the composite-keyed cache with the server version', async () => {
+    const cache = new ThreadMdCache();
+    const { fn } = versioningUpdateFn();
+    const wb = new ThreadMdWriteback(cache, fn);
+
+    const res = await wb.writeBack({ apiUrl: API, botToken: TOKEN, groupNo: GROUP, shortId: SHORT, content: 'hello' });
+
+    expect(res).toEqual({ groupNo: GROUP, shortId: SHORT, version: 1, bytes: 5 });
+    expect(cache.get(GROUP, SHORT)).toEqual({ content: 'hello', version: 1, updated_at: null });
+  });
+
+  it('passes apiUrl/botToken/groupNo/shortId/content through to the PUT client', async () => {
+    const cache = new ThreadMdCache();
+    const fn = vi.fn<UpdateThreadMdFn>(async () => ({ version: 7 }));
+    const wb = new ThreadMdWriteback(cache, fn);
+
+    await wb.writeBack({ apiUrl: API, botToken: TOKEN, groupNo: GROUP, shortId: SHORT, content: 'doc' });
+
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith(
+      expect.objectContaining({ apiUrl: API, botToken: TOKEN, groupNo: GROUP, shortId: SHORT, content: 'doc' }),
+    );
+  });
+
+  it('does NOT touch the parent group key — the write is thread-scoped', async () => {
+    const cache = new ThreadMdCache();
+    const { fn } = versioningUpdateFn();
+    const wb = new ThreadMdWriteback(cache, fn);
+
+    await wb.writeBack({ apiUrl: API, botToken: TOKEN, groupNo: GROUP, shortId: SHORT, content: 'x' });
+
+    // The entry lives under the composite key; a DIFFERENT thread under the same
+    // parent group is unaffected (no group-level bleed).
+    expect(cache.get(GROUP, SHORT)).toMatchObject({ content: 'x' });
+    expect(cache.get(GROUP, 'other-thread')).toBeUndefined();
+  });
+
+  it('allows content exactly at the byte limit', async () => {
+    const cache = new ThreadMdCache();
+    const { fn, calls } = versioningUpdateFn();
+    const wb = new ThreadMdWriteback(cache, fn);
+    const atLimit = 'a'.repeat(MAX_THREAD_MD_CONTENT_BYTES);
+
+    const res = await wb.writeBack({ apiUrl: API, botToken: TOKEN, groupNo: GROUP, shortId: SHORT, content: atLimit });
+
+    expect(res.bytes).toBe(MAX_THREAD_MD_CONTENT_BYTES);
+    expect(calls()).toBe(1);
+  });
+
+  it('rejects content over the byte limit LOCALLY without calling the PUT client', async () => {
+    const cache = new ThreadMdCache();
+    const { fn, calls } = versioningUpdateFn();
+    const wb = new ThreadMdWriteback(cache, fn);
+    const tooBig = 'a'.repeat(MAX_THREAD_MD_CONTENT_BYTES + 1);
+
+    await expect(
+      wb.writeBack({ apiUrl: API, botToken: TOKEN, groupNo: GROUP, shortId: SHORT, content: tooBig }),
+    ).rejects.toBeInstanceOf(ThreadMdContentTooLargeError);
+
+    expect(calls()).toBe(0);
+    expect(cache.get(GROUP, SHORT)).toBeUndefined();
+  });
+
+  it('counts BYTES not characters on the limit (multi-byte UTF-8)', async () => {
+    const cache = new ThreadMdCache();
+    const { fn, calls } = versioningUpdateFn();
+    const wb = new ThreadMdWriteback(cache, fn);
+    const content = '✓'.repeat(3414); // 3 bytes each → 10242 bytes > limit
+    expect(content.length).toBeLessThan(MAX_THREAD_MD_CONTENT_BYTES);
+    expect(Buffer.byteLength(content, 'utf-8')).toBeGreaterThan(MAX_THREAD_MD_CONTENT_BYTES);
+
+    await expect(
+      wb.writeBack({ apiUrl: API, botToken: TOKEN, groupNo: GROUP, shortId: SHORT, content }),
+    ).rejects.toBeInstanceOf(ThreadMdContentTooLargeError);
+    expect(calls()).toBe(0);
+  });
+
+  it('serializes concurrent write-backs to the SAME thread (no overlap, no lost write)', async () => {
+    const cache = new ThreadMdCache();
+    let active = 0;
+    let maxActive = 0;
+    let version = 0;
+    const order: string[] = [];
+    const fn: UpdateThreadMdFn = async (p) => {
+      active++;
+      maxActive = Math.max(maxActive, active);
+      await delay(10);
+      order.push(p.content);
+      version++;
+      active--;
+      return { version };
+    };
+    const wb = new ThreadMdWriteback(cache, fn);
+
+    await Promise.all(
+      ['v1', 'v2', 'v3', 'v4', 'v5'].map((c) =>
+        wb.writeBack({ apiUrl: API, botToken: TOKEN, groupNo: GROUP, shortId: SHORT, content: c }),
+      ),
+    );
+
+    expect(maxActive).toBe(1);
+    expect(order).toEqual(['v1', 'v2', 'v3', 'v4', 'v5']);
+    expect(cache.get(GROUP, SHORT)).toEqual({ content: 'v5', version: 5, updated_at: null });
+  });
+
+  it('runs write-backs for DIFFERENT threads concurrently (incl. same shortId under different groups)', async () => {
+    const cache = new ThreadMdCache();
+    let active = 0;
+    let maxActive = 0;
+    let version = 0;
+    const fn: UpdateThreadMdFn = async () => {
+      active++;
+      maxActive = Math.max(maxActive, active);
+      await delay(10);
+      active--;
+      version++;
+      return { version };
+    };
+    const wb = new ThreadMdWriteback(cache, fn);
+
+    await Promise.all([
+      wb.writeBack({ apiUrl: API, botToken: TOKEN, groupNo: GROUP, shortId: SHORT, content: 'a' }),
+      wb.writeBack({ apiUrl: API, botToken: TOKEN, groupNo: GROUP, shortId: 'other', content: 'b' }),
+      // Same shortId but a DIFFERENT parent group — a distinct composite key.
+      wb.writeBack({ apiUrl: API, botToken: TOKEN, groupNo: 'grp002', shortId: SHORT, content: 'c' }),
+    ]);
+
+    expect(maxActive).toBe(3);
+  });
+
+  it('leaves the cache untouched and does not wedge the lock when a PUT fails', async () => {
+    const cache = new ThreadMdCache();
+    let shouldFail = true;
+    let version = 0;
+    const fn: UpdateThreadMdFn = async () => {
+      if (shouldFail) {
+        shouldFail = false;
+        throw new Error('Octo API PUT failed (500): boom');
+      }
+      version++;
+      return { version };
+    };
+    const wb = new ThreadMdWriteback(cache, fn);
+
+    await expect(
+      wb.writeBack({ apiUrl: API, botToken: TOKEN, groupNo: GROUP, shortId: SHORT, content: 'first' }),
+    ).rejects.toThrow(/PUT failed/);
+    expect(cache.get(GROUP, SHORT)).toBeUndefined();
+
+    const res = await wb.writeBack({ apiUrl: API, botToken: TOKEN, groupNo: GROUP, shortId: SHORT, content: 'second' });
+    expect(res.version).toBe(1);
+    expect(cache.get(GROUP, SHORT)).toEqual({ content: 'second', version: 1, updated_at: null });
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -139,6 +139,18 @@ export interface Config {
    * `serverMd` (which governs the group server-read path).
    */
   threadMd?: boolean;
+  /**
+   * P3-2: `event.type` literal(s) the server emits when a thread's THREAD.md
+   * changes (update or delete). On such an event the in-memory THREAD.md cache
+   * for that subarea (`groupNo::shortId`, located via the event's `short_id`) is
+   * invalidated so the next turn re-fetches the authoritative copy (never
+   * trusting the event payload — same anti-poisoning model as the group side).
+   * PROVISIONAL: the exact literal is not yet confirmed from a real captured
+   * event, so this is overridable here to calibrate without a code change.
+   * Defaults to `DEFAULT_THREAD_MD_EVENT_TYPES`. Only meaningful when `threadMd`
+   * is true.
+   */
+  threadMdEventTypes?: string[];
   sdk: {
     model?: string;
     /**
@@ -332,6 +344,7 @@ type PartialConfig = {
   serverMdEventTypes?: string[];
   mdWriteback?: boolean;
   threadMd?: boolean;
+  threadMdEventTypes?: string[];
   sdk?: Partial<Config['sdk']>;
   rateLimit?: Partial<Config['rateLimit']>;
   context?: Partial<Config['context']>;
@@ -428,6 +441,7 @@ function mergeConfig(base: Config, override: PartialConfig): Config {
     serverMdEventTypes: override.serverMdEventTypes ?? base.serverMdEventTypes,
     mdWriteback: override.mdWriteback ?? base.mdWriteback,
     threadMd: override.threadMd ?? base.threadMd,
+    threadMdEventTypes: override.threadMdEventTypes ?? base.threadMdEventTypes,
     sdk: {
       ...base.sdk,
       ...(override.sdk ?? {}),
@@ -665,6 +679,7 @@ export function resolveBotConfigs(config: Config): Config[] {
       serverMdEventTypes: perBotFile.serverMdEventTypes ?? config.serverMdEventTypes,
       mdWriteback: perBotFile.mdWriteback ?? config.mdWriteback,
       threadMd: perBotFile.threadMd ?? config.threadMd,
+      threadMdEventTypes: perBotFile.threadMdEventTypes ?? config.threadMdEventTypes,
       sdk: {
         ...config.sdk,
         ...(perBotFile.sdk ?? {}),

--- a/src/group-md-events.ts
+++ b/src/group-md-events.ts
@@ -28,8 +28,16 @@
 /**
  * Provisional `event.type` literals treated as a GROUP.md change. PROVISIONAL —
  * see the calibration note above. Overridable via `config.serverMdEventTypes`.
+ *
+ * Both an UPDATE and a DELETE of the server GROUP.md drive the same action —
+ * INVALIDATE the cached entry so the next turn re-fetches (an updated entry is
+ * re-read; a deleted one 404s and cleanly degrades to the local fallback), so
+ * `group_md_deleted` sits alongside `group_md_updated` here (P3-2 deleted tail).
  */
-export const DEFAULT_GROUP_MD_EVENT_TYPES: readonly string[] = ['group_md_updated'];
+export const DEFAULT_GROUP_MD_EVENT_TYPES: readonly string[] = [
+  'group_md_updated',
+  'group_md_deleted',
+];
 
 /** The `payload.event` shape (mirrors MessagePayload.event in octo/types.ts). */
 export interface GroupMdEventLike {
@@ -38,14 +46,53 @@ export interface GroupMdEventLike {
 }
 
 /**
- * True iff this event signals a GROUP.md change and should drive a cache
- * refresh. All other system events (group join/leave, etc.) return false and
- * are dropped unchanged by the router. `eventTypes` lets the operator override
- * the provisional literal(s) without a code change.
+ * True iff this event signals a GROUP.md change (update or delete) and should
+ * drive a cache refresh. All other system events (group join/leave, etc.) return
+ * false and are dropped unchanged by the router. `eventTypes` lets the operator
+ * override the provisional literal(s) without a code change.
  */
 export function isGroupMdUpdateEvent(
   event: GroupMdEventLike | undefined,
   eventTypes: readonly string[] = DEFAULT_GROUP_MD_EVENT_TYPES,
+): boolean {
+  if (!event || typeof event.type !== 'string' || event.type === '') return false;
+  return eventTypes.includes(event.type);
+}
+
+/**
+ * Provisional `event.type` literals treated as a THREAD.md change (P3-2). Same
+ * PROVISIONAL status as the group literals above — the exact wire literal is not
+ * yet confirmed from a captured event, so it is named after the design and is
+ * overridable via `config.threadMdEventTypes` without a code change. As on the
+ * group side, both update and delete map to the same invalidate action.
+ */
+export const DEFAULT_THREAD_MD_EVENT_TYPES: readonly string[] = [
+  'thread_md_updated',
+  'thread_md_deleted',
+];
+
+/**
+ * The `payload.event` shape for a THREAD.md change — like {@link GroupMdEventLike}
+ * but also carrying `short_id`, which locates the subarea whose composite-keyed
+ * (`groupNo::shortId`) cache entry to invalidate. `short_id` is already part of
+ * MessagePayload.event (octo/types.ts).
+ */
+export interface ThreadMdEventLike {
+  type?: string;
+  group_no?: string;
+  short_id?: string;
+}
+
+/**
+ * True iff this event signals a THREAD.md change (update or delete). The literal
+ * sets for group vs thread are DISJOINT (`group_md_*` vs `thread_md_*`), so a
+ * thread event never trips the group invalidation and vice versa — the two
+ * classifiers stay mutually exclusive, matching the read/write mutual-exclusion
+ * contract of #88 P3.
+ */
+export function isThreadMdUpdateEvent(
+  event: ThreadMdEventLike | undefined,
+  eventTypes: readonly string[] = DEFAULT_THREAD_MD_EVENT_TYPES,
 ): boolean {
   if (!event || typeof event.type !== 'string' || event.type === '') return false;
   return eventTypes.includes(event.type);

--- a/src/group-md-tool.ts
+++ b/src/group-md-tool.ts
@@ -20,15 +20,25 @@
 
 import { z } from 'zod';
 import { createSdkMcpServer, tool } from '@anthropic-ai/claude-agent-sdk';
-import { extractParentGroupNo } from './octo/channel-id.js';
+import {
+  extractParentGroupNo,
+  extractThreadShortId,
+  isThreadChannelId,
+} from './octo/channel-id.js';
 import {
   GroupMdContentTooLargeError,
   MAX_GROUP_MD_CONTENT_BYTES,
+  ThreadMdContentTooLargeError,
+  MAX_THREAD_MD_CONTENT_BYTES,
   type GroupMdWriteback,
+  type ThreadMdWriteback,
 } from './group-md-writeback.js';
 
 /** MCP server name; the tool surfaces as `mcp__group_md__update_group_md`. */
 export const GROUP_MD_TOOL_SERVER_NAME = 'group_md';
+
+/** MCP server name; the tool surfaces as `mcp__thread_md__update_thread_md`. */
+export const THREAD_MD_TOOL_SERVER_NAME = 'thread_md';
 
 /** Raw coords of the session invoking the tool — gates the call + targets the group. */
 export interface GroupMdSessionCoords {
@@ -41,6 +51,13 @@ export interface GroupMdSessionCoords {
 /** Shared deps the tool needs to perform a write-back. */
 export interface GroupMdToolDeps {
   writeback: GroupMdWriteback;
+  apiUrl: string;
+  botToken: string;
+}
+
+/** Shared deps the thread write-back tool needs. */
+export interface ThreadMdToolDeps {
+  writeback: ThreadMdWriteback;
   apiUrl: string;
   botToken: string;
 }
@@ -131,5 +148,108 @@ export function createGroupMdToolServer(
     name: GROUP_MD_TOOL_SERVER_NAME,
     version: '1.0.0',
     tools: buildGroupMdTools(deps, coords, ownerUid),
+  });
+}
+
+/**
+ * Build the THREAD.md tool DEFINITIONS for one agent turn (P3-2). The thread
+ * analogue of {@link buildGroupMdTools}: the tool surfaces as
+ * `mcp__thread_md__update_thread_md` and writes THIS thread's OWN THREAD.md
+ * (PUT /v1/bot/groups/{groupNo}/threads/{shortId}/md), NEVER the parent group's
+ * GROUP.md — the thread/group split is mutually exclusive (#88 P3).
+ * index.ts only ever wires the group tool OR this thread tool for a turn (chosen
+ * by channelId shape), so the two never co-exist in one session.
+ *
+ * `coords.channelId` MUST be a thread composite (`<groupNo>____<shortId>`); the
+ * caller (index.ts) guarantees this by routing on `isThreadChannelId`. The
+ * owner-gate is identical to the group tool (bot-owner-only, independent of the
+ * token's server-side thread permission).
+ */
+export function buildThreadMdTools(
+  deps: ThreadMdToolDeps,
+  coords: GroupMdSessionCoords,
+  ownerUid: string,
+) {
+  const isOwner = coords.fromUid === ownerUid && ownerUid !== '';
+
+  return [
+    tool(
+      'update_thread_md',
+      'Persist new THREAD.md content for THIS thread (subarea) on the server (it ' +
+        "becomes the thread's trusted operator instructions on the next turn). " +
+        '`content` is the FULL replacement document, not a diff. Hard limit: 10240 ' +
+        'bytes UTF-8. Only the bot owner may call this; a non-owner request is ' +
+        'rejected. This writes the thread\'s OWN THREAD.md, never the parent ' +
+        "group's GROUP.md. Last write wins server-side — compose the complete " +
+        'updated document, do not assume a concurrent edit merged.',
+      {
+        content: z
+          .string()
+          .describe('Full replacement THREAD.md document (≤10240 bytes UTF-8).'),
+      },
+      async (args) => {
+        try {
+          if (!isOwner) {
+            return errResult('Only the bot owner can update THREAD.md.');
+          }
+          if (!isThreadChannelId(coords.channelId)) {
+            return errResult('This channel is not a thread — THREAD.md is only writable from a thread.');
+          }
+          const groupNo = extractParentGroupNo(coords.channelId);
+          const shortId = extractThreadShortId(coords.channelId);
+          if (!groupNo || !shortId) {
+            return errResult('Could not resolve a thread (groupNo/shortId) from this channel.');
+          }
+          // Friendly over-limit message before the coordinator throws (it re-checks
+          // as the authoritative boundary; this is just for UX).
+          const bytes = Buffer.byteLength(args.content, 'utf-8');
+          if (bytes > MAX_THREAD_MD_CONTENT_BYTES) {
+            return errResult(
+              `content is ${bytes} bytes, over the ${MAX_THREAD_MD_CONTENT_BYTES}-byte ` +
+                `UTF-8 limit — trim it before writing (the server would reject it).`,
+            );
+          }
+          const res = await deps.writeback.writeBack({
+            apiUrl: deps.apiUrl,
+            botToken: deps.botToken,
+            groupNo,
+            shortId,
+            content: args.content,
+          });
+          return jsonResult({
+            updated: {
+              groupNo: res.groupNo,
+              shortId: res.shortId,
+              version: res.version,
+              bytes: res.bytes,
+            },
+          });
+        } catch (err) {
+          if (err instanceof ThreadMdContentTooLargeError) {
+            return errResult(
+              `content is ${err.bytes} bytes, over the ${MAX_THREAD_MD_CONTENT_BYTES}-byte UTF-8 limit.`,
+            );
+          }
+          return errResult(err instanceof Error ? err.message : String(err));
+        }
+      },
+    ),
+  ];
+}
+
+/**
+ * Build the THREAD.md write-back MCP server for one agent turn. `coords` targets
+ * the thread (its composite channelId) + supplies the caller uid; `ownerUid` is
+ * the owner gate.
+ */
+export function createThreadMdToolServer(
+  deps: ThreadMdToolDeps,
+  coords: GroupMdSessionCoords,
+  ownerUid: string,
+) {
+  return createSdkMcpServer({
+    name: THREAD_MD_TOOL_SERVER_NAME,
+    version: '1.0.0',
+    tools: buildThreadMdTools(deps, coords, ownerUid),
   });
 }

--- a/src/group-md-writeback.ts
+++ b/src/group-md-writeback.ts
@@ -28,8 +28,8 @@
  * durable-trust surface.
  */
 
-import { updateGroupMd } from './octo/api.js';
-import type { GroupMdCache } from './group-md-cache.js';
+import { updateGroupMd, updateThreadMd } from './octo/api.js';
+import type { GroupMdCache, ThreadMdCache } from './group-md-cache.js';
 
 /**
  * Hard UTF-8 byte ceiling for GROUP.md content, per the XIN-201 measured
@@ -37,6 +37,15 @@ import type { GroupMdCache } from './group-md-cache.js';
  * answer 400 err.server.bot_api.content_too_large).
  */
 export const MAX_GROUP_MD_CONTENT_BYTES = 10240;
+
+/**
+ * Hard UTF-8 byte ceiling for THREAD.md content. The thread md endpoint shares
+ * the group md limit (P3-2 contract check: the official Octo web client edits
+ * both group and thread md through the SAME editor, whose `MAX_BYTES` is 10240),
+ * so this is an alias of {@link MAX_GROUP_MD_CONTENT_BYTES} rather than a second
+ * magic number — if the server limit ever diverges, the two can split here.
+ */
+export const MAX_THREAD_MD_CONTENT_BYTES = MAX_GROUP_MD_CONTENT_BYTES;
 
 /** Thrown when content exceeds {@link MAX_GROUP_MD_CONTENT_BYTES}. */
 export class GroupMdContentTooLargeError extends Error {
@@ -139,6 +148,130 @@ export class GroupMdWriteback {
         updated_at: null,
       });
       return { groupNo, version, bytes };
+    });
+  }
+}
+
+/** The `updateThreadMd` client signature, injectable for testing. */
+export type UpdateThreadMdFn = typeof updateThreadMd;
+
+/** Thrown when THREAD.md content exceeds {@link MAX_THREAD_MD_CONTENT_BYTES}. */
+export class ThreadMdContentTooLargeError extends Error {
+  constructor(public readonly bytes: number) {
+    super(
+      `THREAD.md content is ${bytes} bytes, over the ${MAX_THREAD_MD_CONTENT_BYTES}-byte UTF-8 limit`,
+    );
+    this.name = 'ThreadMdContentTooLargeError';
+  }
+}
+
+/** Outcome of a successful THREAD.md write-back. */
+export interface ThreadMdWriteResult {
+  groupNo: string;
+  shortId: string;
+  /** Server-assigned version after the PUT. */
+  version: number;
+  /** UTF-8 byte length of the content that was written. */
+  bytes: number;
+}
+
+export interface ThreadMdWriteParams {
+  apiUrl: string;
+  botToken: string;
+  groupNo: string;
+  shortId: string;
+  content: string;
+  signal?: AbortSignal;
+}
+
+/**
+ * Thread analogue of {@link GroupMdWriteback} (P3-2): persists an agent-authored
+ * THREAD.md back to the server (PUT /v1/bot/groups/{groupNo}/threads/{shortId}/md
+ * via `updateThreadMd`), then refreshes the in-memory {@link ThreadMdCache} so
+ * the next resolve does not TTL-refetch a stale copy.
+ *
+ * Carries over every P2-C safety property, adapted to the thread key:
+ *
+ *   1. Same HARD ≤10240-byte (UTF-8) limit ({@link MAX_THREAD_MD_CONTENT_BYTES},
+ *      confirmed to equal the group limit — see that constant). Rejected locally
+ *      BEFORE the PUT so an oversized body never reaches the server.
+ *
+ *   2. The thread PUT, like the group PUT, does NOT compare-and-swap (body is
+ *      just `{ content }`, reply is `{ version }`). All write-backs for the same
+ *      thread are serialized through a per-`groupNo::shortId` promise-chain lock
+ *      so this gateway never races itself. Cross-source last-write-wins remains
+ *      possible by design, identical to the group caveat.
+ *
+ * Keyed by the COMPOSITE `groupNo::shortId` — the SAME key the thread cache and
+ * the P3-1 read side use — so a thread's write lock and cache refresh can never
+ * be confused with its parent group's (which the group coordinator locks by the
+ * bare groupNo). `::` is outside the safe-id charset, so the two key spaces are
+ * disjoint. Owner-gating lives in the MCP tool layer (group-md-tool.ts), not
+ * here. Never persists to disk — the cache it updates is the same memory-only
+ * cache the resolver reads.
+ */
+export class ThreadMdWriteback {
+  /** Tail of the in-flight write chain per composite key (serializes same-thread writes). */
+  private readonly tails = new Map<string, Promise<unknown>>();
+
+  constructor(
+    private readonly cache: ThreadMdCache,
+    /** Injectable PUT client (defaults to the real octo client). */
+    private readonly updateFn: UpdateThreadMdFn = updateThreadMd,
+  ) {}
+
+  /** Composite lock key; mirrors ThreadMdCache's `groupNo::shortId`. */
+  private lockKey(groupNo: string, shortId: string): string {
+    return `${groupNo}::${shortId}`;
+  }
+
+  /**
+   * Run `fn` after every previously-queued op for `key` has settled, so bodies
+   * for the same key never overlap. Different keys run independently. `fn`'s
+   * rejection is surfaced to its own caller; the chain tail swallows it so a
+   * failed write does not wedge later writes. Identical policy to
+   * {@link GroupMdWriteback}.
+   */
+  private withLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
+    const prev = this.tails.get(key) ?? Promise.resolve();
+    const result = prev.then(fn, fn); // run regardless of prior success/failure
+    const tail = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    this.tails.set(key, tail);
+    tail.then(() => {
+      if (this.tails.get(key) === tail) this.tails.delete(key);
+    });
+    return result;
+  }
+
+  /**
+   * Persist `content` as the thread's THREAD.md and refresh the thread cache.
+   *
+   * Rejects with {@link ThreadMdContentTooLargeError} (before any server call)
+   * when content exceeds the UTF-8 byte limit; propagates the client error when
+   * the PUT itself fails (cache is left untouched in that case).
+   */
+  async writeBack(params: ThreadMdWriteParams): Promise<ThreadMdWriteResult> {
+    const { apiUrl, botToken, groupNo, shortId, content, signal } = params;
+    const bytes = Buffer.byteLength(content, 'utf-8');
+    if (bytes > MAX_THREAD_MD_CONTENT_BYTES) {
+      // Reject locally — do NOT hit the server (it would answer 400).
+      throw new ThreadMdContentTooLargeError(bytes);
+    }
+    return this.withLock(this.lockKey(groupNo, shortId), async () => {
+      const { version } = await this.updateFn({ apiUrl, botToken, groupNo, shortId, content, signal });
+      // Refresh the just-persisted content/version into the in-memory thread
+      // cache (composite-keyed) so the next resolveGroupInstructions thread
+      // branch serves what we wrote instead of re-fetching or serving a stale
+      // copy. updated_at is null because the PUT response carries only { version }.
+      this.cache.set(groupNo, shortId, {
+        content,
+        version: typeof version === 'number' ? version : 0,
+        updated_at: null,
+      });
+      return { groupNo, shortId, version, bytes };
     });
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,11 +30,18 @@ import { downloadInboundImage, MAX_IMAGES_PER_MESSAGE } from './media-inbound.js
 import { handleCommand } from './commands.js';
 import { resolveGroupInstructions } from './group-md.js';
 import { GroupMdCache, ThreadMdCache, DEFAULT_GROUP_MD_TTL_MS } from './group-md-cache.js';
-import { GroupMdWriteback } from './group-md-writeback.js';
+import { GroupMdWriteback, ThreadMdWriteback } from './group-md-writeback.js';
 import { CronStore } from './cron-store.js';
 import { CronScheduler } from './cron-scheduler.js';
 import { createCronToolServer, CRON_TOOL_SERVER_NAME, type CronSessionCoords } from './cron-tool.js';
-import { createGroupMdToolServer, GROUP_MD_TOOL_SERVER_NAME, type GroupMdSessionCoords } from './group-md-tool.js';
+import {
+  createGroupMdToolServer,
+  GROUP_MD_TOOL_SERVER_NAME,
+  createThreadMdToolServer,
+  THREAD_MD_TOOL_SERVER_NAME,
+  type GroupMdSessionCoords,
+} from './group-md-tool.js';
+import { isThreadChannelId } from './octo/channel-id.js';
 import { buildInlinedFileBody, truncateUtf8ByBytes, assembleUserMessage, MAX_USER_LLM_BYTES } from './file-inline-wrap.js';
 import { join } from 'node:path';
 import { mkdirSync, realpathSync } from 'node:fs';
@@ -239,6 +246,14 @@ async function startBot(config: ReturnType<typeof loadConfig>, multi: boolean): 
     // is registered (config.mdWriteback). ---
     const groupMdWriteback = new GroupMdWriteback(groupMdCache);
 
+    // --- P3-2: THREAD.md write-back coordinator. Thread analogue of
+    // groupMdWriteback, shared across turns so its per-`groupNo::shortId` write
+    // lock serializes concurrent turns writing the same thread. Updates the SAME
+    // in-memory threadMdCache above on a successful PUT (no disk surface). Cheap
+    // to construct unconditionally; only exercised when the thread write-back
+    // tool is registered (config.mdWriteback on a thread channel). ---
+    const threadMdWriteback = new ThreadMdWriteback(threadMdCache);
+
     // --- #115: cron (opt-in). ---
     if (config.sdk.cron && config.botId) {
       cronStore = new CronStore(join(config.baseDir, config.botId, 'cron.json'));
@@ -291,10 +306,11 @@ async function startBot(config: ReturnType<typeof loadConfig>, multi: boolean): 
     }
 
     // --- Session router ---
-    // P2-B: the router holds the GROUP.md cache so a server GROUP.md change
-    // event invalidates the affected group's entry (re-fetched authoritatively
-    // next turn — never trusting the event payload). No-op when serverMd is off.
-    const router = new SessionRouter(config, gateway.botId, gateway.ownerUid, groupMdCache);
+    // P2-B / P3-2: the router holds both md caches so a server GROUP.md or
+    // THREAD.md change event invalidates the affected entry (re-fetched
+    // authoritatively next turn — never trusting the event payload). No-op when
+    // the corresponding flag (serverMd / threadMd) is off.
+    const router = new SessionRouter(config, gateway.botId, gateway.ownerUid, groupMdCache, threadMdCache);
 
     // --- Active handler tracking (Q6: in-flight drain on shutdown) ---
     const activeHandlers = new Set<Promise<void>>();
@@ -309,7 +325,7 @@ async function startBot(config: ReturnType<typeof loadConfig>, multi: boolean): 
       // these on the WS path; guard here too for safety (otherwise a bot's own
       // group message could be cached into group context as un-processed chatter).
       if (msg.from_uid === gateway.botId) return;
-      const p = handleMessage(msg, config, store, router, groupContext, streamRelay, gateway.botId, cronStore, groupMdCache, groupMdWriteback, threadMdCache)
+      const p = handleMessage(msg, config, store, router, groupContext, streamRelay, gateway.botId, cronStore, groupMdCache, groupMdWriteback, threadMdCache, threadMdWriteback)
         .catch((err) => {
           console.error(`[cc-channel-octo] ${label}Unhandled message handler error:`, err instanceof Error ? err.message : err);
         })
@@ -330,7 +346,7 @@ async function startBot(config: ReturnType<typeof loadConfig>, multi: boolean): 
         cronStore,
         onFire: (msg: BotMessage): Promise<void> => {
           if (gateway.draining) return Promise.resolve();
-          const p = handleMessage(msg, config, store, router, groupContext, streamRelay, gateway.botId, cronStore, groupMdCache, groupMdWriteback, threadMdCache)
+          const p = handleMessage(msg, config, store, router, groupContext, streamRelay, gateway.botId, cronStore, groupMdCache, groupMdWriteback, threadMdCache, threadMdWriteback)
             .finally(() => { activeHandlers.delete(p); });
           activeHandlers.add(p);
           return p;
@@ -393,6 +409,7 @@ export async function handleMessage(
   groupMdCache?: GroupMdCache,
   groupMdWriteback?: GroupMdWriteback,
   threadMdCache?: ThreadMdCache,
+  threadMdWriteback?: ThreadMdWriteback,
 ): Promise<void> {
   const channelId = msg.channel_id ?? '';
   const channelType = msg.channel_type ?? ChannelType.DM;
@@ -899,27 +916,47 @@ export async function handleMessage(
         };
       }
 
-      // P2-C: when GROUP.md write-back is on, inject the write-back MCP tool
-      // bound to THIS message's channel coords (so the write targets the channel's
-      // parent group) and gated to the bot owner uid. Only for group channels —
-      // a DM has no shared GROUP.md. Per-turn server (coords differ per message);
-      // it borrows the shared groupMdWriteback so the per-groupNo write lock and
-      // the cache it refreshes are process-wide, not per-turn.
-      if (config.mdWriteback && groupMdWriteback && isGroup) {
+      // P2-C / P3-2: when md write-back is on, inject the write-back MCP tool
+      // bound to THIS message's channel coords and gated to the bot owner uid.
+      // Only for group-like channels — a DM has no shared md. The tool is chosen
+      // by channel SHAPE and the two are MUTUALLY EXCLUSIVE (#88 P3 redline):
+      //   - a THREAD (CommunityTopic composite `<groupNo>____<shortId>`) gets the
+      //     thread tool, which writes the thread's OWN THREAD.md
+      //     (PUT /threads/{shortId}/md) — never the parent group's GROUP.md. This
+      //     is the XIN-230 follow-up: the write side now matches the P3-1 read
+      //     side instead of collapsing a thread to its parent groupNo.
+      //   - a plain GROUP gets the GROUP.md tool, unchanged (P2-C).
+      // Each borrows its shared writeback coordinator so the per-key write lock
+      // and the cache it refreshes are process-wide, not per-turn.
+      if (config.mdWriteback && isGroup) {
         const coords: GroupMdSessionCoords = {
           channelId,
           fromUid: msg.from_uid,
           fromName: msg.from_name,
         };
-        const groupMdServer = createGroupMdToolServer(
-          { writeback: groupMdWriteback, apiUrl: config.apiUrl, botToken: config.botToken },
-          coords,
-          router.getOwnerUid(),
-        );
-        sessionOpts = {
-          ...(sessionOpts ?? {}),
-          mcpServers: { ...(sessionOpts?.mcpServers ?? {}), [GROUP_MD_TOOL_SERVER_NAME]: groupMdServer },
-        };
+        if (isThreadChannelId(channelId)) {
+          if (threadMdWriteback) {
+            const threadMdServer = createThreadMdToolServer(
+              { writeback: threadMdWriteback, apiUrl: config.apiUrl, botToken: config.botToken },
+              coords,
+              router.getOwnerUid(),
+            );
+            sessionOpts = {
+              ...(sessionOpts ?? {}),
+              mcpServers: { ...(sessionOpts?.mcpServers ?? {}), [THREAD_MD_TOOL_SERVER_NAME]: threadMdServer },
+            };
+          }
+        } else if (groupMdWriteback) {
+          const groupMdServer = createGroupMdToolServer(
+            { writeback: groupMdWriteback, apiUrl: config.apiUrl, botToken: config.botToken },
+            coords,
+            router.getOwnerUid(),
+          );
+          sessionOpts = {
+            ...(sessionOpts ?? {}),
+            mcpServers: { ...(sessionOpts?.mcpServers ?? {}), [GROUP_MD_TOOL_SERVER_NAME]: groupMdServer },
+          };
+        }
       }
 
       const rawChunks = queryAgent(userContentForLLM, config, sessionCtx, onToolUse, sessionOpts);

--- a/src/octo/api.ts
+++ b/src/octo/api.ts
@@ -809,3 +809,48 @@ export async function updateGroupMd(params: {
   if (!text) return { version: 0 };
   return parseOctoJson<{ version: number }>(text);
 }
+
+/**
+ * Update a thread's server-side THREAD.md.
+ * PUT /v1/bot/groups/{groupNo}/threads/{shortId}/md, body `{ content }` → `{ version }`.
+ *
+ * Symmetric to {@link updateGroupMd} (group md = `.../groups/{groupNo}/md`;
+ * thread md = `.../groups/{groupNo}/threads/{shortId}/md`) and to the already-
+ * wired {@link getThreadMd} GET. Path / body / response were confirmed against
+ * the official Octo web client's data source (GET/PUT/DELETE
+ * `groups/{groupNo}/threads/{shortId}/md`, body `{ content }`, reply
+ * `{ version }`) — the same trio the group md endpoint exposes. Like the group
+ * PUT there is NO compare-and-swap: the body carries only `content`, so the
+ * server is last-write-wins (the write-back coordinator serializes same-thread
+ * writes to stop this gateway racing itself — see ThreadMdWriteback).
+ *
+ * Mirrors postJson's timeout, Bearer auth and error-message format.
+ */
+export async function updateThreadMd(params: {
+  apiUrl: string;
+  botToken: string;
+  groupNo: string;
+  shortId: string;
+  content: string;
+  signal?: AbortSignal;
+}): Promise<{ version: number }> {
+  const path = `/v1/bot/groups/${encodeURIComponent(params.groupNo)}/threads/${encodeURIComponent(params.shortId)}/md`;
+  const url = `${params.apiUrl.replace(/\/+$/, "")}${path}`;
+  const effectiveSignal = params.signal ?? AbortSignal.timeout(DEFAULT_TIMEOUT_MS);
+  const resp = await fetch(url, {
+    method: "PUT",
+    headers: {
+      ...DEFAULT_HEADERS,
+      Authorization: `Bearer ${params.botToken}`,
+    },
+    body: JSON.stringify({ content: params.content }),
+    signal: effectiveSignal,
+  });
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => "");
+    throw new Error(`Octo API ${path} failed (${resp.status}): ${text || resp.statusText}`);
+  }
+  const text = await resp.text();
+  if (!text) return { version: 0 };
+  return parseOctoJson<{ version: number }>(text);
+}

--- a/src/session-router.ts
+++ b/src/session-router.ts
@@ -7,9 +7,9 @@ import type { BotMessage, MentionEntity } from './octo/types.js';
 import { ChannelType, MessageType } from './octo/types.js';
 import { sendMessage } from './octo/api.js';
 import { isAuthenticCronFire } from './cron-fire-marker.js';
-import { extractParentGroupNo } from './octo/channel-id.js';
-import type { GroupMdCache } from './group-md-cache.js';
-import { isGroupMdUpdateEvent } from './group-md-events.js';
+import { extractParentGroupNo, extractThreadShortId } from './octo/channel-id.js';
+import type { GroupMdCache, ThreadMdCache } from './group-md-cache.js';
+import { isGroupMdUpdateEvent, isThreadMdUpdateEvent } from './group-md-events.js';
 
 export interface RouteResult {
   sessionKey: string;
@@ -75,12 +75,27 @@ export class SessionRouter {
    */
   private readonly groupMdCache?: GroupMdCache;
 
-  constructor(config: Config, robotId: string, ownerUid = '', groupMdCache?: GroupMdCache) {
+  /**
+   * P3-2: in-memory server THREAD.md cache (P3-1's composite-keyed cache). Held
+   * so a THREAD.md change event can invalidate the affected subarea's entry,
+   * forcing the next turn to re-fetch the authoritative copy. Optional — omitted
+   * (or with `threadMd` off) the thread event path is a harmless no-op.
+   */
+  private readonly threadMdCache?: ThreadMdCache;
+
+  constructor(
+    config: Config,
+    robotId: string,
+    ownerUid = '',
+    groupMdCache?: GroupMdCache,
+    threadMdCache?: ThreadMdCache,
+  ) {
     this.config = config;
     this.robotId = robotId;
     this.ownerUid = ownerUid;
     this.knownBotUids.add(robotId);
     this.groupMdCache = groupMdCache;
+    this.threadMdCache = threadMdCache;
   }
 
   /** G14: register another known bot uid (future multi-bot support). */
@@ -392,6 +407,55 @@ export class SessionRouter {
     }
   }
 
+  /**
+   * P3-2: thread analogue of {@link handleGroupMdEvent}. On a THREAD.md change
+   * event (update or delete) invalidate that subarea's composite-keyed
+   * (`groupNo::shortId`) cache entry, so the next turn re-fetches the
+   * authoritative copy over the bot token — never trusting the event payload as
+   * the new content (identical anti-poisoning rationale to the group side; see
+   * group-md-events.ts).
+   *
+   * Gated on `threadMd` (the flag that governs the thread server-read path): with
+   * it off the thread cache is never populated, so there is nothing to
+   * invalidate. Group and thread event literals are disjoint, so this and
+   * handleGroupMdEvent never both fire for one event.
+   *
+   * A thread is identified by the event's `group_no` + `short_id`. Both come
+   * from the untrusted event, but invalidation is non-destructive — the worst a
+   * forged thread event can do is force a redundant authenticated re-fetch of the
+   * real THREAD.md, never inject content. When the event omits `short_id` there
+   * is no subarea to key, so we fall back to invalidating nothing rather than
+   * guessing (a thread event MUST carry short_id to be actionable).
+   */
+  private handleThreadMdEvent(msg: BotMessage): void {
+    if (!this.config.threadMd || !this.threadMdCache) return;
+    const event = msg.payload.event;
+    if (!isThreadMdUpdateEvent(event, this.config.threadMdEventTypes)) return;
+
+    let groupNo = event?.group_no ?? '';
+    // The shortId only ever comes from the event body: these events are
+    // delivered on a system/DM channel (a thread event on the thread's own
+    // channel dies at the mention gate, never reaching here — XIN-173), so the
+    // arriving channel_id is the sender, not the thread. Fall back to the
+    // channel only for groupNo (never the shortId) when the event omits it AND
+    // it happened to arrive on a thread channel.
+    let shortId = event?.short_id ?? '';
+    if (this.isGroupLike(msg.channel_type)) {
+      const chan = msg.channel_id ?? '';
+      if (groupNo === '') groupNo = extractParentGroupNo(chan);
+      if (shortId === '') shortId = extractThreadShortId(chan) ?? '';
+    }
+    if (groupNo === '' || shortId === '') return;
+
+    // invalidate() is itself total (validates both ids, never throws); the guard
+    // here keeps a future non-total cache from breaking the drop path.
+    try {
+      this.threadMdCache.invalidate(groupNo, shortId);
+    } catch {
+      /* best-effort: a refresh hiccup must never block dropping the event */
+    }
+  }
+
   private async processMessage(msg: BotMessage, key: string): Promise<RouteResult | null> {
     // Skip messages from self.
     if (msg.from_uid === this.robotId) return null;
@@ -451,14 +515,17 @@ export class SessionRouter {
       }
     }
 
-    // System events (group join/leave, GROUP.md change, etc.) never produce a
-    // user-facing reply, so they always route to `null`. P2-B: before dropping,
-    // a GROUP.md change event is dispatched to invalidate that group's cached
-    // server GROUP.md (forcing the next turn to re-fetch the authoritative copy);
-    // every other system event (join/leave/...) is dropped unchanged, exactly as
-    // before — non-md events must NOT be mistaken for an md event.
+    // System events (group join/leave, GROUP.md / THREAD.md change, etc.) never
+    // produce a user-facing reply, so they always route to `null`. P2-B/P3-2:
+    // before dropping, a GROUP.md or THREAD.md change event is dispatched to
+    // invalidate the affected cache entry (forcing the next turn to re-fetch the
+    // authoritative copy); every other system event (join/leave/...) is dropped
+    // unchanged. The two md handlers key on disjoint event-type literals, so a
+    // group event never invalidates a thread entry and vice versa, and neither
+    // is mistaken for an unrelated system event.
     if (msg.payload.event) {
       this.handleGroupMdEvent(msg);
+      this.handleThreadMdEvent(msg);
       return null;
     }
 


### PR DESCRIPTION
## Summary

This is the P3-2 close-out block for #88, building on the already-merged P3-1 inject work (#176).

- **P3-1 (#176, merged):** injects a thread's own `THREAD.md` into the session context, never leaking the parent `GROUP.md`.
- **P3-2 (this PR):** the write-back half of the feature — an owner-gated MCP tool that writes a thread's own `THREAD.md`, plus cache invalidation on `thread`/`deleted` md events so stale thread markdown is dropped.

This branch was rebased onto the current `Mininglamp-OSS:main` (which already contains P3-1 via #176), so the diff here is strictly the P3-2 write-back changes — no P3-1 content is duplicated.

## Changes

- `group-md-writeback.ts` / `group-md-tool.ts`: extend the owner-gated write-back path to a thread's own `THREAD.md`.
- `group-md-events.ts`: invalidate cached thread markdown on `thread` and `deleted` md events.
- `session-router.ts` / `index.ts` / `octo/api.ts` / `config.ts`: wiring for thread-scoped write-back and event handling.
- Tests: new `thread-md-writeback.test.ts`, `thread-md-tool.test.ts`, plus extensions to the group-md and session-router suites.

## Verification

Full suite green locally on the rebased branch: type-check clean (`tsc --noEmit`), `vitest run` → 1275 passed / 66 files. Behavior verified in a controlled environment:

- inject: a thread receives only its own `THREAD.md`, never the parent `GROUP.md` — PASS
- owner-gated write-back: only the thread owner can write the thread's `THREAD.md` — PASS
- no cross-contamination: writing a thread's `THREAD.md` does not touch the parent `GROUP.md` — PASS

Stacked on P3-1 (#176), which is now merged into `main`.

Closes #88
