### PR TITLE
fix(session-router): cancel timed-out agent turns

### DIFF
--- a/src/__tests__/agent-bridge-query.test.ts
+++ b/src/__tests__/agent-bridge-query.test.ts
@@ -448,6 +448,19 @@ describe('queryAgent', () => {
     expect(mockQuery.mock.calls[0][0].options.settingSources).toEqual(['project']);
   });
 
+  it('forwards the dispatch AbortController to the SDK', async () => {
+    mockQuery.mockReturnValue(createMockStream([
+      { type: 'assistant', message: { content: [{ type: 'text', text: 'hi' }] } },
+    ]));
+    const abortController = new AbortController();
+
+    for await (const _ of queryAgent('t', makeConfig(), undefined, undefined, { abortController })) {
+      void _;
+    }
+
+    expect(mockQuery.mock.calls[0][0].options.abortController).toBe(abortController);
+  });
+
   it('reports the SDK session_id once via onSessionId', async () => {
     mockQuery.mockReturnValue(createMockStream([
       { type: 'assistant', session_id: 'sid-xyz', message: { content: [{ type: 'text', text: 'a' }] } },

--- a/src/__tests__/api-timeout.test.ts
+++ b/src/__tests__/api-timeout.test.ts
@@ -6,7 +6,14 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { getGroupMembers, postJson } from "../octo/api.js";
+import {
+  getGroupMembers,
+  getUploadCredentials,
+  leaveThread,
+  postJson,
+  updateGroupMd,
+  updateThreadMd,
+} from "../octo/api.js";
 
 // Mock the global fetch before any postJson calls.
 const mockFetch = vi.fn();
@@ -186,6 +193,72 @@ describe("GET request cancellation", () => {
       groupNo: "group-1",
       signal: controller.signal,
     });
+
+    const options = mockFetch.mock.calls[0][1] as RequestInit;
+    const effectiveSignal = options.signal as AbortSignal;
+    expect(effectiveSignal).not.toBe(controller.signal);
+    expect(effectiveSignal.aborted).toBe(false);
+
+    controller.abort(new Error("dispatch timed out"));
+    expect(effectiveSignal.aborted).toBe(true);
+  });
+});
+
+describe("direct API request cancellation", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        bucket: "bucket",
+        region: "region",
+        key: "key",
+        credentials: {
+          tmpSecretId: "id",
+          tmpSecretKey: "key",
+          sessionToken: "token",
+        },
+        startTime: 1,
+        expiredTime: 2,
+      }),
+      text: () => Promise.resolve('{"version": 1}'),
+    });
+  });
+
+  const requests: Array<[string, (signal: AbortSignal) => Promise<unknown>]> = [
+    ["getUploadCredentials", (signal) => getUploadCredentials({
+      apiUrl: "https://api.example.com",
+      botToken: "test-token",
+      filename: "file.txt",
+      signal,
+    })],
+    ["leaveThread", (signal) => leaveThread({
+      apiUrl: "https://api.example.com",
+      botToken: "test-token",
+      groupNo: "group-1",
+      shortId: "thread-1",
+      signal,
+    })],
+    ["updateGroupMd", (signal) => updateGroupMd({
+      apiUrl: "https://api.example.com",
+      botToken: "test-token",
+      groupNo: "group-1",
+      content: "rules",
+      signal,
+    })],
+    ["updateThreadMd", (signal) => updateThreadMd({
+      apiUrl: "https://api.example.com",
+      botToken: "test-token",
+      groupNo: "group-1",
+      shortId: "thread-1",
+      content: "rules",
+      signal,
+    })],
+  ];
+
+  it.each(requests)("%s combines caller cancellation with the default timeout", async (_name, request) => {
+    const controller = new AbortController();
+    await request(controller.signal);
 
     const options = mockFetch.mock.calls[0][1] as RequestInit;
     const effectiveSignal = options.signal as AbortSignal;

--- a/src/__tests__/api-timeout.test.ts
+++ b/src/__tests__/api-timeout.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { postJson } from "../octo/api.js";
+import { getGroupMembers, postJson } from "../octo/api.js";
 
 // Mock the global fetch before any postJson calls.
 const mockFetch = vi.fn();
@@ -165,5 +165,34 @@ describe("postJson default timeout", () => {
     expect(result).toBeDefined();
     expect(result!.message_id).toBe("123456789012345678");
     expect(result!.data).toBe("ok");
+  });
+});
+
+describe("GET request cancellation", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it("combines caller cancellation with the default timeout", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve('{"members": []}'),
+    });
+
+    const controller = new AbortController();
+    await getGroupMembers({
+      apiUrl: "https://api.example.com",
+      botToken: "test-token",
+      groupNo: "group-1",
+      signal: controller.signal,
+    });
+
+    const options = mockFetch.mock.calls[0][1] as RequestInit;
+    const effectiveSignal = options.signal as AbortSignal;
+    expect(effectiveSignal).not.toBe(controller.signal);
+    expect(effectiveSignal.aborted).toBe(false);
+
+    controller.abort(new Error("dispatch timed out"));
+    expect(effectiveSignal.aborted).toBe(true);
   });
 });

--- a/src/__tests__/api-timeout.test.ts
+++ b/src/__tests__/api-timeout.test.ts
@@ -2,7 +2,7 @@
  * Tests for postJson default timeout behavior (Q2 fix).
  *
  * Verifies that postJson applies a 30s default timeout when no signal is provided,
- * and respects caller-provided signals when explicitly passed.
+ * and combines it with caller-provided cancellation signals.
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -35,7 +35,7 @@ describe("postJson default timeout", () => {
     expect((options.signal as AbortSignal).aborted).toBe(false);
   });
 
-  it("uses caller-provided signal when explicitly passed", async () => {
+  it("combines caller cancellation with the default timeout", async () => {
     mockFetch.mockResolvedValue({
       ok: true,
       text: () => Promise.resolve('{"result": "ok"}'),
@@ -52,7 +52,12 @@ describe("postJson default timeout", () => {
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
     const options = mockFetch.mock.calls[0][1] as RequestInit;
-    expect(options.signal).toBe(controller.signal);
+    const effectiveSignal = options.signal as AbortSignal;
+    expect(effectiveSignal).not.toBe(controller.signal);
+    expect(effectiveSignal.aborted).toBe(false);
+
+    controller.abort(new Error("dispatch timed out"));
+    expect(effectiveSignal.aborted).toBe(true);
   });
 
   it("rejects with abort error when timeout fires", async () => {

--- a/src/__tests__/e2e.test.ts
+++ b/src/__tests__/e2e.test.ts
@@ -72,6 +72,7 @@ import { handleMessage } from '../index.js';
 import {
   sendMessage,
   sendReadReceipt,
+  getGroupMembers,
   getChannelMessages,
 } from '../octo/api.js';
 import { ChannelType, MessageType } from '../octo/types.js';
@@ -489,6 +490,85 @@ describe('E2E smoke tests', () => {
     const history = store.buildHistoryPrefix(sessionKey, 40);
     expect(history).toContain('[user TestUser]: What is this code?');
     expect(history).toContain('[assistant bot-001]: Hello from Claude');
+  });
+
+  it('dispatch timeout prevents delayed roster refresh from mutating group context', async () => {
+    const channelId = 'group-cancelled-roster';
+    const timeoutConfig = makeConfig({ dispatchTimeoutMs: 10 });
+    const timeoutRouter = new SessionRouter(timeoutConfig, BOT_ID);
+    let resolveMembers: ((members: Array<{ uid: string; name: string; role: number }>) => void) | undefined;
+    (getGroupMembers as ReturnType<typeof vi.fn>).mockImplementationOnce(
+      () => new Promise((resolve) => { resolveMembers = resolve; }),
+    );
+
+    const processing = simulateMessage(
+      makeGroupMsg('delayed roster', true, { channel_id: channelId }),
+      timeoutConfig,
+      store,
+      timeoutRouter,
+      groupContext,
+      streamRelay,
+    );
+    await vi.waitFor(() => expect(getGroupMembers).toHaveBeenCalledTimes(1));
+    const request = (getGroupMembers as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(request.signal).toBeInstanceOf(AbortSignal);
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(request.signal.aborted).toBe(true);
+    resolveMembers?.([{ uid: 'late-user', name: 'Late User', role: 0 }]);
+    await processing;
+
+    expect(groupContext.getName('late-user', channelId)).toBeUndefined();
+    expect(groupContext.buildContextSince(channelId, 0).text).toBe('');
+    expect(groupContext.getContextCursor(channelId)).toBe(0);
+  });
+
+  it('dispatch timeout prevents delayed G4 backfill from persisting stale history', async () => {
+    const channelId = 'group-cancelled-backfill';
+    const timeoutConfig = makeConfig({ dispatchTimeoutMs: 10 });
+    const timeoutRouter = new SessionRouter(timeoutConfig, BOT_ID);
+    let resolveHistory: ((messages: Array<{ from_uid: string; content: string; timestamp: number; message_seq: number }>) => void) | undefined;
+    (getChannelMessages as ReturnType<typeof vi.fn>).mockImplementationOnce(
+      () => new Promise((resolve) => { resolveHistory = resolve; }),
+    );
+
+    const first = simulateMessage(
+      makeGroupMsg('first turn', true, { channel_id: channelId, message_seq: 2 }),
+      timeoutConfig,
+      store,
+      timeoutRouter,
+      groupContext,
+      streamRelay,
+    );
+    await vi.waitFor(() => expect(getChannelMessages).toHaveBeenCalledTimes(1));
+    const request = (getChannelMessages as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(request.signal).toBeInstanceOf(AbortSignal);
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(request.signal.aborted).toBe(true);
+    resolveHistory?.([
+      { from_uid: 'old-user', content: 'stale history', timestamp: 1, message_seq: 1 },
+    ]);
+    await first;
+    expect(store.buildHistoryPrefix(channelId, 40)).toBe('');
+
+    (getChannelMessages as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
+      { from_uid: 'old-user', content: 'retry history', timestamp: 1, message_seq: 1 },
+    ]);
+    const retryConfig = makeConfig();
+    const retryRouter = new SessionRouter(retryConfig, BOT_ID);
+    await simulateMessage(
+      makeGroupMsg('second turn', true, { channel_id: channelId, message_seq: 3 }),
+      retryConfig,
+      store,
+      retryRouter,
+      groupContext,
+      streamRelay,
+    );
+
+    expect(getChannelMessages).toHaveBeenCalledTimes(2);
+    expect(store.buildHistoryPrefix(channelId, 40)).toContain('retry history');
+    expect(store.buildHistoryPrefix(channelId, 40)).not.toContain('stale history');
   });
 
   // --- 2b. PR#51 per-session cwd wiring (regression: was uncovered) ---

--- a/src/__tests__/e2e.test.ts
+++ b/src/__tests__/e2e.test.ts
@@ -15,6 +15,7 @@ vi.mock('../octo/api.js', () => ({
   sendTyping: vi.fn().mockResolvedValue(undefined),
   sendReadReceipt: vi.fn().mockResolvedValue(undefined),
   getGroupMembers: vi.fn().mockResolvedValue([]),
+  getGroupMd: vi.fn().mockResolvedValue(undefined),
   // G4 backfill path in the real handleMessage — default to no history.
   getChannelMessages: vi.fn().mockResolvedValue([]),
   getUploadCredentials: vi.fn().mockResolvedValue({
@@ -65,6 +66,7 @@ vi.mock('../media-inbound.js', async (importOriginal) => {
 import { SessionStore } from '../session-store.js';
 import { SessionRouter } from '../session-router.js';
 import { GroupContext } from '../group-context.js';
+import { GroupMdCache } from '../group-md-cache.js';
 import { StreamRelay } from '../stream-relay.js';
 import { createAdapter, type DbAdapter } from '../db-adapter.js';
 import { queryAgent } from '../agent-bridge.js';
@@ -73,6 +75,7 @@ import {
   sendMessage,
   sendReadReceipt,
   getGroupMembers,
+  getGroupMd,
   getChannelMessages,
 } from '../octo/api.js';
 import { ChannelType, MessageType } from '../octo/types.js';
@@ -173,8 +176,19 @@ async function simulateMessage(
   router: SessionRouter,
   groupContext: GroupContext,
   streamRelay: StreamRelay,
+  groupMdCache?: GroupMdCache,
 ): Promise<void> {
-  await handleMessage(msg, config, store, router, groupContext, streamRelay, BOT_ID);
+  await handleMessage(
+    msg,
+    config,
+    store,
+    router,
+    groupContext,
+    streamRelay,
+    BOT_ID,
+    undefined,
+    groupMdCache,
+  );
 }
 
 // --- Tests ---
@@ -569,6 +583,43 @@ describe('E2E smoke tests', () => {
     expect(getChannelMessages).toHaveBeenCalledTimes(2);
     expect(store.buildHistoryPrefix(channelId, 40)).toContain('retry history');
     expect(store.buildHistoryPrefix(channelId, 40)).not.toContain('stale history');
+  });
+
+  it('dispatch timeout prevents delayed GROUP.md fetches from mutating the cache', async () => {
+    const channelId = 'group-cancelled-md';
+    const timeoutConfig = makeConfig({ dispatchTimeoutMs: 10, serverMd: true });
+    const timeoutRouter = new SessionRouter(timeoutConfig, BOT_ID);
+    const groupMdCache = new GroupMdCache();
+    let resolveMd: ((md: { content: string; version: number; updated_at: string; updated_by: string }) => void) | undefined;
+    (getGroupMd as ReturnType<typeof vi.fn>).mockImplementationOnce(
+      () => new Promise((resolve) => { resolveMd = resolve; }),
+    );
+
+    const processing = simulateMessage(
+      makeGroupMsg('delayed group instructions', true, { channel_id: channelId }),
+      timeoutConfig,
+      store,
+      timeoutRouter,
+      groupContext,
+      streamRelay,
+      groupMdCache,
+    );
+    await vi.waitFor(() => expect(getGroupMd).toHaveBeenCalledTimes(1));
+    const request = (getGroupMd as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(request.signal).toBeInstanceOf(AbortSignal);
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(request.signal.aborted).toBe(true);
+    resolveMd?.({
+      content: 'stale server rules',
+      version: 1,
+      updated_at: '2026-07-16T00:00:00Z',
+      updated_by: 'operator',
+    });
+    await processing;
+
+    expect(groupMdCache.get(channelId)).toBeUndefined();
+    expect(queryAgent).not.toHaveBeenCalled();
   });
 
   // --- 2b. PR#51 per-session cwd wiring (regression: was uncovered) ---

--- a/src/__tests__/group-md.test.ts
+++ b/src/__tests__/group-md.test.ts
@@ -162,6 +162,31 @@ describe('resolveGroupInstructions', () => {
     expect(call0Url()).toBe(`${BASE.apiUrl}/v1/bot/groups/${GROUP}/md`);
   });
 
+  it('does not cache or return a delayed server result after cancellation', async () => {
+    let resolveFetch: ((response: Response) => void) | undefined;
+    fetchMock.mockImplementationOnce(
+      () => new Promise<Response>((resolve) => { resolveFetch = resolve; }),
+    );
+    const cache = new GroupMdCache();
+    const controller = new AbortController();
+
+    const pending = resolveGroupInstructions({
+      groupConfigDir: cfgDir,
+      serverMd: true,
+      ...BASE,
+      channelId: GROUP,
+      cache,
+      signal: controller.signal,
+    });
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    controller.abort(new Error('dispatch timed out'));
+    resolveFetch?.(mockMd('stale server rules'));
+
+    await expect(pending).resolves.toBeUndefined();
+    expect(cache.get(GROUP)).toBeUndefined();
+  });
+
   it('caches the server fetch — a second call serves from cache (no second fetch)', async () => {
     fetchMock.mockResolvedValueOnce(mockMd('server rules'));
     const cache = new GroupMdCache();

--- a/src/__tests__/session-router.test.ts
+++ b/src/__tests__/session-router.test.ts
@@ -483,25 +483,31 @@ describe('dispatch timeout (#141)', () => {
       makeConfig({ rateLimit: { maxPerMinute: 100 }, dispatchTimeoutMs: 50 }),
       ROBOT_ID,
     );
-    const completed: number[] = [];
+    const events: string[] = [];
 
-    // Message 1: handler never resolves (simulates a hung agent turn).
+    // Message 1: handler stays active until the router cancels it.
     const p1 = router.routeAndHandle(
       makeMsg({ message_id: '1', channel_type: ChannelType.DM, from_uid: 'same-user' }),
-      () => new Promise<void>(() => { /* never resolves */ }),
+      (_result, { abortController }) => new Promise<void>((resolve) => {
+        events.push('first-started');
+        abortController.signal.addEventListener('abort', () => {
+          events.push('first-aborted');
+          resolve();
+        }, { once: true });
+      }),
     );
 
     // Message 2: a normal fast handler on the SAME session. Without the
     // timeout it would be blocked forever behind message 1's session lock.
     const p2 = router.routeAndHandle(
       makeMsg({ message_id: '2', channel_type: ChannelType.DM, from_uid: 'same-user' }),
-      async () => { completed.push(2); },
+      async () => { events.push('second-started'); },
     );
 
     await Promise.all([p1, p2]);
 
     // Message 2 ran — the lock was released after message 1 timed out.
-    expect(completed).toEqual([2]);
+    expect(events).toEqual(['first-started', 'first-aborted', 'second-started']);
   });
 
   it('sends a single bounded apology on timeout', async () => {
@@ -512,13 +518,47 @@ describe('dispatch timeout (#141)', () => {
 
     await router.routeAndHandle(
       makeMsg({ message_id: '1', channel_type: ChannelType.DM, from_uid: 'u1' }),
-      () => new Promise<void>(() => { /* never resolves */ }),
+      (_result, { abortController }) => new Promise<void>((resolve) => {
+        abortController.signal.addEventListener('abort', () => resolve(), { once: true });
+      }),
     );
 
     expect(sendMessage).toHaveBeenCalledTimes(1);
     expect(vi.mocked(sendMessage).mock.calls[0][0]).toMatchObject({
       content: expect.stringContaining('处理超时'),
     });
+  });
+
+  it('still releases the session after the abort grace when a handler ignores cancellation', async () => {
+    vi.useFakeTimers();
+    try {
+      const router = new SessionRouter(
+        makeConfig({ rateLimit: { maxPerMinute: 100 }, dispatchTimeoutMs: 30 }),
+        ROBOT_ID,
+      );
+      const completed: number[] = [];
+      let signal: AbortSignal | undefined;
+
+      const p1 = router.routeAndHandle(
+        makeMsg({ message_id: '1', channel_type: ChannelType.DM, from_uid: 'same-user' }),
+        (_result, { abortController }) => {
+          signal = abortController.signal;
+          return new Promise<void>(() => { /* deliberately ignores cancellation */ });
+        },
+      );
+      const p2 = router.routeAndHandle(
+        makeMsg({ message_id: '2', channel_type: ChannelType.DM, from_uid: 'same-user' }),
+        async () => { completed.push(2); },
+      );
+
+      await vi.advanceTimersByTimeAsync(3_100);
+      await Promise.all([p1, p2]);
+
+      expect(signal?.aborted).toBe(true);
+      expect(completed).toEqual([2]);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('does not fire for a normal fast handler', async () => {

--- a/src/__tests__/stream-relay.test.ts
+++ b/src/__tests__/stream-relay.test.ts
@@ -297,6 +297,54 @@ describe("StreamRelay", () => {
     expect(countLater).toBe(countAfter);
   });
 
+  it("drops partial output when the dispatch is cancelled", async () => {
+    const controller = new AbortController();
+    async function* cancelledChunks(): AsyncIterable<string> {
+      yield "partial";
+      controller.abort(new Error("dispatch timed out"));
+      throw new Error("cancelled stream");
+    }
+
+    const promise = relay.deliver(
+      CH_ID,
+      CH_TYPE,
+      cancelledChunks(),
+      API_URL,
+      BOT_TOKEN,
+      undefined,
+      undefined,
+      undefined,
+      controller.signal,
+    );
+    await vi.runAllTimersAsync();
+    await expect(promise).resolves.toBeUndefined();
+
+    const sendCalls = mockState.calls.filter((c) => c.fn === "sendMessage");
+    expect(sendCalls).toHaveLength(0);
+  });
+
+  it("forwards the dispatch signal to typing and message requests", async () => {
+    const controller = new AbortController();
+    const promise = relay.deliver(
+      CH_ID,
+      CH_TYPE,
+      asyncChunks(["hello"]),
+      API_URL,
+      BOT_TOKEN,
+      undefined,
+      undefined,
+      undefined,
+      controller.signal,
+    );
+    await vi.runAllTimersAsync();
+    await promise;
+
+    const typingCall = mockState.calls.find((c) => c.fn === "sendTyping");
+    const sendCall = mockState.calls.find((c) => c.fn === "sendMessage");
+    expect(typingCall?.args.signal).toBe(controller.signal);
+    expect(sendCall?.args.signal).toBe(controller.signal);
+  });
+
   it("passes apiUrl and botToken to sendMessage", async () => {
     const chunks = asyncChunks(["test content"]);
     const promise = relay.deliver(CH_ID, CH_TYPE, chunks, API_URL, BOT_TOKEN);

--- a/src/__tests__/thread-md.test.ts
+++ b/src/__tests__/thread-md.test.ts
@@ -171,6 +171,31 @@ describe('resolveGroupInstructions (thread branch)', () => {
     expect(call0Url()).toBe(`${BASE.apiUrl}/v1/bot/groups/${GROUP}/threads/${SHORT}/md`);
   });
 
+  it('does not cache or return a delayed server result after cancellation', async () => {
+    let resolveFetch: ((response: Response) => void) | undefined;
+    fetchMock.mockImplementationOnce(
+      () => new Promise<Response>((resolve) => { resolveFetch = resolve; }),
+    );
+    const threadCache = new ThreadMdCache();
+    const controller = new AbortController();
+
+    const pending = resolveGroupInstructions({
+      groupConfigDir: cfgDir,
+      threadMd: true,
+      ...BASE,
+      channelId: CHANNEL,
+      threadCache,
+      signal: controller.signal,
+    });
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    controller.abort(new Error('dispatch timed out'));
+    resolveFetch?.(mockMd('stale thread rules'));
+
+    await expect(pending).resolves.toBeUndefined();
+    expect(threadCache.get(GROUP, SHORT)).toBeUndefined();
+  });
+
   it('caches the server fetch — a second call serves from cache (no second fetch)', async () => {
     fetchMock.mockResolvedValueOnce(mockMd('server THREAD rules'));
     const threadCache = new ThreadMdCache();

--- a/src/agent-bridge.ts
+++ b/src/agent-bridge.ts
@@ -224,6 +224,8 @@ const MAX_SYSTEM_PROMPT_CHARS = 100 * 1024;
  *     caller injects nothing (history already lives in the session).
  *   - `onSessionId`: called with the SDK session id observed for this turn, so
  *     the caller can persist it and resume next time.
+ *   - `abortController`: owned by the dispatch router and forwarded to the SDK
+ *     so timeout cancellation terminates the query and its resources.
  * @yields string chunks of assistant text output
  */
 export async function* queryAgent(
@@ -231,7 +233,7 @@ export async function* queryAgent(
   config: Config,
   sessionCtx?: SessionCtx,
   onToolUse?: (toolName: string, toolInput?: unknown) => void,
-  opts?: { resume?: string; onSessionId?: (id: string) => void; groupInstructions?: string; memoryDir?: string; mcpServers?: Record<string, McpServerConfig>; onResumeFailed?: () => void; fallbackRetryPrompt?: string },
+  opts?: { resume?: string; onSessionId?: (id: string) => void; groupInstructions?: string; memoryDir?: string; mcpServers?: Record<string, McpServerConfig>; onResumeFailed?: () => void; fallbackRetryPrompt?: string; abortController?: AbortController },
 ): AsyncIterable<string> {
   const permissionMode = toPermissionMode(config.sdk.permissionMode);
   const settingSources = toSettingSources(config.sdk.settingSources);
@@ -314,6 +316,7 @@ export async function* queryAgent(
         // #115: in-process MCP servers (e.g. the cron tool) injected by the caller
         // for this turn. Omitted when none.
         ...(opts?.mcpServers ? { mcpServers: opts.mcpServers } : {}),
+        ...(opts?.abortController ? { abortController: opts.abortController } : {}),
         allowDangerouslySkipPermissions: permissionMode === 'bypassPermissions',
       },
     });

--- a/src/group-context.ts
+++ b/src/group-context.ts
@@ -246,7 +246,12 @@ export class GroupContext {
     }
   }
 
-  async refreshMembers(channelId: string, apiUrl: string, botToken: string): Promise<void> {
+  async refreshMembers(
+    channelId: string,
+    apiUrl: string,
+    botToken: string,
+    signal?: AbortSignal,
+  ): Promise<void> {
     const now = Date.now();
     const last = this.lastRefresh.get(channelId) ?? 0;
     if (now - last < REFRESH_INTERVAL_MS) return;
@@ -260,7 +265,8 @@ export class GroupContext {
       // flags) keyed by the full channelId, so a thread keeps its own isolated
       // roster view. For a plain group channelId extractParentGroupNo is identity.
       const groupNo = extractParentGroupNo(channelId);
-      const members = await getGroupMembers({ apiUrl, botToken, groupNo });
+      const members = await getGroupMembers({ apiUrl, botToken, groupNo, signal });
+      if (signal?.aborted) return;
       this.lastRefresh.set(channelId, now); // Record only on success
       const memberMap = this.getMemberMap(channelId);
       const nameMap = this.getNameToUid(channelId);
@@ -336,6 +342,7 @@ export class GroupContext {
         }
       }
     } catch (err) {
+      if (signal?.aborted) return;
       console.error(`group-context: refreshMembers(${channelId}) failed: ${String(err)}`);
       // Don't update lastRefresh on failure — allow retry
     }

--- a/src/group-md.ts
+++ b/src/group-md.ts
@@ -116,6 +116,7 @@ async function resolveGroupBranch(
 ): Promise<string | undefined> {
   const { groupConfigDir, serverMd, apiUrl, botToken, channelId, cache, signal } = params;
 
+  if (signal?.aborted) return undefined;
   const local = (): string | undefined => loadGroupConfig(groupConfigDir, channelId);
 
   // Flag off (or no cache to dedupe fetches) → pure local file, unchanged behavior.
@@ -137,6 +138,7 @@ async function resolveGroupBranch(
   // b) server-first fetch.
   try {
     const md = await getGroupMd({ apiUrl, botToken, groupNo, signal });
+    if (signal?.aborted) return undefined;
     const bounded = boundInstructions(md?.content ?? '');
     if (bounded) {
       const entry: GroupMdEntry = {
@@ -151,6 +153,7 @@ async function resolveGroupBranch(
     // Server reachable but no/empty GROUP.md → local fallback.
     return local();
   } catch (err) {
+    if (signal?.aborted) return undefined;
     // c) 404 / network / timeout — never-lose local fallback.
     console.error(
       `[cc-channel-octo] group-md: server fetch for ${groupNo} failed, falling back to local: ${String(err)}`,
@@ -180,6 +183,7 @@ async function resolveThreadInstructions(
 ): Promise<string | undefined> {
   const { groupConfigDir, threadMd, apiUrl, botToken, channelId, threadCache, signal } = params;
 
+  if (signal?.aborted) return undefined;
   // Local fallback keeps the FULL channelId — loadGroupConfig routes a thread to
   // its own `<shortId>.md`, never the parent group's `<groupNo>.md`.
   const local = (): string | undefined => loadGroupConfig(groupConfigDir, channelId);
@@ -207,6 +211,7 @@ async function resolveThreadInstructions(
   // b) server-first fetch of this thread's own THREAD.md.
   try {
     const md = await getThreadMd({ apiUrl, botToken, groupNo, shortId, signal });
+    if (signal?.aborted) return undefined;
     const bounded = boundInstructions(md?.content ?? '');
     if (bounded) {
       const entry: GroupMdEntry = {
@@ -221,6 +226,7 @@ async function resolveThreadInstructions(
     // Server reachable but no/empty THREAD.md → local fallback.
     return local();
   } catch (err) {
+    if (signal?.aborted) return undefined;
     // c) 404 / network / timeout — never-lose local fallback.
     console.error(
       `[cc-channel-octo] thread-md: server fetch for ${groupNo}::${shortId} failed, falling back to local: ${String(err)}`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -916,7 +916,9 @@ export async function handleMessage(
           channelId,
           cache: groupMdCache,
           threadCache: threadMdCache,
+          signal,
         });
+        if (signal.aborted) return;
         if (groupInstructions) {
           sessionOpts = { ...(sessionOpts ?? {}), groupInstructions };
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -484,7 +484,8 @@ export async function handleMessage(
       // session, so re-showing them would be redundant and would bloat the session.
       let groupContextBlock = '';
       if (isGroup) {
-        await groupContext.refreshMembers(channelId, config.apiUrl, config.botToken);
+        await groupContext.refreshMembers(channelId, config.apiUrl, config.botToken, signal);
+        if (signal.aborted) return;
         const cursor = groupContext.getContextCursor(channelId);
         const delta = groupContext.buildContextSince(channelId, cursor);
         if (delta.text) {
@@ -716,7 +717,12 @@ export async function handleMessage(
             channelId: msg.channel_id,
             channelType: msg.channel_type,
             limit: Math.min(config.context.historyLimit, 100),
+            signal,
           });
+          if (signal.aborted) {
+            backfilledSessions.delete(backfillKey);
+            return;
+          }
           if (apiMessages.length > 0) {
             // Persist into local store so subsequent turns hit cache,
             // and rebuild historyPrefix with the enriched data. Pass the
@@ -732,6 +738,10 @@ export async function handleMessage(
             historyPrefix = store.buildSegmentedHistoryPrefix(sessionKey, config.context.historyLimit);
           }
         } catch (err) {
+          if (signal.aborted) {
+            backfilledSessions.delete(backfillKey);
+            return;
+          }
           console.error(`[cc-channel-octo] G4 backfill failed for ${sessionKey}: ${String(err)}`);
         }
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -419,9 +419,10 @@ export async function handleMessage(
   // For non-processed messages, routeAndHandle returns without calling handler.
   // We still need to cache group text messages for context.
   let wasProcessed = false;
-  const routeResult = await router.routeAndHandle(msg, async (result) => {
+  const routeResult = await router.routeAndHandle(msg, async (result, { abortController }) => {
     wasProcessed = true;
     const { sessionKey } = result;
+    const { signal } = abortController;
 
     try {
       // --- Session ---
@@ -455,6 +456,7 @@ export async function handleMessage(
               channelId,
               channelType,
               content: command.reply,
+              signal,
             });
           }
           // G8: send a read receipt for command messages too, mirroring the
@@ -467,6 +469,7 @@ export async function handleMessage(
               channelId: msg.channel_id,
               channelType: msg.channel_type,
               messageIds: [msg.message_id],
+              signal,
             }).catch(() => { /* read receipt is best-effort; never surface failures */ });
           }
           return; // skip context, history, and the agent query entirely
@@ -733,6 +736,7 @@ export async function handleMessage(
         }
       }
 
+      if (signal.aborted) return;
       store.appendUser(sessionKey, userContent, msg.message_seq, msg.from_name ?? msg.from_uid);
 
       // --- Session resume + first-turn history injection ---
@@ -814,6 +818,7 @@ export async function handleMessage(
         let noticeCount = 0;
         const MAX_TOOL_NOTICES = 10;
         onToolUse = (toolName: string, toolInput?: unknown): void => {
+          if (signal.aborted) return;
           const params = formatToolParams(toolInput);
           const label = params ? `${toolName}(${params})` : toolName;
           if (label === lastNotice) return; // collapse exact repeats
@@ -827,8 +832,11 @@ export async function handleMessage(
             channelId,
             channelType,
             content: `🔧 Running ${label}…`,
+            signal,
           }).catch((err) =>
-            console.error(`[cc-channel-octo] tool-progress send failed: ${String(err)}`),
+            signal.aborted
+              ? undefined
+              : console.error(`[cc-channel-octo] tool-progress send failed: ${String(err)}`),
           );
         };
       }
@@ -842,12 +850,17 @@ export async function handleMessage(
       // queryAgent recovers by calling onResumeFailed (clear the bad id) and
       // retrying once with the pre-assembled fallbackRetryPrompt so the
       // conversation isn't lost (and assembly happens exactly once — see above).
-      let sessionOpts: { resume?: string; onSessionId?: (id: string) => void; groupInstructions?: string; memoryDir?: string; mcpServers?: Record<string, McpServerConfig>; onResumeFailed?: () => void; fallbackRetryPrompt?: string } | undefined = {
+      let sessionOpts: { resume?: string; onSessionId?: (id: string) => void; groupInstructions?: string; memoryDir?: string; mcpServers?: Record<string, McpServerConfig>; onResumeFailed?: () => void; fallbackRetryPrompt?: string; abortController?: AbortController } | undefined = {
         ...(resume ? { resume } : {}),
-        onSessionId: (id: string) => store.setSdkSessionId(sessionKey, id),
+        abortController,
+        onSessionId: (id: string) => {
+          if (!signal.aborted) store.setSdkSessionId(sessionKey, id);
+        },
         ...(resume
           ? {
-              onResumeFailed: () => store.clearSdkSessionId(sessionKey),
+              onResumeFailed: () => {
+                if (!signal.aborted) store.clearSdkSessionId(sessionKey);
+              },
               fallbackRetryPrompt,
             }
           : {}),
@@ -959,12 +972,14 @@ export async function handleMessage(
         }
       }
 
+      if (signal.aborted) return;
       const rawChunks = queryAgent(userContentForLLM, config, sessionCtx, onToolUse, sessionOpts);
 
       // Tee the generator: collect full text while streaming to Octo
       const collected: string[] = [];
       async function* teeChunks(): AsyncIterable<string> {
         for await (const chunk of rawChunks) {
+          if (signal.aborted) return;
           collected.push(chunk);
           yield chunk;
         }
@@ -981,7 +996,9 @@ export async function handleMessage(
       const isValidMentionUid = isGroup
         ? (uid: string): boolean => groupContext.isMember(channelId, uid)
         : undefined;
-      await streamRelay.deliver(channelId, channelType, teeChunks(), config.apiUrl, config.botToken, config.maxResponseChars, outboundNameToUid, isValidMentionUid);
+      await streamRelay.deliver(channelId, channelType, teeChunks(), config.apiUrl, config.botToken, config.maxResponseChars, outboundNameToUid, isValidMentionUid, signal);
+
+      if (signal.aborted) return;
 
       // G8: Send read receipt after processing (fire-and-forget)
       if (msg.message_id && msg.channel_id && msg.channel_type !== undefined) {
@@ -991,6 +1008,7 @@ export async function handleMessage(
           channelId: msg.channel_id,
           channelType: msg.channel_type,
           messageIds: [msg.message_id],
+          signal,
         }).catch(() => { /* read receipt is best-effort; never surface failures */ });
       }
 
@@ -1014,10 +1032,12 @@ export async function handleMessage(
           channelId,
           channelType,
           content: '[No response generated. Please try rephrasing your question.]',
+          signal,
         });
       }
 
     } catch (err) {
+      if (signal.aborted) return;
       console.error(`[cc-channel-octo] Error processing message (session=${result.sessionKey}):`, String(err));
       // #115: attribute a FAILED cron fire to its task. handleMessage swallows
       // errors here (it sends a user-facing reply, never rethrows), so the
@@ -1035,6 +1055,7 @@ export async function handleMessage(
           channelId,
           channelType,
           content: 'An error occurred while processing your message. Please try again.',
+          signal,
         });
       } catch {
         /* swallow — don't crash on reply failure */

--- a/src/octo/api.ts
+++ b/src/octo/api.ts
@@ -274,7 +274,10 @@ async function getJson<T>(
   signal?: AbortSignal,
 ): Promise<T> {
   const url = `${apiUrl.replace(/\/+$/, "")}${path}`;
-  const effectiveSignal = signal ?? AbortSignal.timeout(DEFAULT_TIMEOUT_MS);
+  const timeoutSignal = AbortSignal.timeout(DEFAULT_TIMEOUT_MS);
+  const effectiveSignal = signal
+    ? AbortSignal.any([signal, timeoutSignal])
+    : timeoutSignal;
   const resp = await fetch(url, {
     method: "GET",
     headers: {
@@ -328,11 +331,13 @@ export async function getGroupMembers(params: {
   apiUrl: string;
   botToken: string;
   groupNo: string;
+  signal?: AbortSignal;
 }): Promise<GroupMember[]> {
   const data = await getJson<Record<string, unknown>>(
     params.apiUrl,
     params.botToken,
     `/v1/bot/groups/${params.groupNo}/members`,
+    params.signal,
   );
   const members = Array.isArray(data?.members)
     ? data.members

--- a/src/octo/api.ts
+++ b/src/octo/api.ts
@@ -18,6 +18,11 @@ import { randomUUID } from "node:crypto";
 
 const DEFAULT_TIMEOUT_MS = 30_000;
 
+function withDefaultTimeout(signal?: AbortSignal): AbortSignal {
+  const timeoutSignal = AbortSignal.timeout(DEFAULT_TIMEOUT_MS);
+  return signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal;
+}
+
 /**
  * Maximum base64-encoded payload length accepted from /v1/bot/messages/sync.
  * D1/S7 (齐 P0-2): a malicious or buggy server could return a single payload
@@ -65,10 +70,7 @@ export async function postJson<T>(
   signal?: AbortSignal,
 ): Promise<T | undefined> {
   const url = `${apiUrl.replace(/\/+$/, "")}${path}`;
-  const timeoutSignal = AbortSignal.timeout(DEFAULT_TIMEOUT_MS);
-  const effectiveSignal = signal
-    ? AbortSignal.any([signal, timeoutSignal])
-    : timeoutSignal;
+  const effectiveSignal = withDefaultTimeout(signal);
   const response = await fetch(url, {
     method: "POST",
     headers: {
@@ -168,7 +170,7 @@ export async function getUploadCredentials(params: {
 }> {
   const base = params.apiUrl.replace(/\/+$/, "");
   const url = `${base}/v1/bot/upload/credentials?filename=${encodeURIComponent(params.filename)}`;
-  const effectiveSignal = params.signal ?? AbortSignal.timeout(DEFAULT_TIMEOUT_MS);
+  const effectiveSignal = withDefaultTimeout(params.signal);
   const response = await fetch(url, {
     method: "GET",
     headers: { Authorization: `Bearer ${params.botToken}` },
@@ -274,10 +276,7 @@ async function getJson<T>(
   signal?: AbortSignal,
 ): Promise<T> {
   const url = `${apiUrl.replace(/\/+$/, "")}${path}`;
-  const timeoutSignal = AbortSignal.timeout(DEFAULT_TIMEOUT_MS);
-  const effectiveSignal = signal
-    ? AbortSignal.any([signal, timeoutSignal])
-    : timeoutSignal;
+  const effectiveSignal = withDefaultTimeout(signal);
   const resp = await fetch(url, {
     method: "GET",
     headers: {
@@ -531,7 +530,7 @@ async function requestNoBody(
   signal?: AbortSignal,
 ): Promise<void> {
   const url = `${apiUrl.replace(/\/+$/, "")}${path}`;
-  const effectiveSignal = signal ?? AbortSignal.timeout(DEFAULT_TIMEOUT_MS);
+  const effectiveSignal = withDefaultTimeout(signal);
   const resp = await fetch(url, {
     method,
     headers: { Authorization: `Bearer ${botToken}` },
@@ -799,7 +798,7 @@ export async function updateGroupMd(params: {
 }): Promise<{ version: number }> {
   const path = `/v1/bot/groups/${encodeURIComponent(params.groupNo)}/md`;
   const url = `${params.apiUrl.replace(/\/+$/, "")}${path}`;
-  const effectiveSignal = params.signal ?? AbortSignal.timeout(DEFAULT_TIMEOUT_MS);
+  const effectiveSignal = withDefaultTimeout(params.signal);
   const resp = await fetch(url, {
     method: "PUT",
     headers: {
@@ -844,7 +843,7 @@ export async function updateThreadMd(params: {
 }): Promise<{ version: number }> {
   const path = `/v1/bot/groups/${encodeURIComponent(params.groupNo)}/threads/${encodeURIComponent(params.shortId)}/md`;
   const url = `${params.apiUrl.replace(/\/+$/, "")}${path}`;
-  const effectiveSignal = params.signal ?? AbortSignal.timeout(DEFAULT_TIMEOUT_MS);
+  const effectiveSignal = withDefaultTimeout(params.signal);
   const resp = await fetch(url, {
     method: "PUT",
     headers: {

--- a/src/octo/api.ts
+++ b/src/octo/api.ts
@@ -65,7 +65,10 @@ export async function postJson<T>(
   signal?: AbortSignal,
 ): Promise<T | undefined> {
   const url = `${apiUrl.replace(/\/+$/, "")}${path}`;
-  const effectiveSignal = signal ?? AbortSignal.timeout(DEFAULT_TIMEOUT_MS);
+  const timeoutSignal = AbortSignal.timeout(DEFAULT_TIMEOUT_MS);
+  const effectiveSignal = signal
+    ? AbortSignal.any([signal, timeoutSignal])
+    : timeoutSignal;
   const response = await fetch(url, {
     method: "POST",
     headers: {

--- a/src/session-router.ts
+++ b/src/session-router.ts
@@ -36,6 +36,11 @@ export interface RouteResult {
   rejectionReason?: 'rate_limited' | 'oversized';
 }
 
+export interface DispatchContext {
+  /** Owned by the router; aborted when this dispatch exceeds its timeout. */
+  abortController: AbortController;
+}
+
 interface TokenBucket {
   tokens: number;
   lastRefill: number;
@@ -50,6 +55,12 @@ const GLOBAL_RATE_MULTIPLIER = 10;
 
 /** Maximum allowed content length in bytes (Q10). Messages exceeding this are rejected. */
 const MAX_CONTENT_BYTES = 32_768; // 32 KB
+
+/**
+ * Give cooperative handlers a short window to finish SDK/process cleanup after
+ * cancellation without reviving the permanent session wedge fixed by #141.
+ */
+const DISPATCH_ABORT_GRACE_MS = 3_000;
 
 export class SessionRouter {
   private readonly config: Config;
@@ -163,7 +174,7 @@ export class SessionRouter {
    */
   async routeAndHandle(
     msg: BotMessage,
-    handler: (result: RouteResult) => Promise<void>,
+    handler: (result: RouteResult, context: DispatchContext) => Promise<void>,
   ): Promise<RouteResult | null> {
     const key = this.sessionKey(msg);
     return this.withSessionLock(key, async () => {
@@ -183,59 +194,77 @@ export class SessionRouter {
    * stuck permanently (silent). Racing the handler against a timeout guarantees
    * the lock releases.
    *
-   * Scope (mirrors openclaw #75): we do NOT cancel the in-flight turn — the SDK
-   * query keeps running to completion in the background; we only unblock the
-   * queue. Worst case is a delayed real reply arriving after the apology.
-   *
-   * `timeoutError` is a per-invocation Error so the catch identifies OUR timeout
-   * by reference equality, never by string comparison (a same-text upstream
-   * error must not be misclassified).
+   * On timeout we abort the dispatch, give cooperative SDK/process cleanup a
+   * short bounded grace period, then release the lock. The production handler
+   * uses the same cancellation signal to fence late output and persistence.
    */
   private async runHandlerWithTimeout(
     result: RouteResult,
-    handler: (result: RouteResult) => Promise<void>,
+    handler: (result: RouteResult, context: DispatchContext) => Promise<void>,
   ): Promise<void> {
+    const abortController = new AbortController();
+    const context = { abortController } satisfies DispatchContext;
     const timeoutMs = this.config.dispatchTimeoutMs;
     if (!timeoutMs || timeoutMs <= 0) {
       // Timeout disabled — run unguarded.
-      await handler(result);
+      await handler(result, context);
       return;
     }
 
     let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
-    const timeoutError = new Error(`dispatch timed out after ${timeoutMs}ms`);
-    const timeoutPromise = new Promise<never>((_, reject) => {
-      timeoutHandle = setTimeout(() => reject(timeoutError), timeoutMs);
+    const timeoutOutcome = new Promise<{ kind: 'timeout' }>((resolve) => {
+      timeoutHandle = setTimeout(() => resolve({ kind: 'timeout' }), timeoutMs);
     });
 
-    // The handler keeps running after a timeout (we don't cancel the in-flight
-    // turn — see scope note above). Once the race settles on timeoutError, that
-    // orphaned promise is no longer awaited; attach a no-op catch so a late
-    // rejection from a handler that doesn't self-contain its errors can't surface
-    // as an unhandledRejection. Today's caller (index.ts) is fully try/caught, so
-    // this is defense-in-depth for future callers.
-    const handlerPromise = handler(result);
-    handlerPromise.catch(() => { /* swallow late rejection after timeout */ });
+    // Convert rejection into a value so a handler that settles after the timeout
+    // can never surface as an unhandled rejection.
+    const handlerOutcome = handler(result, context).then(
+      () => ({ kind: 'completed' } as const),
+      (error: unknown) => ({ kind: 'failed', error } as const),
+    );
 
     try {
-      await Promise.race([handlerPromise, timeoutPromise]);
-    } catch (err) {
-      if (err === timeoutError) {
+      const outcome = await Promise.race([handlerOutcome, timeoutOutcome]);
+      if (outcome.kind === 'timeout') {
+        const timeoutError = new Error(`dispatch timed out after ${timeoutMs}ms`);
+        abortController.abort(timeoutError);
+
         console.warn(
-          `session-router: dispatch hung past ${timeoutMs}ms, releasing session lock (session=${result.sessionKey})`,
+          `session-router: dispatch hung past ${timeoutMs}ms, cancelling active turn (session=${result.sessionKey})`,
         );
+
+        // Preserve #141's bounded queue-unblock guarantee even if a future handler
+        // ignores cancellation. Production handlers fence late side effects with
+        // this same signal before the lock is released.
+        let graceHandle: ReturnType<typeof setTimeout> | undefined;
+        const settledDuringGrace = await Promise.race([
+          handlerOutcome.then(() => true),
+          new Promise<boolean>((resolve) => {
+            graceHandle = setTimeout(() => resolve(false), DISPATCH_ABORT_GRACE_MS);
+          }),
+        ]);
+        if (graceHandle) clearTimeout(graceHandle);
+        if (!settledDuringGrace) {
+          console.warn(
+            `session-router: cancelled dispatch did not settle within ${DISPATCH_ABORT_GRACE_MS}ms; releasing session lock with stale side effects fenced (session=${result.sessionKey})`,
+          );
+        }
+
         // Bounded apology — replySafe swallows its own errors, and the
         // underlying sendMessage in octo/api.ts is itself time-bounded, so a
         // sick Octo API can't re-hang us here.
         await this.replySafe(result.message, '⚠️ 处理超时，请稍后重试。');
         return; // swallow: the lock releases, the queue advances
       }
-      // A real handler error — index.ts's handler already catches and replies
-      // internally, so reaching here is unexpected. Swallow to keep the lock
-      // release path identical (never let an error wedge the queue).
-      console.error(
-        `session-router: handler error (session=${result.sessionKey}): ${String(err)}`,
-      );
+
+      if (outcome.kind === 'failed') {
+        // A real handler error — index.ts's handler already catches and replies
+        // internally, so reaching here is unexpected. Swallow to keep the lock
+        // release path identical (never let an error wedge the queue).
+        console.error(
+          `session-router: handler error (session=${result.sessionKey}): ${String(outcome.error)}`,
+        );
+      }
     } finally {
       if (timeoutHandle) clearTimeout(timeoutHandle);
     }

--- a/src/stream-relay.ts
+++ b/src/stream-relay.ts
@@ -166,13 +166,16 @@ export class StreamRelay {
     maxResponseChars: number = DEFAULT_MAX_RESPONSE_CHARS,
     memberMap?: Map<string, string>,
     isValidUid?: (uid: string) => boolean,
+    signal?: AbortSignal,
   ): Promise<void> {
+    if (signal?.aborted) return;
+
     // --- Typing heartbeat ---
-    const typingParams = { apiUrl, botToken, channelId, channelType };
+    const typingParams = { apiUrl, botToken, channelId, channelType, signal };
     // Fire one immediately — don't wait for the first interval tick.
     sendTyping(typingParams).catch(() => {});
     const typingTimer = setInterval(() => {
-      sendTyping(typingParams).catch(() => {});
+      if (!signal?.aborted) sendTyping(typingParams).catch(() => {});
     }, TYPING_INTERVAL_MS);
 
     try {
@@ -186,6 +189,7 @@ export class StreamRelay {
       let streamError: unknown;
       try {
         for await (const chunk of chunks) {
+          if (signal?.aborted) return;
           accumulated += chunk;
           // Q32: Stop accumulating once limit is reached to prevent unbounded memory.
           if (accumulated.length > maxResponseChars) {
@@ -201,9 +205,13 @@ export class StreamRelay {
           }
         }
       } catch (err) {
+        // A dispatch timeout owns the user-facing apology. Do not flush partial
+        // output from the stale turn or surface the expected cancellation error.
+        if (signal?.aborted) return;
         streamError = err;
         console.error(`[stream-relay] agent stream threw after ${accumulated.length} char(s); flushing partial output: ${String(err)}`);
       }
+      if (signal?.aborted) return;
       if (truncated) {
         console.warn(`[stream-relay] Response truncated at ${maxResponseChars} chars`);
       }
@@ -231,6 +239,7 @@ export class StreamRelay {
         let segStart = 0;
         let mentionAllConsumed = false;
         for (const segment of segments) {
+          if (signal?.aborted) return;
           const segEnd = segStart + segment.length;
           // Partition entities falling within this segment, re-rebase to
           // segment-local offsets. Server expects per-message offsets.
@@ -267,8 +276,10 @@ export class StreamRelay {
               ...(segUids.length > 0 ? { mentionUids: segUids } : {}),
               ...(segEntities.length > 0 ? { mentionEntities: segEntities } : {}),
               ...(useMentionAll ? { mentionAll: true } : {}),
+              signal,
             });
           } catch (err) {
+            if (signal?.aborted) return;
             console.error(`[stream-relay] sendMessage failed for segment (${segment.length} chars), continuing: ${String(err)}`);
             // Continue sending remaining segments — don't let one failure drop the rest
           }


### PR DESCRIPTION
## Summary

- abort timed-out dispatches through the Claude Agent SDK instead of only releasing the session lock
- propagate cancellation to Octo requests and stream delivery so stale turns cannot send partial replies or update session state
- fence delayed group-roster, G4 backfill, and GROUP.md/THREAD.md fetch results before they mutate shared caches, cursors, or history
- preserve the default 30-second HTTP timeout when a caller cancellation signal is also supplied
- keep a bounded 3-second cleanup grace before releasing the queue when a handler ignores cancellation

## Verification

- `npm run type-check`
- `npx vitest run src/__tests__/group-md.test.ts src/__tests__/thread-md.test.ts src/__tests__/api-timeout.test.ts src/__tests__/e2e.test.ts`
- `npm run lint`
- `npm run build`
- `npm test` (66 files, 1,289 tests)

## Notes

The bounded grace preserves the queue-unblocking behavior introduced by #141. If a handler ignores the abort signal, the queue is still released after the grace period, while production reply, context, instruction-cache, and session-state side effects are fenced by the same signal.

Closes #184