### PR TITLE
fix(agent-bridge): prevent nested and excessive subagents

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ configurable.
 | `sdk.allowedTools` | `"*"` | Either `"*"` (allow every tool the SDK exposes) or an explicit string array whitelist. |
 | `sdk.permissionMode` | `bypassPermissions` | SDK permission mode |
 | `sdk.maxTurns` | *(SDK default)* | Max agentic turns per query |
+| `sdk.maxConcurrentAgents` | `6` | Max concurrent subagents per root turn; `0` disables `Agent`. Nested subagents are always denied. |
 | `sdk.systemPrompt` | *(built-in)* | Custom system prompt (a `<baseDir>/<id>/SOUL.md` overrides this). |
 | `sdk.toolProgress` | `false` | When true, post `🔧 Running <tool>(<params>)…` notices as the agent invokes tools (params truncated; deduped, capped per turn) |
 | `sdk.settingSources` | `['project']` | Filesystem settings sources the SDK loads. Default `['project']` so it discovers skills symlinked into the session sandbox's `.claude/skills/` (see [Agent skills](#agent-skills)). Memory stays isolated regardless (inline auto-memory dir pin). Add `'user'` only to deliberately load the operator's real `~/.claude`. |

--- a/config.bot.example.json
+++ b/config.bot.example.json
@@ -8,6 +8,7 @@
   "sdk": {
     "_comment_model": "Override the model for this bot, e.g. 'vertexai/claude-opus-4-8'.",
     "_comment_systemPrompt": "Inline personality string. A ./SOUL.md file next to this config overrides it.",
+    "_comment_maxConcurrentAgents": "Override the root-turn subagent concurrency limit for this bot. Default 6; set 0 to disable Agent. Nested subagents are always denied.",
     "_comment_skills": "Per-bot skill selection: 'all' or a string[] of skill names from the shared library (~/.cc-channel-octo/skills + this bot's ./skills).",
     "_comment_env": "Extra env injected into the agent's tool subprocess, e.g. {\"OCTO_BOT_ID\":\"<robotId>\"} so a shared CLI acts as this bot.",
     "_comment_cron": "Set cron=true to let the agent schedule tasks (cron_create/list/delete → ./cron.json, owner-gated).",

--- a/config.example.json
+++ b/config.example.json
@@ -19,6 +19,8 @@
     "_comment_allowed_tools": "Q2: either '*' (allow every tool the SDK exposes) or an explicit string[] whitelist.",
     "allowedTools": "*",
     "permissionMode": "bypassPermissions",
+    "_comment_max_concurrent_agents": "Maximum concurrent subagents per root turn. Default 6; set 0 to disable Agent. Nested subagents are always denied.",
+    "maxConcurrentAgents": 6,
     "_comment_tool_progress": "v0.3: set toolProgress=true to post '🔧 Running <tool>(<params>)…' notices (params truncated). Off by default.",
     "_comment_setting_sources": "#100: which host filesystem settings the SDK loads (user=~/.claude, project=.claude, local=.claude/*.local). Default [\"project\"] so the SDK discovers skills symlinked into each session sandbox's .claude/skills/. Memory stays isolated regardless (the auto-memory dir is pinned via inline settings, ranked above projectSettings). Add \"user\" only to deliberately load the operator's real ~/.claude.",
     "settingSources": ["project"],

--- a/src/__tests__/agent-bridge-query.test.ts
+++ b/src/__tests__/agent-bridge-query.test.ts
@@ -177,6 +177,7 @@ describe('queryAgent', () => {
         settingSources: ['user', 'project'],
         model: 'claude-sonnet-4-20250514',
         maxTurns: 5,
+        maxConcurrentAgents: 2,
         systemPrompt: 'Custom instructions',
       },
     });
@@ -202,6 +203,7 @@ describe('queryAgent', () => {
     // systemPrompt is the claude_code preset (required for SDK auto-memory to
     // activate); our FROZEN composed text rides in `append`.
     const callArgs = mockQuery.mock.calls[0][0];
+    expect(callArgs.options.hooks.PreToolUse[0].matcher).toBe('Agent');
     const sp = callArgs.options.systemPrompt;
     expect(sp).toMatchObject({ type: 'preset', preset: 'claude_code' });
     expect(sp.append).toContain('untrusted IM users');

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -85,6 +85,7 @@ describe('loadConfig defaults', () => {
     // Q2: default is the wildcard sentinel — no whitelist applied at the SDK layer.
     expect(cfg.sdk.allowedTools).toBe('*');
     expect(cfg.sdk.permissionMode).toBe('bypassPermissions');
+    expect(cfg.sdk.maxConcurrentAgents).toBe(6);
     // #100: project-scope by default so the SDK discovers sandbox .claude/skills/.
     // Memory stays isolated via the inline autoMemoryDirectory pin.
     expect(cfg.sdk.settingSources).toEqual(['project']);
@@ -103,6 +104,60 @@ describe('loadConfig defaults', () => {
     // #100: skill dirs derived (per-bot + install-wide global).
     expect(bot.skillsDir).toBe(`${tmpDir}/default/skills`);
     expect(bot.globalSkillsDir).toBe(`${tmpDir}/skills`);
+  });
+});
+
+describe('sdk.maxConcurrentAgents', () => {
+  beforeEach(setup);
+  afterEach(teardown);
+
+  it('accepts a non-negative integer override', () => {
+    const path = writeConfig({
+      botToken: 'bf_test',
+      apiUrl: 'https://api.test',
+      sdk: { maxConcurrentAgents: 0 },
+    });
+
+    expect(loadConfig(path).sdk.maxConcurrentAgents).toBe(0);
+  });
+
+  it.each([-1, 1.5, '6'])('rejects invalid value %j', (maxConcurrentAgents) => {
+    const path = writeConfig({
+      botToken: 'bf_test',
+      apiUrl: 'https://api.test',
+      sdk: { maxConcurrentAgents },
+    });
+
+    expect(() => loadConfig(path)).toThrow(/sdk\.maxConcurrentAgents/);
+  });
+
+  it('supports a per-bot override', () => {
+    const path = writeConfig({
+      apiUrl: 'https://api.test',
+      bots: [{ id: 'worker' }],
+    });
+    writeBotConfig('worker', {
+      botToken: 'bf_worker',
+      sdk: { maxConcurrentAgents: 2 },
+    });
+
+    const [bot] = resolveBotConfigs(loadConfig(path));
+    expect(bot.sdk.maxConcurrentAgents).toBe(2);
+  });
+
+  it('rejects an invalid per-bot override', () => {
+    const path = writeConfig({
+      apiUrl: 'https://api.test',
+      bots: [{ id: 'worker' }],
+    });
+    writeBotConfig('worker', {
+      botToken: 'bf_worker',
+      sdk: { maxConcurrentAgents: -1 },
+    });
+
+    expect(() => resolveBotConfigs(loadConfig(path))).toThrow(
+      /Bot "worker": Invalid sdk\.maxConcurrentAgents/,
+    );
   });
 });
 

--- a/src/__tests__/subagent-limiter.test.ts
+++ b/src/__tests__/subagent-limiter.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  HookCallback,
+  PreToolUseHookInput,
+  SubagentStartHookInput,
+  SubagentStopHookInput,
+} from '@anthropic-ai/claude-agent-sdk';
+import { createSubagentHooks } from '../subagent-limiter.js';
+
+const hookOptions = { signal: new AbortController().signal };
+
+function getHook(
+  hooks: ReturnType<typeof createSubagentHooks>,
+  event: 'PreToolUse' | 'SubagentStart' | 'SubagentStop',
+): HookCallback {
+  const hook = hooks[event]?.[0]?.hooks[0];
+  if (!hook) throw new Error(`Missing ${event} hook`);
+  return hook;
+}
+
+function preToolUse(
+  toolUseId: string,
+  toolName = 'Agent',
+  agentId?: string,
+): PreToolUseHookInput {
+  return {
+    session_id: 'session-1',
+    transcript_path: '/tmp/session.jsonl',
+    cwd: '/tmp/workspace',
+    hook_event_name: 'PreToolUse',
+    tool_name: toolName,
+    tool_input: {},
+    tool_use_id: toolUseId,
+    ...(agentId ? { agent_id: agentId } : {}),
+  };
+}
+
+function subagentStart(agentId: string): SubagentStartHookInput {
+  return {
+    session_id: 'session-1',
+    transcript_path: '/tmp/session.jsonl',
+    cwd: '/tmp/workspace',
+    hook_event_name: 'SubagentStart',
+    agent_id: agentId,
+    agent_type: 'general-purpose',
+  };
+}
+
+function subagentStop(agentId: string): SubagentStopHookInput {
+  return {
+    session_id: 'session-1',
+    transcript_path: '/tmp/session.jsonl',
+    cwd: '/tmp/workspace',
+    hook_event_name: 'SubagentStop',
+    stop_hook_active: false,
+    agent_id: agentId,
+    agent_type: 'general-purpose',
+    agent_transcript_path: `/tmp/${agentId}.jsonl`,
+  };
+}
+
+function decision(output: Awaited<ReturnType<HookCallback>>): string | undefined {
+  const specific = output.hookSpecificOutput;
+  return specific?.hookEventName === 'PreToolUse'
+    ? specific.permissionDecision
+    : undefined;
+}
+
+describe('createSubagentHooks', () => {
+  it('denies Agent calls made by a subagent', async () => {
+    const hooks = createSubagentHooks(6);
+    const output = await getHook(hooks, 'PreToolUse')(
+      preToolUse('nested', 'Agent', 'parent-agent'),
+      'nested',
+      hookOptions,
+    );
+
+    expect(decision(output)).toBe('deny');
+    expect(output.hookSpecificOutput).toMatchObject({
+      permissionDecisionReason: 'Nested subagents are not supported by cc-channel-octo.',
+    });
+  });
+
+  it('caps concurrent root subagents and frees a slot on stop', async () => {
+    const hooks = createSubagentHooks(2);
+    const before = getHook(hooks, 'PreToolUse');
+    const start = getHook(hooks, 'SubagentStart');
+    const stop = getHook(hooks, 'SubagentStop');
+
+    expect(decision(await before(preToolUse('tool-1'), 'tool-1', hookOptions))).toBeUndefined();
+    expect(decision(await before(preToolUse('tool-2'), 'tool-2', hookOptions))).toBeUndefined();
+    expect(decision(await before(preToolUse('tool-3'), 'tool-3', hookOptions))).toBe('deny');
+
+    await start(subagentStart('agent-1'), undefined, hookOptions);
+    await stop(subagentStop('agent-1'), undefined, hookOptions);
+
+    expect(decision(await before(preToolUse('tool-4'), 'tool-4', hookOptions))).toBeUndefined();
+  });
+
+  it('supports zero as a hard disable for root Agent calls', async () => {
+    const hooks = createSubagentHooks(0);
+    const output = await getHook(hooks, 'PreToolUse')(
+      preToolUse('tool-1'),
+      'tool-1',
+      hookOptions,
+    );
+
+    expect(decision(output)).toBe('deny');
+    expect(output.hookSpecificOutput).toMatchObject({
+      permissionDecisionReason: 'Subagent concurrency limit of 0 reached for this root turn.',
+    });
+  });
+
+  it('does not count non-Agent tools against the limit', async () => {
+    const hooks = createSubagentHooks(1);
+    const before = getHook(hooks, 'PreToolUse');
+
+    await before(preToolUse('read-1', 'Read'), 'read-1', hookOptions);
+    expect(decision(await before(preToolUse('agent-1'), 'agent-1', hookOptions))).toBeUndefined();
+    expect(decision(await before(preToolUse('agent-2'), 'agent-2', hookOptions))).toBe('deny');
+  });
+
+  it('keeps limits isolated between root turns', async () => {
+    const firstRoot = createSubagentHooks(1);
+    const secondRoot = createSubagentHooks(1);
+
+    await getHook(firstRoot, 'PreToolUse')(preToolUse('first'), 'first', hookOptions);
+    const output = await getHook(secondRoot, 'PreToolUse')(
+      preToolUse('second'),
+      'second',
+      hookOptions,
+    );
+
+    expect(decision(output)).toBeUndefined();
+  });
+
+  it('rejects invalid programmatic limits', () => {
+    expect(() => createSubagentHooks(-1)).toThrow(/non-negative integer/);
+    expect(() => createSubagentHooks(1.5)).toThrow(/non-negative integer/);
+  });
+});

--- a/src/__tests__/subagent-limiter.test.ts
+++ b/src/__tests__/subagent-limiter.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type {
   HookCallback,
   PreToolUseHookInput,
@@ -67,6 +67,14 @@ function decision(output: Awaited<ReturnType<HookCallback>>): string | undefined
 }
 
 describe('createSubagentHooks', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('denies Agent calls made by a subagent', async () => {
     const hooks = createSubagentHooks(6);
     const output = await getHook(hooks, 'PreToolUse')(
@@ -79,22 +87,50 @@ describe('createSubagentHooks', () => {
     expect(output.hookSpecificOutput).toMatchObject({
       permissionDecisionReason: 'Nested subagents are not supported by cc-channel-octo.',
     });
+    expect(console.warn).toHaveBeenCalledWith(
+      '[cc-channel-octo] subagent denied: reason=nested ' +
+        'session_id=session-1 agent_id=parent-agent',
+    );
   });
 
-  it('caps concurrent root subagents and frees a slot on stop', async () => {
-    const hooks = createSubagentHooks(2);
+  it('caps wide root fan-out at the default limit', async () => {
+    const hooks = createSubagentHooks(6);
+    const before = getHook(hooks, 'PreToolUse');
+
+    for (let i = 1; i <= 6; i += 1) {
+      expect(
+        decision(await before(preToolUse(`tool-${i}`), `tool-${i}`, hookOptions)),
+      ).toBeUndefined();
+    }
+
+    const denied = await before(preToolUse('tool-7'), 'tool-7', hookOptions);
+    expect(decision(denied)).toBe('deny');
+    expect(console.warn).toHaveBeenCalledWith(
+      '[cc-channel-octo] subagent denied: reason=concurrency-limit ' +
+        'session_id=session-1 active=6 limit=6',
+    );
+  });
+
+  it('tracks overlapping agents and frees slots after out-of-order stops', async () => {
+    const hooks = createSubagentHooks(3);
     const before = getHook(hooks, 'PreToolUse');
     const start = getHook(hooks, 'SubagentStart');
     const stop = getHook(hooks, 'SubagentStop');
 
-    expect(decision(await before(preToolUse('tool-1'), 'tool-1', hookOptions))).toBeUndefined();
-    expect(decision(await before(preToolUse('tool-2'), 'tool-2', hookOptions))).toBeUndefined();
-    expect(decision(await before(preToolUse('tool-3'), 'tool-3', hookOptions))).toBe('deny');
+    for (let i = 1; i <= 3; i += 1) {
+      expect(
+        decision(await before(preToolUse(`tool-${i}`), `tool-${i}`, hookOptions)),
+      ).toBeUndefined();
+      await start(subagentStart(`agent-${i}`), undefined, hookOptions);
+    }
 
-    await start(subagentStart('agent-1'), undefined, hookOptions);
-    await stop(subagentStop('agent-1'), undefined, hookOptions);
-
+    await stop(subagentStop('agent-2'), undefined, hookOptions);
     expect(decision(await before(preToolUse('tool-4'), 'tool-4', hookOptions))).toBeUndefined();
+    await start(subagentStart('agent-4'), undefined, hookOptions);
+    expect(decision(await before(preToolUse('tool-5'), 'tool-5', hookOptions))).toBe('deny');
+
+    await stop(subagentStop('agent-1'), undefined, hookOptions);
+    expect(decision(await before(preToolUse('tool-6'), 'tool-6', hookOptions))).toBeUndefined();
   });
 
   it('supports zero as a hard disable for root Agent calls', async () => {

--- a/src/agent-bridge.ts
+++ b/src/agent-bridge.ts
@@ -11,12 +11,14 @@
 
 import { query as sdkQuery } from '@anthropic-ai/claude-agent-sdk';
 import type { PermissionMode, SettingSource, Settings, McpServerConfig } from '@anthropic-ai/claude-agent-sdk';
+import { DEFAULT_MAX_CONCURRENT_AGENTS } from './config.js';
 import type { Config } from './config.js';
 import { resolveSessionCwd } from './cwd-resolver.js';
 import type { SessionCtx } from './cwd-resolver.js';
 import { linkSkillsIntoSandbox } from './skill-linker.js';
 import { trustedText, escapeSectionMarkers, CURRENT_MESSAGE_ANCHOR } from './prompt-safety.js';
 import type { SafeText } from './prompt-safety.js';
+import { createSubagentHooks } from './subagent-limiter.js';
 
 
 /**
@@ -264,6 +266,9 @@ export async function* queryAgent(
   }
 
   const env = buildSdkEnv(config.sdk, process.env)
+  const subagentHooks = createSubagentHooks(
+    config.sdk.maxConcurrentAgents ?? DEFAULT_MAX_CONCURRENT_AGENTS,
+  );
 
   // Build + iterate the SDK stream for a given resume id and prompt. Extracted so
   // a stale/expired `resume` (the SDK throws "No conversation found with session
@@ -306,6 +311,7 @@ export async function* queryAgent(
           : { allowedTools: config.sdk.allowedTools }),
         permissionMode,
         maxTurns: config.sdk.maxTurns,
+        hooks: subagentHooks,
         model: config.sdk.model,
         settingSources,
         // #110: per-bot skill selection — enable only the listed skills (or 'all')

--- a/src/config.ts
+++ b/src/config.ts
@@ -33,6 +33,8 @@ export const DEFAULT_CONFIG_PATH = pathJoin(homedir(), '.cc-channel-octo', 'conf
  */
 export type AllowedTools = string[] | '*';
 
+export const DEFAULT_MAX_CONCURRENT_AGENTS = 6;
+
 export interface Config {
   botToken: string;
   apiUrl: string;
@@ -163,6 +165,12 @@ export interface Config {
     allowedTools: AllowedTools;
     permissionMode: string;
     maxTurns?: number;
+    /**
+     * Maximum number of subagents running concurrently within one root turn.
+     * Defaults to 6. Set to 0 to disable Agent calls entirely. Subagents are
+     * never allowed to create nested subagents, regardless of this value.
+     */
+    maxConcurrentAgents?: number;
     systemPrompt?: string;
     /**
      * Which filesystem settings sources the SDK loads (`user`/`project`/`local`).
@@ -372,6 +380,7 @@ function defaults(): Config {
       // Q2: default to wildcard — operators tighten only when they need to.
       allowedTools: '*',
       permissionMode: 'bypassPermissions',
+      maxConcurrentAgents: DEFAULT_MAX_CONCURRENT_AGENTS,
       // #100: load project-scope settings so the SDK discovers skills symlinked
       // into the session sandbox's .claude/skills/. Memory stays isolated via the
       // inline settings.autoMemoryDirectory pin (flagSettings > projectSettings).
@@ -513,8 +522,17 @@ export function loadConfig(configPath?: string): Config {
       `or http://localhost/http://127.0.0.1 (SSRF protection)`,
     );
   }
+  assertMaxConcurrentAgents(final.sdk.maxConcurrentAgents);
 
   return final;
+}
+
+function assertMaxConcurrentAgents(value: unknown, prefix = ''): asserts value is number {
+  if (typeof value !== 'number' || !Number.isInteger(value) || value < 0) {
+    throw new Error(
+      `${prefix}Invalid sdk.maxConcurrentAgents: expected a non-negative integer, got ${String(value)}`,
+    );
+  }
 }
 
 /**
@@ -690,6 +708,8 @@ export function resolveBotConfigs(config: Config): Config[] {
     if (!isAllowedApiUrl(resolved.apiUrl)) {
       throw new Error(`Bot "${id}": unsafe apiUrl ${resolved.apiUrl} (SSRF protection)`);
     }
+    resolved.sdk.maxConcurrentAgents ??= DEFAULT_MAX_CONCURRENT_AGENTS;
+    assertMaxConcurrentAgents(resolved.sdk.maxConcurrentAgents, `Bot "${id}": `);
     // GROUP.md trust boundary: groupConfigDir must not be the bot's writable cwd.
     assertGroupConfigDirOutsideCwd(resolved);
     return resolved;

--- a/src/subagent-limiter.ts
+++ b/src/subagent-limiter.ts
@@ -36,10 +36,18 @@ export function createSubagentHooks(maxConcurrentAgents: number): SdkHooks {
     if (input.hook_event_name !== 'PreToolUse' || input.tool_name !== 'Agent') return {};
 
     if (input.agent_id) {
+      console.warn(
+        '[cc-channel-octo] subagent denied: reason=nested ' +
+          `session_id=${input.session_id} agent_id=${input.agent_id}`,
+      );
       return denyAgent('Nested subagents are not supported by cc-channel-octo.');
     }
 
     if (admittedCount >= maxConcurrentAgents) {
+      console.warn(
+        '[cc-channel-octo] subagent denied: reason=concurrency-limit ' +
+          `session_id=${input.session_id} active=${admittedCount} limit=${maxConcurrentAgents}`,
+      );
       return denyAgent(
         `Subagent concurrency limit of ${maxConcurrentAgents} reached for this root turn.`,
       );

--- a/src/subagent-limiter.ts
+++ b/src/subagent-limiter.ts
@@ -1,0 +1,73 @@
+import type {
+  HookCallback,
+  HookJSONOutput,
+  Options,
+} from '@anthropic-ai/claude-agent-sdk';
+
+type SdkHooks = NonNullable<Options['hooks']>;
+
+function denyAgent(reason: string): HookJSONOutput {
+  return {
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      permissionDecision: 'deny',
+      permissionDecisionReason: reason,
+    },
+  };
+}
+
+/**
+ * Build root-turn-local hooks that prevent recursive Agent fan-out and cap
+ * concurrent root subagents. A slot is reserved before Agent runs and released
+ * only after the SDK reports that the admitted subagent stopped. If the SDK
+ * never emits a matching lifecycle, the slot stays conservatively reserved for
+ * the remainder of this root turn rather than risking an over-limit launch.
+ */
+export function createSubagentHooks(maxConcurrentAgents: number): SdkHooks {
+  if (!Number.isInteger(maxConcurrentAgents) || maxConcurrentAgents < 0) {
+    throw new Error('maxConcurrentAgents must be a non-negative integer');
+  }
+
+  let admittedCount = 0;
+  let pendingStarts = 0;
+  const activeAgentIds = new Set<string>();
+
+  const beforeAgent: HookCallback = async (input) => {
+    if (input.hook_event_name !== 'PreToolUse' || input.tool_name !== 'Agent') return {};
+
+    if (input.agent_id) {
+      return denyAgent('Nested subagents are not supported by cc-channel-octo.');
+    }
+
+    if (admittedCount >= maxConcurrentAgents) {
+      return denyAgent(
+        `Subagent concurrency limit of ${maxConcurrentAgents} reached for this root turn.`,
+      );
+    }
+
+    admittedCount += 1;
+    pendingStarts += 1;
+    return {};
+  };
+
+  const onSubagentStart: HookCallback = async (input) => {
+    if (input.hook_event_name !== 'SubagentStart') return {};
+    if (pendingStarts === 0 || activeAgentIds.has(input.agent_id)) return {};
+
+    pendingStarts -= 1;
+    activeAgentIds.add(input.agent_id);
+    return {};
+  };
+
+  const onSubagentStop: HookCallback = async (input) => {
+    if (input.hook_event_name !== 'SubagentStop') return {};
+    if (activeAgentIds.delete(input.agent_id)) admittedCount -= 1;
+    return {};
+  };
+
+  return {
+    PreToolUse: [{ matcher: 'Agent', hooks: [beforeAgent] }],
+    SubagentStart: [{ hooks: [onSubagentStart] }],
+    SubagentStop: [{ hooks: [onSubagentStop] }],
+  };
+}


### PR DESCRIPTION
## Summary

- hard-deny nested `Agent` calls from subagents through an SDK `PreToolUse` hook
- cap concurrent root subagents per root turn with `sdk.maxConcurrentAgents` (default `6`; `0` disables `Agent`)
- emit operator-visible warning logs when nesting or concurrency limits deny an `Agent` call
- validate global and per-bot overrides, document the setting, and add lifecycle/concurrency regression tests

## Verification

- `npm run type-check`
- `npx vitest run src/__tests__/config.test.ts src/__tests__/subagent-limiter.test.ts src/__tests__/agent-bridge-query.test.ts` (121 tests)
- `npm run lint`
- `npm run build`
- `npm test` (67 files, 1,288 tests)

## Notes

The limit is concurrent and local to one root turn; it is intentionally not a cumulative per-turn or bot-global quota. Slots are released on `SubagentStop`. If the SDK omits a matching lifecycle event, the slot remains conservatively reserved until that root turn ends rather than allowing an over-limit launch.

Closes #185
